### PR TITLE
fix(backends/java): JBR Win64 Panama compat + serde default fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ rust_out.*
 .basemind/
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
-.ai-rulez/.generated-manifest.json
 .claude/
 .codex/
 .cursor/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,6 @@ repos:
       - id: rust-max-lines
         args:
           - --max=1000
-        exclude: src/backends/php/gen_bindings/types/structs\.rs
 
       # Python — repo-internal pre-commit helper scripts only
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,7 @@ repos:
       - id: rust-max-lines
         args:
           - --max=1000
+        exclude: src/backends/php/gen_bindings/types/structs\.rs
 
       # Python — repo-internal pre-commit helper scripts only
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **(backends/java): promote all integer layouts to `JAVA_LONG` for JBR Win64 Panama compat.** Panama linker implementations on JBR/Win64 throw `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load time when any sub-64-bit integer layout appears in a `FunctionDescriptor`. All integer return types are now promoted to `JAVA_LONG`; `MethodHandle.invoke()` adapts the wider value back at the call site via cast chains in `java_ffi_return_cast()` (e.g., `(int)(long)` for i32, `(short)(long)` for i16, `(byte)(long)` for i8). Enum discriminants (i32 in FFI) are also promoted. (`src/backends/java/type_map.rs`, `src/backends/java/gen_bindings/marshal.rs`, `src/backends/java/templates/`)
+- **(backends/java/gen_bindings/types/builders, records): treat function-path `#[serde(default = "fn")]` as a serde-managed default in Java builder/record codegen.** The extractor preserved the function path verbatim (`serde(default = "default_true")`) instead of the generic `/* serde(default) */` marker, so the Java builder's `has_serde_default` check missed it and emitted the path string literally — e.g. `private boolean structure = serde(default = "default_true");` — invalid Java. Fix: `is_serde_default_marker()` in `helpers.rs` now matches both the bare marker and any string starting with `"serde(default = \""`. (`src/backends/java/gen_bindings/helpers.rs`, `src/backends/java/gen_bindings/types/builders.rs`, `src/backends/java/gen_bindings/types/records.rs`)
 - **Per-variant constructors now box `Box<T>` fields.** When a data enum's struct variant has a
   field whose core type is `Box<T>`/`Option<Box<T>>` for a Named `T` (e.g. `CrawlEvent::Page {
   result: Box<CrawlPageResult> }`), the generated `_factory_<variant>` constructor emitted
@@ -1307,7 +1309,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **(backends/java): promote sub-64-bit integer layouts for JBR Win64 Panama compat.** Panama linker implementations on JBR/Win64 throw `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load time when `JAVA_BYTE`, `JAVA_SHORT`, or `JAVA_INT` appear in a `FunctionDescriptor`. All integer return types are now promoted: 8/16-bit integers to `JAVA_INT`, 32-bit integers and booleans to `JAVA_LONG`, enum discriminants (i32 in FFI) to `JAVA_LONG`. `MethodHandle.invoke()` adapts the wider value back to the narrower Java type at the call site via the cast chain in `java_ffi_return_cast()` (e.g., `(int)(long)` for i32, `(short)(int)` for i16). (`src/backends/java/type_map.rs`, `src/backends/java/gen_bindings/marshal.rs`, `src/backends/java/templates/`)
 - **(backends/swift): scope the swift post-build `cargo build` to `-p liter-llm-swift`.**
   It previously built the whole workspace, which re-triggered other crates' build scripts —
   notably liter-llm-dart's frb codegen, which regenerated `lib.dart` and wiped the dart
@@ -1338,7 +1339,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`&serde_json::Value: FromZvalMut` unsatisfied), breaking `liter-llm-php` compilation during a
   full regen. The display text is exposed via the core-derived `text()` accessor instead.
   (`src/backends/php/gen_bindings/types/structs.rs`)
-- **(backends/java/gen_bindings/types/builders, records): treat function-path `#[serde(default = "fn")]` as a serde-managed default in Java builder/record codegen.** The extractor change preserved the function path verbatim (`serde(default = "default_true")`) instead of the generic `/* serde(default) */` marker, so the Java builder's `has_serde_default` check missed it and emitted the path string literally — e.g. `private boolean structure = serde(default = "default_true");` — invalid Java (Java reserves `default`). Fix: `is_serde_default_marker()` in `helpers.rs` now matches both the bare marker and any string starting with `"serde(default = \""`. (`src/backends/java/gen_bindings/helpers.rs`, `src/backends/java/gen_bindings/types/builders.rs`, `src/backends/java/gen_bindings/types/records.rs`)
 - **(e2e/codegen/swift): use the per-call `result_type` override for root-type
   detection** so first-class result structs render property access
   (`result.choices`) instead of method-call access. (`src/e2e/codegen/swift/values.rs`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1337,6 +1337,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`&serde_json::Value: FromZvalMut` unsatisfied), breaking `liter-llm-php` compilation during a
   full regen. The display text is exposed via the core-derived `text()` accessor instead.
   (`src/backends/php/gen_bindings/types/structs.rs`)
+- **(backends/java/gen_bindings/types/builders, records): treat function-path `#[serde(default = "fn")]` as a serde-managed default in Java builder/record codegen.** The extractor change preserved the function path verbatim (`serde(default = "default_true")`) instead of the generic `/* serde(default) */` marker, so the Java builder's `has_serde_default` check missed it and emitted the path string literally — e.g. `private boolean structure = serde(default = "default_true");` — invalid Java (Java reserves `default`). Fix: `is_serde_default_marker()` in `helpers.rs` now matches both the bare marker and any string starting with `"serde(default = \""`. (`src/backends/java/gen_bindings/helpers.rs`, `src/backends/java/gen_bindings/types/builders.rs`, `src/backends/java/gen_bindings/types/records.rs`)
 - **(e2e/codegen/swift): use the per-call `result_type` override for root-type
   detection** so first-class result structs render property access
   (`result.choices`) instead of method-call access. (`src/e2e/codegen/swift/values.rs`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1307,6 +1307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **(backends/java): promote sub-64-bit integer layouts for JBR Win64 Panama compat.** Panama linker implementations on JBR/Win64 throw `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load time when `JAVA_BYTE`, `JAVA_SHORT`, or `JAVA_INT` appear in a `FunctionDescriptor`. All integer return types are now promoted: 8/16-bit integers to `JAVA_INT`, 32-bit integers and booleans to `JAVA_LONG`, enum discriminants (i32 in FFI) to `JAVA_LONG`. `MethodHandle.invoke()` adapts the wider value back to the narrower Java type at the call site via the cast chain in `java_ffi_return_cast()` (e.g., `(int)(long)` for i32, `(short)(int)` for i16). (`src/backends/java/type_map.rs`, `src/backends/java/gen_bindings/marshal.rs`, `src/backends/java/templates/`)
 - **(backends/swift): scope the swift post-build `cargo build` to `-p liter-llm-swift`.**
   It previously built the whole workspace, which re-triggered other crates' build scripts —
   notably liter-llm-dart's frb codegen, which regenerated `lib.dart` and wiped the dart

--- a/src/backends/java/gen_bindings/ffi_class/sync_functions.rs
+++ b/src/backends/java/gen_bindings/ffi_class/sync_functions.rs
@@ -266,7 +266,7 @@ pub(super) fn gen_sync_function_method_with_visitor(
         out.push_str(&crate::backends::java::template_env::render(
             "ffi_invoke_primitive_result.jinja",
             minijinja::context! {
-                cast_type => "int",
+                cast_type => "(int)(long)",
                 ffi_handle => &ffi_handle,
                 call_args => {
                     let mut args = call_args.clone();

--- a/src/backends/java/gen_bindings/ffi_class/sync_functions.rs
+++ b/src/backends/java/gen_bindings/ffi_class/sync_functions.rs
@@ -1,7 +1,7 @@
 use crate::backends::java::type_map::{java_boxed_type, java_return_type, java_type};
 use crate::codegen::naming::to_java_name;
 use crate::core::config::HostCapsuleTypeConfig;
-use crate::core::ir::{FunctionDef, TypeRef};
+use crate::core::ir::{FunctionDef, PrimitiveType, TypeRef};
 use ahash::{AHashMap, AHashSet};
 use heck::ToSnakeCase;
 use std::collections::{HashMap, HashSet};
@@ -266,7 +266,7 @@ pub(super) fn gen_sync_function_method_with_visitor(
         out.push_str(&crate::backends::java::template_env::render(
             "ffi_invoke_primitive_result.jinja",
             minijinja::context! {
-                cast_type => "(int)(long)",
+                cast_type => java_ffi_return_cast(&TypeRef::Primitive(PrimitiveType::I32)),
                 ffi_handle => &ffi_handle,
                 call_args => {
                     let mut args = call_args.clone();

--- a/src/backends/java/gen_bindings/marshal.rs
+++ b/src/backends/java/gen_bindings/marshal.rs
@@ -48,18 +48,6 @@ pub(crate) fn is_ffi_string_return(ty: &TypeRef) -> bool {
     }
 }
 
-/// Return the Java cast expression for a primitive FFI return type.
-/// Returns the Java cast expression to apply to `MethodHandle.invoke()` return value.
-///
-/// The cast must match the widened ValueLayout from `java_ffi_type()`. When the
-/// FunctionDescriptor uses a wider layout than the logical Java type (e.g. JAVA_LONG
-/// for i32, JAVA_INT for i16), `invoke()` boxes the wider type. We need a chain of
-/// casts to unbox then narrow back to the target type.
-///
-/// Examples:
-/// - JAVA_LONG return (i32 → long): `(int)(long)` unboxes Long then narrows to int
-/// - JAVA_INT return (i16 → int): `(short)(int)` unboxes Integer then narrows to short
-/// - JAVA_LONG return (bool → long): `long` unboxes Long directly (comparison handles narrowing)
 /// Returns the Java cast expression (including parens) to apply to `MethodHandle.invoke()`.
 ///
 /// Templates no longer wrap this in `()` — the parens are included here. When the
@@ -504,5 +492,27 @@ pub(crate) fn gen_helper_methods(out: &mut String, prefix: &str, class_name: &st
                 free_handle => free_handle,
             },
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ahash::AHashSet;
+
+    #[test]
+    fn gen_ffi_layout_with_enums_enum_uses_java_long() {
+        let mut enum_names = AHashSet::new();
+        enum_names.insert("Status".to_string());
+        let ty = TypeRef::Named("Status".to_string());
+        assert_eq!(gen_ffi_layout_with_enums(&ty, &enum_names), "ValueLayout.JAVA_LONG");
+    }
+
+    #[test]
+    fn gen_ffi_layout_with_enums_non_enum_named_uses_address() {
+        let mut enum_names = AHashSet::new();
+        enum_names.insert("Status".to_string());
+        let ty = TypeRef::Named("SomeStruct".to_string());
+        assert_eq!(gen_ffi_layout_with_enums(&ty, &enum_names), "ValueLayout.ADDRESS");
     }
 }

--- a/src/backends/java/gen_bindings/marshal.rs
+++ b/src/backends/java/gen_bindings/marshal.rs
@@ -50,24 +50,23 @@ pub(crate) fn is_ffi_string_return(ty: &TypeRef) -> bool {
 
 /// Returns the Java cast expression (including parens) to apply to `MethodHandle.invoke()`.
 ///
-/// Templates no longer wrap this in `()` — the parens are included here. When the
-/// FunctionDescriptor uses a wider layout than the logical Java type (e.g. JAVA_LONG
-/// for i32, JAVA_INT for i16), `invoke()` boxes the wider type. We emit a chain of
-/// casts to unbox then narrow back to the target type:
+/// All integers use `JAVA_LONG` (see `java_ffi_type()`), so `invoke()` always boxes
+/// as `Long`. The cast unboxes Long then narrows to the target Java type:
 ///
-/// - JAVA_LONG return (bool or i32): `(long)` or `(int)(long)` — unboxes Long
-/// - JAVA_INT return (i16 or i8): `(short)(int)` / `(byte)(int)` — unboxes Integer then narrows
-/// - JAVA_LONG / JAVA_FLOAT / JAVA_DOUBLE: `(long)`, `(float)`, `(double)` — direct unbox
+/// - bool/i64/u64: `(long)` — unbox Long directly
+/// - i32/u32: `(int)(long)` — unbox Long, narrow to int
+/// - i16/u16: `(short)(long)` — unbox Long, narrow to short
+/// - i8/u8: `(byte)(long)` — unbox Long, narrow to byte
 pub(crate) fn java_ffi_return_cast(ty: &TypeRef) -> &'static str {
     match ty {
         TypeRef::Primitive(prim) => match prim {
-            // Bool is i32 in FFI (JAVA_LONG layout); keep as long, comparison handles bool semantics.
+            // All integers use JAVA_LONG; bool keeps the long value (comparison narrows to bool).
             PrimitiveType::Bool => "(long)",
-            // 8-bit types use JAVA_INT layout; unbox Integer then narrow to byte.
-            PrimitiveType::U8 | PrimitiveType::I8 => "(byte)(int)",
-            // 16-bit types use JAVA_INT layout; unbox Integer then narrow to short.
-            PrimitiveType::U16 | PrimitiveType::I16 => "(short)(int)",
-            // 32-bit types use JAVA_LONG layout; unbox Long then narrow to int.
+            // 8-bit: unbox Long, narrow to byte.
+            PrimitiveType::U8 | PrimitiveType::I8 => "(byte)(long)",
+            // 16-bit: unbox Long, narrow to short.
+            PrimitiveType::U16 | PrimitiveType::I16 => "(short)(long)",
+            // 32-bit: unbox Long, narrow to int.
             PrimitiveType::U32 | PrimitiveType::I32 => "(int)(long)",
             PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Usize | PrimitiveType::Isize => "(long)",
             PrimitiveType::F32 => "(float)",
@@ -499,6 +498,30 @@ pub(crate) fn gen_helper_methods(out: &mut String, prefix: &str, class_name: &st
 mod tests {
     use super::*;
     use ahash::AHashSet;
+
+    #[test]
+    fn java_ffi_return_cast_i8_uses_long_chain() {
+        assert_eq!(
+            java_ffi_return_cast(&TypeRef::Primitive(PrimitiveType::I8)),
+            "(byte)(long)"
+        );
+        assert_eq!(
+            java_ffi_return_cast(&TypeRef::Primitive(PrimitiveType::U8)),
+            "(byte)(long)"
+        );
+    }
+
+    #[test]
+    fn java_ffi_return_cast_i16_uses_long_chain() {
+        assert_eq!(
+            java_ffi_return_cast(&TypeRef::Primitive(PrimitiveType::I16)),
+            "(short)(long)"
+        );
+        assert_eq!(
+            java_ffi_return_cast(&TypeRef::Primitive(PrimitiveType::U16)),
+            "(short)(long)"
+        );
+    }
 
     #[test]
     fn gen_ffi_layout_with_enums_enum_uses_java_long() {

--- a/src/backends/java/gen_bindings/marshal.rs
+++ b/src/backends/java/gen_bindings/marshal.rs
@@ -49,19 +49,44 @@ pub(crate) fn is_ffi_string_return(ty: &TypeRef) -> bool {
 }
 
 /// Return the Java cast expression for a primitive FFI return type.
+/// Returns the Java cast expression to apply to `MethodHandle.invoke()` return value.
+///
+/// The cast must match the widened ValueLayout from `java_ffi_type()`. When the
+/// FunctionDescriptor uses a wider layout than the logical Java type (e.g. JAVA_LONG
+/// for i32, JAVA_INT for i16), `invoke()` boxes the wider type. We need a chain of
+/// casts to unbox then narrow back to the target type.
+///
+/// Examples:
+/// - JAVA_LONG return (i32 → long): `(int)(long)` unboxes Long then narrows to int
+/// - JAVA_INT return (i16 → int): `(short)(int)` unboxes Integer then narrows to short
+/// - JAVA_LONG return (bool → long): `long` unboxes Long directly (comparison handles narrowing)
+/// Returns the Java cast expression (including parens) to apply to `MethodHandle.invoke()`.
+///
+/// Templates no longer wrap this in `()` — the parens are included here. When the
+/// FunctionDescriptor uses a wider layout than the logical Java type (e.g. JAVA_LONG
+/// for i32, JAVA_INT for i16), `invoke()` boxes the wider type. We emit a chain of
+/// casts to unbox then narrow back to the target type:
+///
+/// - JAVA_LONG return (bool or i32): `(long)` or `(int)(long)` — unboxes Long
+/// - JAVA_INT return (i16 or i8): `(short)(int)` / `(byte)(int)` — unboxes Integer then narrows
+/// - JAVA_LONG / JAVA_FLOAT / JAVA_DOUBLE: `(long)`, `(float)`, `(double)` — direct unbox
 pub(crate) fn java_ffi_return_cast(ty: &TypeRef) -> &'static str {
     match ty {
         TypeRef::Primitive(prim) => match prim {
-            PrimitiveType::Bool => "int",
-            PrimitiveType::U8 | PrimitiveType::I8 => "byte",
-            PrimitiveType::U16 | PrimitiveType::I16 => "short",
-            PrimitiveType::U32 | PrimitiveType::I32 => "int",
-            PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Usize | PrimitiveType::Isize => "long",
-            PrimitiveType::F32 => "float",
-            PrimitiveType::F64 => "double",
+            // Bool is i32 in FFI (JAVA_LONG layout); keep as long, comparison handles bool semantics.
+            PrimitiveType::Bool => "(long)",
+            // 8-bit types use JAVA_INT layout; unbox Integer then narrow to byte.
+            PrimitiveType::U8 | PrimitiveType::I8 => "(byte)(int)",
+            // 16-bit types use JAVA_INT layout; unbox Integer then narrow to short.
+            PrimitiveType::U16 | PrimitiveType::I16 => "(short)(int)",
+            // 32-bit types use JAVA_LONG layout; unbox Long then narrow to int.
+            PrimitiveType::U32 | PrimitiveType::I32 => "(int)(long)",
+            PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Usize | PrimitiveType::Isize => "(long)",
+            PrimitiveType::F32 => "(float)",
+            PrimitiveType::F64 => "(double)",
         },
-        TypeRef::Duration => "long",
-        _ => "MemorySegment",
+        TypeRef::Duration => "(long)",
+        _ => "(MemorySegment)",
     }
 }
 
@@ -81,9 +106,10 @@ pub(crate) fn gen_ffi_layout_with_enums(ty: &TypeRef, enum_names: &AHashSet<Stri
         TypeRef::Vec(_) => "ValueLayout.ADDRESS".to_string(),
         TypeRef::Map(_, _) => "ValueLayout.ADDRESS".to_string(),
         TypeRef::Named(name) => {
-            // Enum types (Copy-typed Named types) are passed as i32 discriminants
+            // Enum types (Copy-typed Named types) are passed as i32 discriminants.
+            // Use JAVA_LONG for the same Win64 Panama compat reason as PrimitiveType::I32.
             if enum_names.contains(name.as_str()) {
-                "ValueLayout.JAVA_INT".to_string()
+                "ValueLayout.JAVA_LONG".to_string()
             } else {
                 "ValueLayout.ADDRESS".to_string()
             }

--- a/src/backends/java/gen_bindings/types/builders.rs
+++ b/src/backends/java/gen_bindings/types/builders.rs
@@ -563,3 +563,30 @@ pub(super) fn gen_builder_nested_class(
 
     body
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::backends::java::gen_bindings::helpers::is_serde_default_marker;
+
+    #[test]
+    fn is_serde_default_marker_bare_marker() {
+        assert!(is_serde_default_marker(Some("/* serde(default) */")));
+    }
+
+    #[test]
+    fn is_serde_default_marker_function_path() {
+        assert!(is_serde_default_marker(Some("serde(default = \"default_true\")")));
+    }
+
+    #[test]
+    fn is_serde_default_marker_none() {
+        assert!(!is_serde_default_marker(None));
+    }
+
+    #[test]
+    fn is_serde_default_marker_explicit_literal_not_serde() {
+        assert!(!is_serde_default_marker(Some("true")));
+        assert!(!is_serde_default_marker(Some("0")));
+        assert!(!is_serde_default_marker(Some("null")));
+    }
+}

--- a/src/backends/java/templates/ffi_invoke_primitive_result.jinja
+++ b/src/backends/java/templates/ffi_invoke_primitive_result.jinja
@@ -1,1 +1,1 @@
-            var primitiveResult = ({{ cast_type }}) {{ ffi_handle }}.invoke({{ call_args }});
+            var primitiveResult = {{ cast_type }} {{ ffi_handle }}.invoke({{ call_args }});

--- a/src/backends/java/templates/ffi_primitive_result_call.jinja
+++ b/src/backends/java/templates/ffi_primitive_result_call.jinja
@@ -1,1 +1,1 @@
-            var primitiveResult = ({{ cast_type }}) {{ ffi_handle }}.invoke({{ args }});
+            var primitiveResult = {{ cast_type }} {{ ffi_handle }}.invoke({{ args }});

--- a/src/backends/java/templates/helper_check_last_error.jinja
+++ b/src/backends/java/templates/helper_check_last_error.jinja
@@ -1,5 +1,5 @@
     private static void checkLastError() throws Throwable {
-        int errCode = (int) NativeLib.{{ prefix_upper }}_LAST_ERROR_CODE.invoke();
+        int errCode = (int)(long) NativeLib.{{ prefix_upper }}_LAST_ERROR_CODE.invoke();
         if (errCode != 0) {
             var ctxPtr = (MemorySegment) NativeLib.{{ prefix_upper }}_LAST_ERROR_CONTEXT.invoke();
             String msg = ctxPtr.reinterpret(Long.MAX_VALUE).getString(0);

--- a/src/backends/java/templates/native_lib.jinja
+++ b/src/backends/java/templates/native_lib.jinja
@@ -245,7 +245,7 @@ final class {{ class_name }} {
 
     static final MethodHandle {{ prefix_upper }}_LAST_ERROR_CODE = LINKER.downcallHandle(
         LIB.find("{{ prefix }}_last_error_code").orElse(null),
-        FunctionDescriptor.of(ValueLayout.JAVA_INT)
+        FunctionDescriptor.of(ValueLayout.JAVA_LONG)
     );
 
     static final MethodHandle {{ prefix_upper }}_LAST_ERROR_CONTEXT = LINKER.downcallHandle(

--- a/src/backends/java/templates/stream_method_optional_primitive_result.jinja
+++ b/src/backends/java/templates/stream_method_optional_primitive_result.jinja
@@ -1,4 +1,4 @@
-            var result = ({{ java_primitive_type }}) {{ ffi_handle }}.invoke({{ args_joined }});
+            var result = {{ java_primitive_type }} {{ ffi_handle }}.invoke({{ args_joined }});
 {{ named_frees }}{%- if is_optional_long %}
             return java.util.OptionalLong.of(result);
 {%- else %}

--- a/src/backends/java/templates/stream_method_primitive_result.jinja
+++ b/src/backends/java/templates/stream_method_primitive_result.jinja
@@ -1,2 +1,2 @@
-            var result = ({{ java_primitive_type }}) {{ ffi_handle }}.invoke({{ args_joined }});
+            var result = {{ java_primitive_type }} {{ ffi_handle }}.invoke({{ args_joined }});
 {{ named_frees }}            return {{ java_primitive_expr }};

--- a/src/backends/java/templates/streaming_helpers.jinja
+++ b/src/backends/java/templates/streaming_helpers.jinja
@@ -2,7 +2,7 @@
     // CPD-OFF — generated FFI boilerplate, identical across all opaque types by design.
     private static void checkLastFfiError() throws {{ exception_class }} {
         try {
-            int code = (int) NativeLib.{{ prefix_upper }}_LAST_ERROR_CODE.invoke();
+            int code = (int)(long) NativeLib.{{ prefix_upper }}_LAST_ERROR_CODE.invoke();
             if (code == 0) { return; }
             MemorySegment ctxPtr = (MemorySegment) NativeLib.{{ prefix_upper }}_LAST_ERROR_CONTEXT.invoke();
             String msg = ctxPtr.equals(MemorySegment.NULL) ? "unknown" : ctxPtr.reinterpret(Long.MAX_VALUE).getString(0);

--- a/src/backends/java/type_map.rs
+++ b/src/backends/java/type_map.rs
@@ -183,24 +183,20 @@ pub fn java_return_type(ty: &TypeRef) -> Cow<'static, str> {
 
 /// Maps a primitive type to its Java FFI equivalent (Panama FFM ValueLayout).
 ///
-/// Sub-64-bit integer layouts (`JAVA_BYTE`, `JAVA_SHORT`, `JAVA_INT`) are not
-/// supported by all Panama linker implementations (JBR/Win64 throws
-/// `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load time
-/// when any of these appear in a `FunctionDescriptor`). All integer primitives
-/// are promoted to either `JAVA_INT` (for 8/16-bit types) or `JAVA_LONG` (for
-/// 32/64-bit types). `MethodHandle.invoke()` adapts the wider value back to the
-/// narrower Java type (byte/short/int) at the call site via `asType()`, which
-/// is allowed for numeric primitive narrowing.
+/// All sub-64-bit integer layouts are promoted to `JAVA_LONG`. JBR/Win64 Panama
+/// throws `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load
+/// time when any non-LONG integer layout (`JAVA_BYTE`, `JAVA_SHORT`, `JAVA_INT`)
+/// appears in a `FunctionDescriptor`. `MethodHandle.invoke()` adapts the wider
+/// value back at the call site via the cast chain in `java_ffi_return_cast()`.
 pub fn java_ffi_type(prim: &PrimitiveType) -> &'static str {
     match prim {
-        // bool is represented as i32 in the Rust FFI; promote to JAVA_LONG for Win64 compat.
-        PrimitiveType::Bool => "ValueLayout.JAVA_LONG",
-        // 8-bit values widened to 32-bit (x86-64 always returns ≥32 bits).
-        PrimitiveType::U8 | PrimitiveType::I8 => "ValueLayout.JAVA_INT",
-        // 16-bit values widened to 32-bit (returned in EAX on x86-64).
-        PrimitiveType::U16 | PrimitiveType::I16 => "ValueLayout.JAVA_INT",
-        // 32-bit integers promoted to 64-bit for JBR Win64 Panama compat.
-        PrimitiveType::U32 | PrimitiveType::I32 => "ValueLayout.JAVA_LONG",
+        PrimitiveType::Bool
+        | PrimitiveType::U8
+        | PrimitiveType::I8
+        | PrimitiveType::U16
+        | PrimitiveType::I16
+        | PrimitiveType::U32
+        | PrimitiveType::I32 => "ValueLayout.JAVA_LONG",
         PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Usize | PrimitiveType::Isize => {
             "ValueLayout.JAVA_LONG"
         }
@@ -346,16 +342,15 @@ mod tests {
     }
 
     #[test]
-    fn java_ffi_type_promotes_i16_u16_to_java_int() {
-        // 16-bit types widened to JAVA_INT (not JAVA_SHORT — sub-32-bit unsupported on JBR).
-        assert_eq!(java_ffi_type(&PrimitiveType::I16), "ValueLayout.JAVA_INT");
-        assert_eq!(java_ffi_type(&PrimitiveType::U16), "ValueLayout.JAVA_INT");
+    fn java_ffi_type_promotes_i16_u16_to_java_long() {
+        assert_eq!(java_ffi_type(&PrimitiveType::I16), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::U16), "ValueLayout.JAVA_LONG");
     }
 
     #[test]
-    fn java_ffi_type_promotes_i8_u8_to_java_int() {
-        assert_eq!(java_ffi_type(&PrimitiveType::I8), "ValueLayout.JAVA_INT");
-        assert_eq!(java_ffi_type(&PrimitiveType::U8), "ValueLayout.JAVA_INT");
+    fn java_ffi_type_promotes_i8_u8_to_java_long() {
+        assert_eq!(java_ffi_type(&PrimitiveType::I8), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::U8), "ValueLayout.JAVA_LONG");
     }
 
     #[test]

--- a/src/backends/java/type_map.rs
+++ b/src/backends/java/type_map.rs
@@ -182,12 +182,25 @@ pub fn java_return_type(ty: &TypeRef) -> Cow<'static, str> {
 }
 
 /// Maps a primitive type to its Java FFI equivalent (Panama FFM ValueLayout).
+///
+/// Sub-64-bit integer layouts (`JAVA_BYTE`, `JAVA_SHORT`, `JAVA_INT`) are not
+/// supported by all Panama linker implementations (JBR/Win64 throws
+/// `ClassCastException: OfIntImpl cannot be cast to OfLong` at class-load time
+/// when any of these appear in a `FunctionDescriptor`). All integer primitives
+/// are promoted to either `JAVA_INT` (for 8/16-bit types) or `JAVA_LONG` (for
+/// 32/64-bit types). `MethodHandle.invoke()` adapts the wider value back to the
+/// narrower Java type (byte/short/int) at the call site via `asType()`, which
+/// is allowed for numeric primitive narrowing.
 pub fn java_ffi_type(prim: &PrimitiveType) -> &'static str {
     match prim {
-        PrimitiveType::Bool => "ValueLayout.JAVA_INT",
-        PrimitiveType::U8 | PrimitiveType::I8 => "ValueLayout.JAVA_BYTE",
-        PrimitiveType::U16 | PrimitiveType::I16 => "ValueLayout.JAVA_SHORT",
-        PrimitiveType::U32 | PrimitiveType::I32 => "ValueLayout.JAVA_INT",
+        // bool is represented as i32 in the Rust FFI; promote to JAVA_LONG for Win64 compat.
+        PrimitiveType::Bool => "ValueLayout.JAVA_LONG",
+        // 8-bit values widened to 32-bit (x86-64 always returns ≥32 bits).
+        PrimitiveType::U8 | PrimitiveType::I8 => "ValueLayout.JAVA_INT",
+        // 16-bit values widened to 32-bit (returned in EAX on x86-64).
+        PrimitiveType::U16 | PrimitiveType::I16 => "ValueLayout.JAVA_INT",
+        // 32-bit integers promoted to 64-bit for JBR Win64 Panama compat.
+        PrimitiveType::U32 | PrimitiveType::I32 => "ValueLayout.JAVA_LONG",
         PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Usize | PrimitiveType::Isize => {
             "ValueLayout.JAVA_LONG"
         }
@@ -317,5 +330,45 @@ mod tests {
     fn java_return_type_preserves_vec() {
         let ty = TypeRef::Vec(Box::new(TypeRef::String));
         assert_eq!(java_return_type(&ty), "List<String>");
+    }
+
+    #[test]
+    fn java_ffi_type_promotes_bool_to_java_long() {
+        // Bool is i32 in FFI; must use JAVA_LONG for JBR Win64 Panama compat.
+        assert_eq!(java_ffi_type(&PrimitiveType::Bool), "ValueLayout.JAVA_LONG");
+    }
+
+    #[test]
+    fn java_ffi_type_promotes_i32_u32_to_java_long() {
+        // 32-bit types promoted to JAVA_LONG to avoid OfIntImpl→OfLong ClassCastException on JBR.
+        assert_eq!(java_ffi_type(&PrimitiveType::I32), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::U32), "ValueLayout.JAVA_LONG");
+    }
+
+    #[test]
+    fn java_ffi_type_promotes_i16_u16_to_java_int() {
+        // 16-bit types widened to JAVA_INT (not JAVA_SHORT — sub-32-bit unsupported on JBR).
+        assert_eq!(java_ffi_type(&PrimitiveType::I16), "ValueLayout.JAVA_INT");
+        assert_eq!(java_ffi_type(&PrimitiveType::U16), "ValueLayout.JAVA_INT");
+    }
+
+    #[test]
+    fn java_ffi_type_promotes_i8_u8_to_java_int() {
+        assert_eq!(java_ffi_type(&PrimitiveType::I8), "ValueLayout.JAVA_INT");
+        assert_eq!(java_ffi_type(&PrimitiveType::U8), "ValueLayout.JAVA_INT");
+    }
+
+    #[test]
+    fn java_ffi_type_64bit_types_use_java_long() {
+        assert_eq!(java_ffi_type(&PrimitiveType::I64), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::U64), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::Isize), "ValueLayout.JAVA_LONG");
+        assert_eq!(java_ffi_type(&PrimitiveType::Usize), "ValueLayout.JAVA_LONG");
+    }
+
+    #[test]
+    fn java_ffi_type_float_types_unchanged() {
+        assert_eq!(java_ffi_type(&PrimitiveType::F32), "ValueLayout.JAVA_FLOAT");
+        assert_eq!(java_ffi_type(&PrimitiveType::F64), "ValueLayout.JAVA_DOUBLE");
     }
 }


### PR DESCRIPTION
## Summary

- Promote sub-64-bit Panama FFM layouts to `JAVA_LONG`/`JAVA_INT` in `FunctionDescriptor` for JBR Win64 compatibility. JBR's Panama linker casts all layouts to `OfLong` internally — `OfIntImpl cannot be cast to OfLong` at class load (tslp#148).
- Fix call-site casts to use compound casts (`(int)(long)`, `(short)(int)`, `(byte)(int)`) matching the widened boxed return from `MethodHandle.invoke()`.
- Fix function-path `#[serde(default = "fn")]` fields emitting invalid Java (used `default` — reserved keyword). Centralise detection in `is_serde_default()` — boxed nullable types + `@JsonInclude(NON_ABSENT)` so Rust serde applies the actual default.

## Test plan

- [ ] `cargo test` — all 3817+ lib tests pass
- [ ] `cargo test is_serde_default` — 4 new unit tests pass
- [ ] `cargo test java_ffi_type` — 6 type-promotion tests pass
- [ ] Regenerate tree-sitter-language-pack Java bindings and verify CI passes