### PR TITLE
refactor(elixir): hash through sha2

### DIFF
--- a/src/publish/package/elixir.rs
+++ b/src/publish/package/elixir.rs
@@ -204,6 +204,7 @@ fn resolve_nif_versions(config: &ResolvedCrateConfig) -> Vec<String> {
 
 /// Compute SHA-256 hex digest of a file.
 fn sha256_file(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
     use std::io::Read;
     let mut file = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
     let mut hasher = Sha256::new();
@@ -215,173 +216,55 @@ fn sha256_file(path: &Path) -> Result<String> {
         }
         hasher.update(&buf[..n]);
     }
-    Ok(hasher.finalize_hex())
-}
-
-/// Minimal SHA-256 implementation to avoid adding a dependency.
-struct Sha256 {
-    state: [u32; 8],
-    buf: Vec<u8>,
-}
-
-impl Sha256 {
-    fn new() -> Self {
-        Self {
-            state: [
-                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
-            ],
-            buf: Vec::new(),
-        }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter() {
+        use std::fmt::Write as _;
+        write!(&mut hex, "{byte:02x}").expect("writing to String never fails");
     }
-
-    fn update(&mut self, data: &[u8]) {
-        self.buf.extend_from_slice(data);
-    }
-
-    fn finalize_hex(mut self) -> String {
-        let orig_len_bits = (self.buf.len() as u64) * 8;
-        self.buf.push(0x80);
-        while self.buf.len() % 64 != 56 {
-            self.buf.push(0);
-        }
-        self.buf.extend_from_slice(&orig_len_bits.to_be_bytes());
-
-        let k: [u32; 64] = SHA256_K;
-        for block in self.buf.as_chunks::<64>().0 {
-            let mut w = [0u32; 64];
-            for (i, chunk) in block.as_chunks::<4>().0.iter().enumerate().take(16) {
-                w[i] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-            }
-            for i in 16..64 {
-                let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
-                let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
-                w[i] = w[i - 16].wrapping_add(s0).wrapping_add(w[i - 7]).wrapping_add(s1);
-            }
-            let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = self.state;
-            for i in 0..64 {
-                let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
-                let ch = (e & f) ^ (!e & g);
-                let temp1 = h
-                    .wrapping_add(s1)
-                    .wrapping_add(ch)
-                    .wrapping_add(k[i])
-                    .wrapping_add(w[i]);
-                let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
-                let maj = (a & b) ^ (a & c) ^ (b & c);
-                let temp2 = s0.wrapping_add(maj);
-                h = g;
-                g = f;
-                f = e;
-                e = d.wrapping_add(temp1);
-                d = c;
-                c = b;
-                b = a;
-                a = temp1.wrapping_add(temp2);
-            }
-            self.state[0] = self.state[0].wrapping_add(a);
-            self.state[1] = self.state[1].wrapping_add(b);
-            self.state[2] = self.state[2].wrapping_add(c);
-            self.state[3] = self.state[3].wrapping_add(d);
-            self.state[4] = self.state[4].wrapping_add(e);
-            self.state[5] = self.state[5].wrapping_add(f);
-            self.state[6] = self.state[6].wrapping_add(g);
-            self.state[7] = self.state[7].wrapping_add(h);
-        }
-        self.state
-            .iter()
-            .flat_map(|&w| w.to_be_bytes())
-            .map(|b| format!("{b:02x}"))
-            .collect()
-    }
+    Ok(hex)
 }
-
-/// SHA-256 round constants (first 32 bits of fractional parts of cube roots of first 64 primes).
-const SHA256_K: [u32; 64] = [
-    0x428a_2f98,
-    0x7137_4491,
-    0xb5c0_fbcf,
-    0xe9b5_dba5,
-    0x3956_c25b,
-    0x59f1_11f1,
-    0x923f_82a4,
-    0xab1c_5ed5,
-    0xd807_aa98,
-    0x1283_5b01,
-    0x2431_85be,
-    0x550c_7dc3,
-    0x72be_5d74,
-    0x80de_b1fe,
-    0x9bdc_06a7,
-    0xc19b_f174,
-    0xe49b_69c1,
-    0xefbe_4786,
-    0x0fc1_9dc6,
-    0x240c_a1cc,
-    0x2de9_2c6f,
-    0x4a74_84aa,
-    0x5cb0_a9dc,
-    0x76f9_88da,
-    0x983e_5152,
-    0xa831_c66d,
-    0xb003_27c8,
-    0xbf59_7fc7,
-    0xc6e0_0bf3,
-    0xd5a7_9147,
-    0x06ca_6351,
-    0x1429_2967,
-    0x27b7_0a85,
-    0x2e1b_2138,
-    0x4d2c_6dfc,
-    0x5338_0d13,
-    0x650a_7354,
-    0x766a_0abb,
-    0x81c2_c92e,
-    0x9272_2c85,
-    0xa2bf_e8a1,
-    0xa81a_664b,
-    0xc24b_8b70,
-    0xc76c_51a3,
-    0xd192_e819,
-    0xd699_0624,
-    0xf40e_3585,
-    0x106a_a070,
-    0x19a4_c116,
-    0x1e37_6c08,
-    0x2748_774c,
-    0x34b0_bcb5,
-    0x391c_0cb3,
-    0x4ed8_aa4a,
-    0x5b9c_ca4f,
-    0x682e_6ff3,
-    0x748f_82ee,
-    0x78a5_636f,
-    0x84c8_7814,
-    0x8cc7_0208,
-    0x90be_fffa,
-    0xa450_6ceb,
-    0xbef9_a3f7,
-    0xc671_78f2,
-];
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    /// Hash `contents` through the real file path `sha256_file` takes.
+    fn sha256_of(contents: &[u8]) -> String {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("payload.bin");
+        fs::write(&path, contents).unwrap();
+        sha256_file(&path).unwrap()
+    }
+
     #[test]
     fn sha256_known_vector() {
-        let mut h = Sha256::new();
-        h.update(b"");
-        let hex = h.finalize_hex();
-        assert_eq!(hex, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        assert_eq!(
+            sha256_of(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
     }
 
     #[test]
     fn sha256_hello() {
-        let mut h = Sha256::new();
-        h.update(b"hello");
-        let hex = h.finalize_hex();
-        assert_eq!(hex, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+        assert_eq!(
+            sha256_of(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    /// Guards the streaming read loop: a payload larger than the 64 KiB buffer
+    /// exercises multiple `update` calls, where an off-by-one in chunking would
+    /// silently produce a wrong digest.
+    #[test]
+    fn sha256_spans_multiple_read_chunks() {
+        // 1_000_000 repetitions of "a" — the standard SHA-256 long-message vector.
+        let payload: Vec<u8> = std::iter::repeat_n(b'a', 1_000_000).collect();
+        assert_eq!(
+            sha256_of(&payload),
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The comment claimed the implementation existed "to avoid adding a dependency", but sha2 is already a direct dependency and publish/package/php.rs uses it for the same purpose. 


This remove code that should not be maintained in this repo.