### PR TITLE
Keep generated Ruby constants under the binding namespace

### DIFF
--- a/src/backends/magnus/gen_bindings/tests.rs
+++ b/src/backends/magnus/gen_bindings/tests.rs
@@ -160,7 +160,7 @@ fn ruby_public_wrapper_keeps_generated_constants_namespaced() {
         .expect("main Ruby wrapper must exist");
 
     assert!(
-        !main_file.content.contains("::Object.const_set"),
+        !main_file.content.contains("Object.const_set"),
         "the generated Ruby wrapper must not export constants globally"
     );
 }

--- a/src/backends/magnus/gen_bindings/tests.rs
+++ b/src/backends/magnus/gen_bindings/tests.rs
@@ -149,6 +149,23 @@ fn generate_public_api_emits_gem_files() {
 }
 
 #[test]
+fn ruby_public_wrapper_keeps_generated_constants_namespaced() {
+    let backend = MagnusBackend;
+    let config = make_config();
+    let api = make_api_surface();
+    let files = backend.generate_public_api(&api, &config).unwrap();
+    let main_file = files
+        .iter()
+        .find(|file| file.path.to_string_lossy().ends_with("test_lib.rb"))
+        .expect("main Ruby wrapper must exist");
+
+    assert!(
+        !main_file.content.contains("::Object.const_set"),
+        "the generated Ruby wrapper must not export constants globally"
+    );
+}
+
+#[test]
 fn output_path_defaults_to_packages_ruby() {
     let backend = MagnusBackend;
     let config = make_config();

--- a/src/backends/magnus/templates/main_rb_wrapper.rb.jinja
+++ b/src/backends/magnus/templates/main_rb_wrapper.rb.jinja
@@ -16,11 +16,5 @@ module {{ module_name }}
 {% endif %}
 end
 
-# Bring top-level {{ module_name }} classes into the global namespace so callers
-# (and the generated e2e suite) can reference them unqualified. The native
-# extension has already been required above, so every type constant is defined
-# under {{ module_name }} by this point.
-{{ module_name }}.constants.each do |const_name|
-  value = {{ module_name }}.const_get(const_name)
-  ::Object.const_set(const_name, value) if value.is_a?(Module) && !::Object.const_defined?(const_name)
-end
+# Keep generated types under {{ module_name }}. Publishing generated constants
+# into Object makes generic names collide with unrelated Ruby libraries.


### PR DESCRIPTION
## Summary

Remove the Magnus Ruby wrapper's automatic export of generated constants into `Object`.

Generated Ruby types should remain under the public binding namespace. Publishing them globally is unsafe because generic names can collide with unrelated Ruby libraries. For example, TSLP's generated native `TreeSitterLanguagePack::Parser` was exported as `::Parser`; requiring the `parser` gem afterward raised:

```text
TypeError: Parser is not a module
```

The `parser` gem is not a dependency of TSLP. This is a generator namespace-pollution bug.

## Changes

- Remove the global `Object.const_set` re-export loop from the Magnus Ruby wrapper template.
- Keep generated constants available through the binding module.
- Add a generator regression test asserting that generated Ruby wrappers do not export constants globally.

The repository has issues disabled, so this PR is also the bug report and design record.

## Verification

```text
cargo test --lib backends::magnus::gen_bindings::tests::ruby_public_wrapper_keeps_generated_constants_namespaced
```

Passes.
