### PR TITLE
fix(magnus): release GVL around async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Magnus async free-function wrappers no longer retain Ruby's GVL while blocking on Rust
+  futures.** Both generated entrypoints now convert their arguments first, release the GVL on the
+  calling Ruby thread, and drive a current-thread Tokio runtime until the future completes. Ruby
+  error construction and result conversion happen only after the GVL is restored. This prevents
+  deadlock when an async core function calls back through a generated Ruby host trait bridge and
+  allows unrelated Ruby threads to run while Rust work is pending.
+
 - **The Kotlin/Android `update` default was pinned to the last release before its own Gradle 9
   fix.** Four of the five consumer repos independently overrode `[crates.update.kotlin_android]`
   to a no-op, two of them citing "gradle-versions-plugin incompatible with Gradle 9". The plugin

--- a/src/backends/magnus/gen_bindings/functions/async_wrappers.rs
+++ b/src/backends/magnus/gen_bindings/functions/async_wrappers.rs
@@ -13,8 +13,8 @@ use crate::core::ir::{ApiSurface, FunctionDef, TypeRef};
 use ahash::AHashSet;
 
 /// ~keep The async wrapper's return type is fallible unconditionally, independent of whether the
-/// core function declares an error type: every emitted body opens by building a tokio runtime with
-/// `Runtime::new()...?` and closes with `Ok(..)` (see `function_async_body.rs.jinja`), so the
+/// core function declares an error type: every emitted body runs a tokio runtime without the GVL
+/// and closes with `Ok(..)` (see `function_async_body.rs.jinja`), so the
 /// delegable path — the authority on the signature — only compiles inside `Result<T, Error>`. The
 /// unimplemented body must be selected against this same fact, or it emits `compile_error!`/a bare
 /// `()` into a `Result` slot for a non-delegable function with no declared error type.

--- a/src/backends/magnus/gen_bindings/mod.rs
+++ b/src/backends/magnus/gen_bindings/mod.rs
@@ -218,6 +218,13 @@ impl Backend for MagnusBackend {
             builder.add_item("pub mod service;");
         }
 
+        if api.functions.iter().any(|func| func.is_async) {
+            builder.add_item(&crate::backends::magnus::template_env::render(
+                "function_async_gvl_helper.rs.jinja",
+                minijinja::context! {},
+            ));
+        }
+
         let opaque_types: AHashSet<String> = api
             .types
             .iter()

--- a/src/backends/magnus/template_env.rs
+++ b/src/backends/magnus/template_env.rs
@@ -97,6 +97,10 @@ static TEMPLATES: &[(&str, &str)] = &[
         include_str!("templates/function_async_body.rs.jinja"),
     ),
     (
+        "function_async_gvl_helper.rs.jinja",
+        include_str!("templates/function_async_gvl_helper.rs.jinja"),
+    ),
+    (
         "function_result_body.rs.jinja",
         include_str!("templates/function_result_body.rs.jinja"),
     ),

--- a/src/backends/magnus/templates/function_async_body.rs.jinja
+++ b/src/backends/magnus/templates/function_async_body.rs.jinja
@@ -1,7 +1,13 @@
-let rt = tokio::runtime::Runtime::new().map_err(|e| magnus::Error::new(unsafe { Ruby::get_unchecked() }.exception_runtime_error(), e.to_string()))?;
+let async_result = alef_magnus_run_without_gvl(move || -> Result<_, String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
     {% if has_error -%}
-let result = rt.block_on(async { {{ core_call }}.await }).map_err(|e| magnus::Error::new(unsafe { Ruby::get_unchecked() }.exception_runtime_error(), e.to_string()))?;
+    rt.block_on(async { {{ core_call }}.await }).map_err(|e| e.to_string())
     {%- else -%}
-let result = rt.block_on(async { {{ core_call }}.await });
+    Ok(rt.block_on(async { {{ core_call }}.await }))
     {%- endif %}
+});
+let result = async_result.map_err(|message| magnus::Error::new(unsafe { Ruby::get_unchecked() }.exception_runtime_error(), message))?;
 Ok({{ wrap }})

--- a/src/backends/magnus/templates/function_async_gvl_helper.rs.jinja
+++ b/src/backends/magnus/templates/function_async_gvl_helper.rs.jinja
@@ -1,0 +1,45 @@
+/// Run owned Rust work while the calling Ruby thread releases the GVL.
+fn alef_magnus_run_without_gvl<F, T>(callback: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    struct RunState<F, T> {
+        callback: Option<F>,
+        result: Option<std::thread::Result<T>>,
+    }
+
+    extern "C" fn run_without_gvl<F, T>(data: *mut std::ffi::c_void) -> *mut std::ffi::c_void
+    where
+        F: FnOnce() -> T,
+    {
+        // SAFETY: `data` points to the caller's RunState for the duration of this callback.
+        let state = unsafe { &mut *(data as *mut RunState<F, T>) };
+        let Some(callback) = state.callback.take() else {
+            state.result = Some(Err(Box::new("Alef Magnus callback already consumed")));
+            return std::ptr::null_mut();
+        };
+        state.result = Some(std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback)));
+        std::ptr::null_mut()
+    }
+
+    extern "C" fn unblock_run(_data: *mut std::ffi::c_void) {}
+
+    let mut state = RunState {
+        callback: Some(callback),
+        result: None,
+    };
+    // SAFETY: Ruby invokes the callback synchronously, and `state` remains live until it returns.
+    unsafe {
+        rb_sys::rb_thread_call_without_gvl(
+            Some(run_without_gvl::<F, T>),
+            &mut state as *mut RunState<F, T> as *mut std::ffi::c_void,
+            Some(unblock_run),
+            std::ptr::null_mut(),
+        );
+    }
+
+    match state.result.expect("Alef Magnus callback did not run") {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -869,6 +869,25 @@ fn test_async_function() {
         "Should contain async/tokio runtime handling"
     );
 
+    assert_eq!(
+        content.matches("rb_sys::rb_thread_call_without_gvl").count(),
+        1,
+        "Should emit one shared without-GVL helper"
+    );
+    assert_eq!(
+        content.matches("alef_magnus_run_without_gvl(move ||").count(),
+        2,
+        "Both generated Ruby entrypoints should release the GVL"
+    );
+    assert!(
+        content.contains("tokio::runtime::Builder::new_current_thread()"),
+        "Should poll the future on the calling Ruby OS thread"
+    );
+    assert!(
+        !content.contains("tokio::runtime::Runtime::new()"),
+        "Async free-function wrappers must not block a multi-thread runtime under the GVL"
+    );
+
     assert!(
         content.contains("function!("),
         "Should use function! macro for free functions"


### PR DESCRIPTION
## Summary

- generate one reusable Magnus helper that runs owned Rust work under `rb_thread_call_without_gvl`
- drive async free functions with a current-thread Tokio runtime on the calling Ruby OS thread
- defer `magnus::Error` construction and return conversion until after the GVL is restored
- contain panics inside the C callback and resume them only after returning to Rust with the GVL

This prevents the deadlock where an async Rust free function calls an Alef-generated Ruby host trait bridge: the host dispatcher can now acquire the GVL while the entrypoint waits for the future.

Closes #287.

## Validation

- `cargo test --test backends_magnus_gen_bindings_test` (49 passed)
- generated StructuredMerge Ruby extension `cargo check`
- generated extension release compilation through `rb_sys`
- downstream runtime regression: async Rust free function re-enters a generated Ruby host provider and preserves arbitrary bytes
- downstream Ruby prototype suite (30 examples, 0 failures)

The upstream `cargo test --lib ...` target currently does not compile because pre-existing Zig scaffold tests compare `PathBuf` with `str` at nine sites; the Magnus integration test target above is green.
