### PR TITLE
fix(magnus): pass names to trait bridge constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constructors again.** Function bridges cache a companion required `name: String` parameter when
   one is present, while anonymous callback and options-field bridges retain an empty identity.
   Both paths had continued emitting the obsolete one-argument constructor after direct host
-  registration added the cached-name argument.
+  registration added the cached-name argument. Function bridges also preserve the extractor's
+  core-wrapper contract: `Arc<dyn Trait>` parameters receive the generated bridge directly, while
+  `Arc<Mutex<dyn Trait>>` handles retain their mutex wrapper.
 
 - **The Kotlin/Android `update` default was pinned to the last release before its own Gradle 9
   fix.** Four of the five consumer repos independently overrode `[crates.update.kotlin_android]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deadlock when an async core function calls back through a generated Ruby host trait bridge and
   allows unrelated Ruby threads to run while Rust work is pending.
 
+- **Magnus function-parameter and options-field trait bridges compile with named bridge
+  constructors again.** Function bridges cache a companion required `name: String` parameter when
+  one is present, while anonymous callback and options-field bridges retain an empty identity.
+  Both paths had continued emitting the obsolete one-argument constructor after direct host
+  registration added the cached-name argument.
+
 - **The Kotlin/Android `update` default was pinned to the last release before its own Gradle 9
   fix.** Four of the five consumer repos independently overrode `[crates.update.kotlin_android]`
   to a no-op, two of them citing "gradle-versions-plugin incompatible with Gradle 9". The plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both paths had continued emitting the obsolete one-argument constructor after direct host
   registration added the cached-name argument. Function bridges also preserve the extractor's
   core-wrapper contract: `Arc<dyn Trait>` parameters receive the generated bridge directly, while
-  `Arc<Mutex<dyn Trait>>` handles retain their mutex wrapper.
+  `Arc<Mutex<dyn Trait>>` handles retain their mutex wrapper. Function parameter extraction now
+  records these existing `CoreWrapper` variants instead of recording only `Cow` and discarding the
+  other wrapper evidence before code generation.
 
 - **The Kotlin/Android `update` default was pinned to the last release before its own Gradle 9
   fix.** Four of the five consumer repos independently overrode `[crates.update.kotlin_android]`

--- a/src/backends/magnus/trait_bridge/bridge_functions.rs
+++ b/src/backends/magnus/trait_bridge/bridge_functions.rs
@@ -17,6 +17,18 @@ fn named_type_name(ty: &crate::core::ir::TypeRef) -> Option<&str> {
     }
 }
 
+/// Use a companion `name: String` parameter as the bridge's cached plugin identity when present.
+/// Per-call callback bridges generally have no identity and retain the historical empty name.
+fn bridge_name_expr(func: &crate::core::ir::FunctionDef, bridge_param_idx: usize) -> &'static str {
+    let has_name = func.params.iter().enumerate().any(|(idx, param)| {
+        idx != bridge_param_idx
+            && param.name == "name"
+            && !param.optional
+            && matches!(param.ty, crate::core::ir::TypeRef::String)
+    });
+    if has_name { "name.clone()" } else { "String::new()" }
+}
+
 /// Generate a Magnus free function that has one parameter replaced by `magnus::Value` (a trait
 /// bridge). The bridge is constructed before calling the core function.
 #[allow(clippy::too_many_arguments)]
@@ -37,6 +49,7 @@ pub fn gen_bridge_function(
     let param_name = &func.params[bridge_param_idx].name;
     let bridge_param = &func.params[bridge_param_idx];
     let is_optional = bridge_param.optional || matches!(&bridge_param.ty, TypeRef::Optional(_));
+    let bridge_name = bridge_name_expr(func, bridge_param_idx);
 
     let mut sig_parts = Vec::new();
     for (idx, p) in func.params.iter().enumerate() {
@@ -47,7 +60,7 @@ pub fn gen_bridge_function(
                 sig_parts.push(format!("{}: magnus::Value", p.name));
             }
         } else {
-            let promoted = idx > bridge_param_idx || func.params[..idx].iter().any(|pp| pp.optional);
+            let promoted = (is_optional && idx > bridge_param_idx) || func.params[..idx].iter().any(|pp| pp.optional);
             let ty = if p.optional || promoted {
                 format!("Option<{}>", mapper.map_type(&p.ty))
             } else {
@@ -91,7 +104,7 @@ pub fn gen_bridge_function(
         format!(
             "let {param_name}: Option<{handle_path}> = match {param_name} {{\n        \
              Some(v) if !v.is_nil() => {{\n            \
-             let bridge = {struct_name}::new(v);\n            \
+             let bridge = {struct_name}::new(v, {bridge_name})?;\n            \
              Some(std::sync::Arc::new(std::sync::Mutex::new(bridge)) as {handle_path})\n        \
              }},\n        \
              _ => None,\n    \
@@ -100,7 +113,7 @@ pub fn gen_bridge_function(
     } else {
         format!(
             "let {param_name} = {{\n        \
-             let bridge = {struct_name}::new({param_name});\n        \
+             let bridge = {struct_name}::new({param_name}, {bridge_name})?;\n        \
              std::sync::Arc::new(std::sync::Mutex::new(bridge)) as {handle_path}\n    \
              }};"
         )

--- a/src/backends/magnus/trait_bridge/bridge_functions.rs
+++ b/src/backends/magnus/trait_bridge/bridge_functions.rs
@@ -50,6 +50,17 @@ pub fn gen_bridge_function(
     let bridge_param = &func.params[bridge_param_idx];
     let is_optional = bridge_param.optional || matches!(&bridge_param.ty, TypeRef::Optional(_));
     let bridge_name = bridge_name_expr(func, bridge_param_idx);
+    let (bridge_handle_type, bridge_value) = if bridge_param.core_wrapper == crate::core::ir::CoreWrapper::Arc {
+        (
+            format!("std::sync::Arc<dyn {handle_path}>"),
+            "std::sync::Arc::new(bridge)".to_string(),
+        )
+    } else {
+        (
+            handle_path.clone(),
+            "std::sync::Arc::new(std::sync::Mutex::new(bridge))".to_string(),
+        )
+    };
 
     let mut sig_parts = Vec::new();
     for (idx, p) in func.params.iter().enumerate() {
@@ -102,10 +113,10 @@ pub fn gen_bridge_function(
 
     let bridge_wrap = if is_optional {
         format!(
-            "let {param_name}: Option<{handle_path}> = match {param_name} {{\n        \
+            "let {param_name}: Option<{bridge_handle_type}> = match {param_name} {{\n        \
              Some(v) if !v.is_nil() => {{\n            \
              let bridge = {struct_name}::new(v, {bridge_name})?;\n            \
-             Some(std::sync::Arc::new(std::sync::Mutex::new(bridge)) as {handle_path})\n        \
+             Some({bridge_value} as {bridge_handle_type})\n        \
              }},\n        \
              _ => None,\n    \
              }};"
@@ -114,7 +125,7 @@ pub fn gen_bridge_function(
         format!(
             "let {param_name} = {{\n        \
              let bridge = {struct_name}::new({param_name}, {bridge_name})?;\n        \
-             std::sync::Arc::new(std::sync::Mutex::new(bridge)) as {handle_path}\n    \
+             {bridge_value} as {bridge_handle_type}\n    \
              }};"
         )
     };

--- a/src/backends/magnus/trait_bridge/options_field.rs
+++ b/src/backends/magnus/trait_bridge/options_field.rs
@@ -119,7 +119,7 @@ pub fn gen_options_field_bridge_function(
          }} else if let Ok(opts_binding) = <&{options_type} as magnus::TryConvert>::try_convert(v) {{\n            \
          opts_binding.clone().into()\n        \
          }} else {{\n            \
-         let bridge = {struct_name}::new(v);\n            \
+         let bridge = {struct_name}::new(v, String::new())?;\n            \
          let handle = std::sync::Arc::new(std::sync::Mutex::new(bridge)) as {handle_path};\n            \
          let mut opts = {core_import}::{options_type}::default();\n            \
          opts.{options_field} = Some(handle);\n            \

--- a/src/extract/extractor/functions/params.rs
+++ b/src/extract/extractor/functions/params.rs
@@ -246,7 +246,7 @@ pub(crate) fn extract_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, sy
                 let core_wrapper = if param_is_cow_str(&pat_type.ty) {
                     crate::core::ir::CoreWrapper::Cow
                 } else {
-                    crate::core::ir::CoreWrapper::None
+                    super::super::helpers::detect_core_wrapper(&pat_type.ty)
                 };
 
                 let sanitized = is_tuple_type(&resolved);
@@ -280,4 +280,24 @@ pub(crate) fn extract_params(inputs: &syn::punctuated::Punctuated<syn::FnArg, sy
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_params;
+    use crate::core::ir::CoreWrapper;
+
+    #[test]
+    fn preserves_arc_and_arc_mutex_parameter_wrappers() {
+        let item: syn::ItemFn = syn::parse_quote! {
+            fn register(
+                provider: std::sync::Arc<dyn WorkflowHost>,
+                visitor: std::sync::Arc<std::sync::Mutex<dyn Visitor>>,
+            ) {}
+        };
+
+        let params = extract_params(&item.sig.inputs);
+        assert_eq!(params[0].core_wrapper, CoreWrapper::Arc);
+        assert_eq!(params[1].core_wrapper, CoreWrapper::ArcMutex);
+    }
 }

--- a/src/extract/extractor/helpers.rs
+++ b/src/extract/extractor/helpers.rs
@@ -17,9 +17,9 @@ pub(crate) use attributes::{
     is_thiserror_enum,
 };
 pub(crate) use enum_variants::extract_enum_variant;
-#[cfg(test)]
-pub(crate) use field_types::detect_core_wrapper;
-pub(crate) use field_types::{build_rust_path, extract_field_type_rust_path, syn_type_is_boxed, unwrap_optional};
+pub(crate) use field_types::{
+    build_rust_path, detect_core_wrapper, extract_field_type_rust_path, syn_type_is_boxed, unwrap_optional,
+};
 pub(crate) use fields::extract_field;
 pub(crate) use reexport_map::{ReexportKind, collect_reexport_map};
 pub(crate) use result_alias_scope::{ResultModuleContextGuard, resolve_result_alias_scope};

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -4833,6 +4833,7 @@ fn magnus_function_param_bridge_caches_companion_name() {
             ParamDef {
                 name: "provider".to_string(),
                 ty: TypeRef::Named("Greeter".to_string()),
+                core_wrapper: CoreWrapper::Arc,
                 ..ParamDef::default()
             },
             ParamDef {
@@ -4871,6 +4872,7 @@ fn magnus_function_param_bridge_caches_companion_name() {
 
     assert!(content.contains("provider: magnus::Value, name: String"));
     assert!(content.contains("RbGreeterBridge::new(provider, name.clone())?"));
+    assert!(content.contains("Arc::new(bridge) as std::sync::Arc<dyn test_lib::Greeter>"));
     assert!(content.contains("test_lib::replace_greeter(provider, name)"));
     assert!(content.contains("RbGreeterBridge::new(provider, String::new())?"));
 }

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -4822,6 +4822,59 @@ fn test_magnus_async_struct_param_marshalled_as_native_ruby_value() {
     );
 }
 
+#[test]
+fn magnus_function_param_bridge_caches_companion_name() {
+    let (mut api, _trait_def, mut bridge) = neutral_plugin_fixture(false);
+    bridge.param_name = Some("provider".to_string());
+    api.functions.push(FunctionDef {
+        name: "replace_greeter".to_string(),
+        rust_path: "test_lib::replace_greeter".to_string(),
+        params: vec![
+            ParamDef {
+                name: "provider".to_string(),
+                ty: TypeRef::Named("Greeter".to_string()),
+                ..ParamDef::default()
+            },
+            ParamDef {
+                name: "name".to_string(),
+                ty: TypeRef::String,
+                ..ParamDef::default()
+            },
+        ],
+        return_type: TypeRef::Unit,
+        error_type: Some("Error".to_string()),
+        ..FunctionDef::default()
+    });
+    api.functions.push(FunctionDef {
+        name: "visit_with_greeter".to_string(),
+        rust_path: "test_lib::visit_with_greeter".to_string(),
+        params: vec![ParamDef {
+            name: "provider".to_string(),
+            ty: TypeRef::Named("Greeter".to_string()),
+            ..ParamDef::default()
+        }],
+        return_type: TypeRef::Unit,
+        error_type: Some("Error".to_string()),
+        ..FunctionDef::default()
+    });
+    let mut config = make_config();
+    config.trait_bridges = vec![bridge];
+
+    let files = MagnusBackend
+        .generate_bindings(&api, &config)
+        .expect("generation should succeed");
+    let content = &files
+        .iter()
+        .find(|file| file.path.to_string_lossy().contains("lib.rs"))
+        .expect("lib.rs must be generated")
+        .content;
+
+    assert!(content.contains("provider: magnus::Value, name: String"));
+    assert!(content.contains("RbGreeterBridge::new(provider, name.clone())?"));
+    assert!(content.contains("test_lib::replace_greeter(provider, name)"));
+    assert!(content.contains("RbGreeterBridge::new(provider, String::new())?"));
+}
+
 /// Magnus is the two-sided case: a gated method needs `#[cfg]` on the wrapper `fn` **and** on the
 /// `class.define_method(...)` statement in `ruby_init`. `method!(Type::name, n)` resolves
 /// `Type::name` as a path, so gating only the `fn` turns a feature-off build into an E0599 rather


### PR DESCRIPTION
Recovers #290, whose branch became CONFLICTING once #288 merged. The fork is owned by the `structuredmerge` organisation, and GitHub only honours "allow edits by maintainers" for user-owned forks, so the branch could not be rebased in place. The three commits are cherry-picked unchanged with Peter H. Boling preserved as author; only `CHANGELOG.md` conflicted and every code file merged cleanly.

Fixes generated Ruby that stopped compiling after the two-argument trait-bridge constructor landed: two call-site emitters still emitted the obsolete one-argument form. Function bridges now cache a companion required `name: String` parameter where one exists, and anonymous callback and options-field bridges pass an empty identity. `extract_params` also stops flattening parameter wrappers, so `Arc<dyn Trait>` gets `Arc::new(bridge)` while `Arc<Mutex<dyn Trait>>` keeps its mutex.

One behavioural note worth recording: `promoted` now requires the bridge parameter itself to be optional, where previously every parameter following a bridge parameter was promoted to `Option<T>` regardless. The new rule is the general one — a parameter is promoted iff some earlier parameter is optional — and the old clause was an over-broad special case. This does change already-shipped generated Ruby signatures for any consumer with a required bridge parameter followed by others.

`cargo test --test backends_magnus_gen_bindings_test`: 52 passed, 0 failed, rebased onto `d0376d1b9`.

Closes #290.