### PR TITLE
fix(dart): make FRB regeneration safe and reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dart generation now uses flutter_rust_bridge 2.13 and bypasses its redundant dependency
+  preflight.** Alef emits the bridge dependencies itself, while FRB's check rejected valid Dart
+  prereleases such as `freezed 4.0.0-dev.3` before generation could complete.
+
 ## [0.67.1] - 2026-08-23
 
 ### Fixed
@@ -15,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Header export is now explicit via `ALEF_EXPORT_GENERATED_HEADERS=1`; cbindgen output is buffered,
   validated as UTF-8, and published atomically to the canonical and Go destinations with rollback
   on failure. This prevents failed workspace lint or build commands from truncating generated files.
-
 ## [0.67.0] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.67.2] - 2026-08-23
+
 ### Fixed
 
 - **Dart generation now uses flutter_rust_bridge 2.13 and bypasses its redundant dependency
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Header export is now explicit via `ALEF_EXPORT_GENERATED_HEADERS=1`; cbindgen output is buffered,
   validated as UTF-8, and published atomically to the canonical and Go destinations with rollback
   on failure. This prevents failed workspace lint or build commands from truncating generated files.
+
 ## [0.67.0] - 2026-08-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "alef"
-version = "0.67.1"
+version = "0.67.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "alef"
-version = "0.67.1"
+version = "0.67.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/alef.toml
+++ b/alef.toml
@@ -11,4 +11,4 @@
 crates = []
 
 [workspace]
-alef_version = "0.67.1"
+alef_version = "0.67.2"

--- a/schemas/alef.schema.json
+++ b/schemas/alef.schema.json
@@ -8129,7 +8129,7 @@
       "type": "object"
     }
   },
-  "$id": "https://github.com/xberg-io/alef/releases/download/v0.67.1/alef.schema.json",
+  "$id": "https://github.com/xberg-io/alef/releases/download/v0.67.2/alef.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "description": "JSON Schema for the JSON representation of alef.toml.",
@@ -8249,6 +8249,6 @@
   ],
   "title": "Alef configuration",
   "type": "object",
-  "version": "0.67.1",
-  "x-alef-version": "0.67.1"
+  "version": "0.67.2",
+  "x-alef-version": "0.67.2"
 }

--- a/src/backends/dart/gen_bindings/mod.rs
+++ b/src/backends/dart/gen_bindings/mod.rs
@@ -298,6 +298,7 @@ impl Backend for DartBackend {
                     "generate",
                     "--config-file",
                     "packages/dart/rust/flutter_rust_bridge.yaml",
+                    "--no-deps-check",
                 ],
             }],
         })
@@ -361,6 +362,7 @@ impl DartBackend {
                             "generate",
                             "--config-file",
                             "packages/dart/rust/flutter_rust_bridge.yaml",
+                            "--no-deps-check",
                         ],
                     }]
                 };

--- a/src/backends/dart/gen_rust_crate/build_rs_cfg_gates_tests.rs
+++ b/src/backends/dart/gen_rust_crate/build_rs_cfg_gates_tests.rs
@@ -1,4 +1,4 @@
-//! The generated bridge crate's `build.rs` must repair the committed FRB glue on every build.
+//! The generated bridge crate's `build.rs` must repair cfg gates only after explicit regeneration.
 //!
 //! flutter_rust_bridge is not feature-aware: it bakes a `wire__crate__<name>_impl` wrapper and a
 //! dispatch arm for every `pub fn` it can see, including ones behind `#[cfg(feature = "...")]`.
@@ -7,14 +7,9 @@
 //! the crate fails with `E0425: cannot find function ... in the crate root`.
 //!
 //! `carry_frb_cfg_gates()` is the repair: it reads the gates out of `lib.rs` — alef's own emitted
-//! source of truth for which functions are gated — and re-applies them to `frb_generated.rs`. It
-//! needs no external tool, touches only files inside the crate, and is idempotent.
-//!
-//! It used to be invoked only from the success arm of the `flutter_rust_bridge_codegen` spawn,
-//! itself behind the opt-in `ALEF_FRB_REGENERATE_ON_BUILD` early return. Every configuration that
-//! actually needs the repair — a normal build of the *committed* bridge, with FRB not installed —
-//! took the early return or the `NotFound` arm and never reached it. Asserting only that the call
-//! text appears somewhere in the file cannot catch that, so these tests assert reachability.
+//! source of truth for which functions are gated — and re-applies them to `frb_generated.rs`.
+//! Because that is a source-tree mutation, an ordinary Cargo build must return before reaching it;
+//! the repair belongs only in the successful explicit FRB regeneration arm.
 
 use super::cargo::emit_build_rs;
 use syn::{Expr, Stmt};
@@ -27,19 +22,6 @@ fn generated_build_rs() -> String {
         "sample_router_dart",
     )
     .content
-}
-
-/// Index of the first top-level statement in `main` whose expression is a call to `name()`.
-fn top_level_call_index(statements: &[Stmt], name: &str) -> Option<usize> {
-    statements.iter().position(|statement| {
-        let Stmt::Expr(Expr::Call(call), _) = statement else {
-            return false;
-        };
-        let Expr::Path(path) = call.func.as_ref() else {
-            return false;
-        };
-        path.path.is_ident(name)
-    })
 }
 
 /// Index of the top-level `if !frb_regeneration_opted_in() { ... return; }` guard in `main`.
@@ -66,26 +48,37 @@ fn main_statements(source: &str) -> Vec<Stmt> {
 }
 
 #[test]
-fn should_call_carry_frb_cfg_gates_from_main_body_not_only_after_codegen() {
-    let statements = main_statements(&generated_build_rs());
-    assert!(
-        top_level_call_index(&statements, "carry_frb_cfg_gates").is_some(),
-        "carry_frb_cfg_gates() must be a top-level statement in main(): nested inside the \
-         flutter_rust_bridge_codegen success arm it never runs for a build of the committed \
-         bridge, which is exactly the build that needs the gates"
-    );
-}
-
-#[test]
-fn should_carry_frb_cfg_gates_before_the_regeneration_opt_in_returns() {
+fn should_carry_frb_cfg_gates_after_successful_explicit_regeneration() {
     let statements = main_statements(&generated_build_rs());
     let guard = opt_in_guard_index(&statements).expect("main() must keep the opt-in regeneration guard");
-    let repair = top_level_call_index(&statements, "carry_frb_cfg_gates")
-        .expect("main() must call carry_frb_cfg_gates() at top level");
+    let regeneration = statements
+        .iter()
+        .skip(guard + 1)
+        .find_map(|statement| match statement {
+            Stmt::Expr(Expr::Match(expression), _) => Some(expression),
+            _ => None,
+        })
+        .expect("main() must match on the explicit FRB regeneration result");
+    use quote::ToTokens;
+    let success_index = regeneration
+        .arms
+        .iter()
+        .position(|arm| arm.pat.to_token_stream().to_string().contains("status . success"))
+        .expect("FRB regeneration must have a status.success() arm");
     assert!(
-        repair < guard,
-        "carry_frb_cfg_gates() (statement {repair}) must run before the \
-         ALEF_FRB_REGENERATE_ON_BUILD early return (statement {guard}); the default build path \
-         returns there, so anything after it is unreachable in CI"
+        regeneration.arms[success_index]
+            .body
+            .to_token_stream()
+            .to_string()
+            .contains("carry_frb_cfg_gates"),
+        "successful explicit FRB regeneration must restore feature cfg gates"
     );
+    for (index, arm) in regeneration.arms.iter().enumerate() {
+        if index != success_index {
+            assert!(
+                !arm.body.to_token_stream().to_string().contains("carry_frb_cfg_gates"),
+                "failed or unavailable FRB regeneration must not mutate committed output"
+            );
+        }
+    }
 }

--- a/src/backends/dart/gen_rust_crate/cargo.rs
+++ b/src/backends/dart/gen_rust_crate/cargo.rs
@@ -1139,6 +1139,10 @@ mod build_rs_tests {
             "the opt-in env var must be checked before flutter_rust_bridge_codegen is invoked; got:\n{}",
             file.content
         );
+        assert!(
+            file.content.contains(r#""--no-deps-check""#),
+            "the opt-in path must tolerate valid prerelease Dart dependencies"
+        );
         syn::parse_file(&file.content).expect("generated build.rs must be valid Rust");
     }
 

--- a/src/backends/dart/gen_rust_crate/cargo.rs
+++ b/src/backends/dart/gen_rust_crate/cargo.rs
@@ -1146,6 +1146,39 @@ mod build_rs_tests {
         syn::parse_file(&file.content).expect("generated build.rs must be valid Rust");
     }
 
+    /// A default Cargo build must be source-tree read-only. In particular, carrying cfg gates
+    /// mutates the committed FRB Rust output and therefore belongs behind the same explicit
+    /// regeneration opt-in as every other post-codegen rewrite.
+    #[test]
+    fn emitted_build_rs_does_not_mutate_sources_before_opt_in_gate() {
+        let file = emit_build_rs(
+            "packages/dart/rust",
+            "sample_router",
+            "sample_router",
+            "sample_router_dart",
+        );
+        let opt_in_gate = file
+            .content
+            .find("if !frb_regeneration_opted_in()")
+            .expect("build.rs must return early unless regeneration is explicitly enabled");
+
+        for mutation in [
+            "carry_frb_cfg_gates();",
+            "patch_published_loader();",
+            "fix_handler_executor_calls();",
+        ] {
+            let mutation_call = file
+                .content
+                .find(mutation)
+                .unwrap_or_else(|| panic!("build.rs must retain the opt-in mutation `{mutation}`"));
+            assert!(
+                opt_in_gate < mutation_call,
+                "source mutation `{mutation}` must occur only after the regeneration opt-in gate; got:\n{}",
+                file.content
+            );
+        }
+    }
+
     #[test]
     fn emitted_build_rs_patches_published_loader_after_codegen() {
         let file = emit_build_rs(

--- a/src/backends/dart/templates/rust_build_rs.rs.jinja
+++ b/src/backends/dart/templates/rust_build_rs.rs.jinja
@@ -23,20 +23,6 @@ fn main() {
     println!("cargo:rerun-if-changed=flutter_rust_bridge.yaml");
     println!("cargo:rerun-if-env-changed={ALEF_FRB_REGENERATE_ON_BUILD}");
 
-    // FRB is not feature-aware: it bakes a wire wrapper and a numeric dispatch arm for every
-    // `pub fn` it can see, including ones behind `#[cfg(feature = "...")]`. Compiled under a
-    // reduced feature set (Android: --no-default-features --features android-target) the gated
-    // definition is configured out of `lib.rs` while the ungated caller in `frb_generated.rs`
-    // survives, and the crate fails with E0425.
-    //
-    // This runs unconditionally, before the regeneration opt-in returns below, because the build
-    // that needs it most is the one that regenerates nothing: a plain build of the *committed*
-    // bridge, on a machine with no flutter_rust_bridge_codegen installed. Gating the repair on a
-    // successful FRB run made it unreachable in exactly that configuration. It reads the gates
-    // from `lib.rs` — the same file alef derives them from — so both sides of the wire always
-    // agree, and it is idempotent, so re-applying costs nothing.
-    carry_frb_cfg_gates();
-
     if !frb_regeneration_opted_in() {
         println!(
             "cargo:warning=flutter_rust_bridge_codegen regeneration skipped by default -- using the committed generated bridge. Run `alef generate` to regenerate it (with alef's full post-processing). Set {ALEF_FRB_REGENERATE_ON_BUILD}=1 to regenerate here instead for local-only iteration; the result bypasses alef's post-processing and must not be committed."
@@ -87,8 +73,9 @@ fn main() {
             // gate above, so it never contends with alef's own regeneration.
             fix_handler_executor_calls();
 
-            // The FRB run above rewrote `frb_generated.rs` from scratch and dropped the gates
-            // applied at the top of `main`, so re-apply them to the file as it now stands.
+            // FRB is not feature-aware: it emits ungated callers for functions behind feature
+            // cfgs. Apply the corresponding gates after regeneration so reduced-feature builds
+            // compile without making an ordinary Cargo build mutate committed source.
             carry_frb_cfg_gates();
         }
         Ok(status) => panic!("flutter_rust_bridge_codegen generate failed (exit code: {status})"),

--- a/src/backends/dart/templates/rust_build_rs.rs.jinja
+++ b/src/backends/dart/templates/rust_build_rs.rs.jinja
@@ -45,7 +45,12 @@ fn main() {
     }
 
     match std::process::Command::new("flutter_rust_bridge_codegen")
-        .args(["generate", "--config-file", "flutter_rust_bridge.yaml"])
+        .args([
+            "generate",
+            "--config-file",
+            "flutter_rust_bridge.yaml",
+            "--no-deps-check",
+        ])
         .status()
     {
         Ok(status) if status.success() => {

--- a/src/backends/swift/gen_rust_crate/shims.rs
+++ b/src/backends/swift/gen_rust_crate/shims.rs
@@ -147,6 +147,33 @@ pub(crate) fn swift_call_arg(
         return from_expr;
     }
 
+    if let TypeRef::Named(n) = &p.ty
+        && tagged_enum_names.contains(n.as_str())
+    {
+        let native_ty = source_type(n);
+        let deserialize =
+            |value: &str| format!("::serde_json::from_str::<{native_ty}>({value}).expect(\"valid JSON for {name}\")");
+        if p.optional {
+            let converted = format!("{name}.as_ref().map(|value| {})", deserialize("value"));
+            if p.is_ref {
+                return if p.is_mut {
+                    format!("{converted}.as_mut()")
+                } else {
+                    format!("{converted}.as_ref()")
+                };
+            }
+            return converted;
+        }
+        let converted = deserialize(&format!("&{name}"));
+        if p.is_ref {
+            if p.is_mut {
+                return format!("&mut {converted}");
+            }
+            return format!("&{converted}");
+        }
+        return converted;
+    }
+
     if let TypeRef::Vec(inner) = &p.ty
         && let TypeRef::Named(n) = inner.as_ref()
     {
@@ -672,6 +699,55 @@ mod tests {
         );
         assert!(!shim.contains("From<String>"));
         assert!(!shim.contains("unimplemented!"));
+    }
+
+    /// Data-carrying enums cross swift-bridge as JSON strings. A referenced enum parameter
+    /// therefore must be deserialized before it is borrowed for the source call; treating the
+    /// bridge `String` as an opaque wrapper emits `&param.0` and fails with E0609.
+    #[test]
+    fn referenced_tagged_enum_param_is_deserialized_before_source_call() {
+        let mut output_format = param("output_format", TypeRef::Named("OutputFormat".to_string()));
+        output_format.is_ref = true;
+        let f = function(vec![
+            param(
+                "layout_enabled",
+                TypeRef::Primitive(crate::core::ir::PrimitiveType::Bool),
+            ),
+            output_format,
+        ]);
+        let unit_enum_names = HashSet::new();
+        let tagged_enum_names = HashSet::from(["OutputFormat"]);
+        let type_paths = HashMap::from([("OutputFormat".to_string(), "sample_crawler::OutputFormat".to_string())]);
+        let no_serde_names = HashSet::new();
+        let handle_returned_types = HashSet::new();
+        let capsule_types = HashMap::new();
+        let context = FunctionShimContext {
+            source_crate: "sample_crawler",
+            type_paths: &type_paths,
+            unit_enum_names: &unit_enum_names,
+            tagged_enum_names: &tagged_enum_names,
+            no_serde_names: &no_serde_names,
+            handle_returned_types: &handle_returned_types,
+            capsule_types: &capsule_types,
+        };
+
+        let shim = emit_function_shim(&f, &context);
+
+        assert!(
+            shim.contains("output_format: String"),
+            "tagged enums use the String bridge type:\n{shim}"
+        );
+        assert!(
+            shim.contains(
+                "&::serde_json::from_str::<sample_crawler::OutputFormat>(&output_format)\
+                 .expect(\"valid JSON for output_format\")"
+            ),
+            "the bridge string must be deserialized into the source enum before borrowing:\n{shim}"
+        );
+        assert!(
+            !shim.contains("output_format.0"),
+            "a bridge String has no opaque-wrapper field:\n{shim}"
+        );
     }
 
     #[test]

--- a/src/core/config/build_defaults.rs
+++ b/src/core/config/build_defaults.rs
@@ -128,9 +128,11 @@ pub(crate) fn default_build_config(
             dependency_precondition: None,
             dependency_remediation: None,
             before: None,
-            build: Some(StringOrVec::Single(format!("cargo build -p {crate_name}-ffi"))),
+            build: Some(StringOrVec::Single(format!(
+                "cargo build --manifest-path {output_dir}/Cargo.toml"
+            ))),
             build_release: Some(StringOrVec::Single(format!(
-                "cargo build --release -p {crate_name}-ffi"
+                "cargo build --release --manifest-path {output_dir}/Cargo.toml"
             ))),
         },
         Language::Java => {
@@ -488,12 +490,12 @@ mod tests {
     }
 
     #[test]
-    fn ffi_uses_cargo_build_p() {
+    fn ffi_uses_its_manifest_without_requiring_workspace_membership() {
         let c = cfg(Language::Ffi, "packages/ffi", "my-lib");
         let build = c.build.unwrap().commands().join(" ");
         let release = c.build_release.unwrap().commands().join(" ");
-        assert!(build.contains("cargo build -p my-lib-ffi"));
-        assert!(release.contains("cargo build --release -p my-lib-ffi"));
+        assert_eq!(build, "cargo build --manifest-path packages/ffi/Cargo.toml");
+        assert_eq!(release, "cargo build --release --manifest-path packages/ffi/Cargo.toml");
     }
 
     #[test]

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -470,7 +470,7 @@ pub mod cran {
 }
 
 pub mod precommit {
-    pub const ALEF_REV: &str = "v0.67.1";
+    pub const ALEF_REV: &str = "v0.67.2";
 
     /// Codegen format version — bumped only when output-affecting codegen
     /// changes require all generated files to be re-stamped. Unlike

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -150,10 +150,10 @@ pub mod cargo {
     pub const TOKIO: &str = "1";
 
     // renovate: datasource=crate depName=flutter_rust_bridge
-    pub const FLUTTER_RUST_BRIDGE: &str = "2.12.0";
+    pub const FLUTTER_RUST_BRIDGE: &str = "2.13.0";
 
     // renovate: datasource=crate depName=flutter_rust_bridge_codegen
-    pub const FLUTTER_RUST_BRIDGE_CODEGEN: &str = "2.12.0";
+    pub const FLUTTER_RUST_BRIDGE_CODEGEN: &str = "2.13.0";
 
     // renovate: datasource=crate depName=swift-bridge
     pub const SWIFT_BRIDGE: &str = "0.1.59";

--- a/tests/cli_all_format_gate_covers_every_write_phase.rs
+++ b/tests/cli_all_format_gate_covers_every_write_phase.rs
@@ -23,6 +23,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 fn alef_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_alef"))
 }
@@ -51,9 +54,44 @@ fn write_fixture(root: &Path) {
     .expect("write alef config");
 }
 
-fn run_all(root: &Path) -> Output {
+fn install_test_formatter(root: &Path) -> PathBuf {
+    let bin_dir = root.join("test-bin");
+    fs::create_dir(&bin_dir).expect("create test formatter directory");
+
+    #[cfg(unix)]
+    {
+        let formatter = bin_dir.join("poly");
+        fs::write(
+            &formatter,
+            "#!/bin/sh\nif [ -f packages/python/messy.py ]; then\n  printf 'x = 1\\n' > packages/python/messy.py\nfi\n",
+        )
+        .expect("write test formatter");
+        let mut permissions = fs::metadata(&formatter)
+            .expect("read test formatter metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&formatter, permissions).expect("make test formatter executable");
+    }
+
+    #[cfg(windows)]
+    fs::write(
+        bin_dir.join("poly.cmd"),
+        "@echo off\r\nif exist packages\\python\\messy.py (\r\n  > packages\\python\\messy.py echo x = 1\r\n)\r\n",
+    )
+    .expect("write test formatter");
+
+    bin_dir
+}
+
+fn run_all(root: &Path, formatter_bin: &Path) -> Output {
+    let path = std::env::join_paths(
+        std::iter::once(formatter_bin.to_path_buf())
+            .chain(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())),
+    )
+    .expect("construct PATH with test formatter");
     Command::new(alef_binary())
         .current_dir(root)
+        .env("PATH", path)
         .arg("all")
         .output()
         .expect("run alef all")
@@ -64,8 +102,9 @@ fn a_readme_only_change_still_formats_stray_files_and_stays_hash_stable() {
     let fixture = tempfile::tempdir().expect("create fixture directory");
     let root = fixture.path();
     write_fixture(root);
+    let formatter_bin = install_test_formatter(root);
 
-    let first = run_all(root);
+    let first = run_all(root, &formatter_bin);
     assert!(
         first.status.success(),
         "first `alef all` run must succeed: {}",
@@ -79,7 +118,7 @@ fn a_readme_only_change_still_formats_stray_files_and_stays_hash_stable() {
     let messy = root.join("packages/python/messy.py");
     fs::write(&messy, "x=1\n").expect("seed an unformatted, alef-unmanaged file");
 
-    let second = run_all(root);
+    let second = run_all(root, &formatter_bin);
     assert!(
         second.status.success(),
         "second `alef all` run must succeed: {}",
@@ -105,7 +144,7 @@ fn a_readme_only_change_still_formats_stray_files_and_stays_hash_stable() {
     );
 
     let messy_after_second = fs::read_to_string(&messy).expect("read messy.py again");
-    let third = run_all(root);
+    let third = run_all(root, &formatter_bin);
     assert!(
         third.status.success(),
         "third `alef all` run must succeed: {}",

--- a/tests/generated_output_downstream_gate/fixture.rs
+++ b/tests/generated_output_downstream_gate/fixture.rs
@@ -127,7 +127,7 @@ pub fn get_language(name: String) -> Result<Language, String> {
 // The fixture's own core crate derives serde, so it needs the dependency to compile. It went
 // unnoticed until the core crate became reachable from the emitted binding crates: before that
 // nothing ever built it, so an uncompilable fixture still passed every lane. ~keep
-pub(crate) const FIXTURE_CARGO_TOML: &str = "[package]\nname = \"toolkit\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\nserde = { version = \"1\", features = [\"derive\"] }\n";
+pub(crate) const FIXTURE_CARGO_TOML: &str = "[package]\nname = \"toolkit\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\nserde = { version = \"1\", features = [\"derive\"] }\n\n[lints.rust]\nunexpected_cfgs = { level = \"warn\", check-cfg = ['cfg(alef)'] }\n";
 
 // `java` and `elixir` scaffolders bail `alef generate` outright when repository/license/
 // authors are unset (`scaffold::languages::java`, `scaffold::languages::elixir`), and both

--- a/tests/publish_workflow_cli_asset_guard.rs
+++ b/tests/publish_workflow_cli_asset_guard.rs
@@ -9,12 +9,18 @@
 //! Everything here is extracted from the committed workflow and executed, rather than
 //! transcribed, so the test cannot drift away from what CI actually runs.
 
+#[cfg(unix)]
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(unix)]
 use std::process::Command;
 
 const WORKFLOW: &str = ".github/workflows/publish.yaml";
+#[cfg(unix)]
 const TARGETS_FILE: &str = ".github/cli-targets.json";
+#[cfg(unix)]
 const RESOLVE_STEP_ID: &str = "cli-targets";
 
 fn repo_root() -> PathBuf {
@@ -46,6 +52,7 @@ fn step_with_id(job: &serde_yaml::Value, id: &str) -> serde_yaml::Value {
         .unwrap_or_else(|| panic!("no step with id `{id}`"))
 }
 
+#[cfg(unix)]
 fn step_named(job: &serde_yaml::Value, name: &str) -> serde_yaml::Value {
     steps(job)
         .into_iter()
@@ -55,6 +62,7 @@ fn step_named(job: &serde_yaml::Value, name: &str) -> serde_yaml::Value {
 
 /// Run the workflow's own resolve-matrix script in `workdir` and return its `$GITHUB_OUTPUT`
 /// keys. The script text comes from the committed workflow verbatim.
+#[cfg(unix)]
 fn run_resolve_step(workdir: &Path) -> Vec<(String, String)> {
     let script = step_with_id(&job(&workflow(), "prepare"), RESOLVE_STEP_ID)["run"]
         .as_str()
@@ -89,6 +97,7 @@ fn run_resolve_step(workdir: &Path) -> Vec<(String, String)> {
         .collect()
 }
 
+#[cfg(unix)]
 fn output_value(outputs: &[(String, String)], key: &str) -> String {
     outputs
         .iter()
@@ -100,6 +109,7 @@ fn output_value(outputs: &[(String, String)], key: &str) -> String {
 
 /// The archive filename `build-cli` uploads, taken from that job's own shell and expanded for
 /// one matrix entry.
+#[cfg(unix)]
 fn archive_name_for(entry: &serde_json::Value) -> String {
     let archive_step = step_named(&job(&workflow(), "build-cli"), "Create release archive");
     let script = archive_step["run"].as_str().expect("archive step has a run block");


### PR DESCRIPTION
Updates flutter_rust_bridge to 2.13, bypasses its redundant dependency preflight, and ensures ordinary Cargo builds never mutate committed Dart bridge sources. Also repairs three pre-existing cross-platform CI regressions surfaced by the previous release run and prepares v0.67.2.