### PR TITLE
fix(e2e): resolve fixture wire keys to host property names

### DIFF
--- a/src/e2e/codegen/php/values.rs
+++ b/src/e2e/codegen/php/values.rs
@@ -164,6 +164,28 @@ pub(super) fn emit_php_object_array_with_mock_base(
     }
 }
 
+/// Find the `FieldDef` on `struct_name` that fixture key `key` refers to, matching either the
+/// field's Rust name or its wire name (`#[serde(rename = ...)]` / a container `rename_all`) —
+/// a fixture may key a field either way. Without the wire-name arm, a field whose wire name
+/// diverges from its Rust name (e.g. `ChatCompletionTool.tool_type` renamed to wire `type`) is
+/// invisible to every lookup here even though the fixture key is exactly what that field
+/// declares, since only `field.name` was ever compared. ~keep
+fn resolve_field<'a>(
+    struct_name: &str,
+    key: &str,
+    type_defs: &'a [crate::core::ir::TypeDef],
+) -> Option<&'a crate::core::ir::FieldDef> {
+    let definition = type_defs.iter().find(|td| td.name == struct_name)?;
+    definition.fields.iter().find(|field| {
+        field.name == key
+            || crate::codegen::naming::wire_field_name(
+                &field.name,
+                field.serde_rename.as_deref(),
+                definition.serde_rename_all.as_deref(),
+            ) == key
+    })
+}
+
 /// True when `field_name` on `struct_name` is a plain `String` or `Optional<String>`
 /// field — i.e. a field where an empty string `""` is a meaningful value the fixture
 /// intends to send (e.g. `ExtractInput.mime_type = ""` to exercise the empty-MIME
@@ -177,10 +199,7 @@ pub(super) fn field_is_string_typed(
     let Some(struct_name) = struct_name else {
         return false;
     };
-    type_defs
-        .iter()
-        .find(|td| td.name == struct_name)
-        .and_then(|td| td.fields.iter().find(|f| f.name == field_name))
+    resolve_field(struct_name, field_name, type_defs)
         .map(|field| match &field.ty {
             TypeRef::String => true,
             TypeRef::Optional(inner) => matches!(**inner, TypeRef::String),
@@ -253,24 +272,21 @@ pub(super) fn json_to_php(value: &serde_json::Value) -> String {
 
 /// Get the field type name for a given struct and field name.
 ///
-/// Returns the string name of the field's type if it's a Named type, otherwise None.
+/// Returns the string name of the field's type if it names one through any number of
+/// `Option`/`Vec` wrappers (see [`crate::e2e::codegen::call_ir::named_type`]), otherwise None.
+/// Unwrapping `Vec` matters here as much as `Option` does: a `Vec<ChatCompletionTool>` field
+/// (e.g. `ChatCompletionRequest.tools`) used to resolve to `None`, so every element of the
+/// array below recursed with `current_type_name` reset to `None` — losing the owner type for
+/// exactly the array-of-struct shape a tool-calling request is built from, and silently
+/// re-enabling the blind per-key camelCase this module exists to avoid one level down. ~keep
 pub(super) fn get_field_type_name(
     struct_name: &str,
     field_name: &str,
     type_defs: &[crate::core::ir::TypeDef],
 ) -> Option<String> {
-    type_defs
-        .iter()
-        .find(|td| td.name == struct_name)
-        .and_then(|td| td.fields.iter().find(|f| f.name == field_name))
-        .and_then(|field| match &field.ty {
-            TypeRef::Named(name) => Some(name.clone()),
-            TypeRef::Optional(inner) => match &**inner {
-                TypeRef::Named(name) => Some(name.clone()),
-                _ => None,
-            },
-            _ => None,
-        })
+    resolve_field(struct_name, field_name, type_defs)
+        .and_then(|field| crate::e2e::codegen::call_ir::named_type(&field.ty))
+        .map(str::to_string)
 }
 
 /// Like `json_to_php` but optionally converts object keys to lowerCamelCase.
@@ -297,8 +313,23 @@ pub(super) fn json_to_php_camel_keys_with_types(
             let items: Vec<String> = map
                 .iter()
                 .map(|(k, v)| {
+                    // `k` is the fixture's WIRE key (e.g. `type` for `ChatCompletionTool` from
+                    // the core Rust struct's own `#[serde(rename = "type")]`), but the PHP
+                    // binding's host property/alias is always spelled off the RUST FIELD name
+                    // (`tool_type` -> `toolType`), never off that wire name -- see
+                    // `codegen::naming::wire`'s module doc. Blindly camelCasing `k` itself
+                    // produced `"type"` (`to_lower_camel_case("type") == "type"`) against a
+                    // binding that only accepts `tool_type`/`toolType`, silently leaving the
+                    // field at its `#[serde(default)]` value. Resolving through the field
+                    // first, and camelCasing ITS name, fixes both the unrenamed case (already
+                    // identical) and the renamed one. A key IR cannot resolve (an opaque/
+                    // untyped object, or `current_type_name` unset) falls back to the previous
+                    // blind conversion. ~keep
                     let final_key = if serde_rename_all == Some("camelCase") {
-                        k.to_lower_camel_case()
+                        match current_type_name.and_then(|tn| resolve_field(tn, k, type_defs)) {
+                            Some(field) => crate::codegen::naming::to_php_name(&field.name),
+                            None => k.to_lower_camel_case(),
+                        }
                     } else {
                         k.to_string()
                     };
@@ -414,5 +445,76 @@ mod native_dto_tests {
             rendered.contains("content: file_get_contents(\"guide.pdf\")"),
             "{rendered}"
         );
+    }
+}
+
+#[cfg(test)]
+mod wire_name_tests {
+    use super::*;
+    use crate::core::ir::{FieldDef, TypeDef};
+
+    /// A field keyed by its WIRE name (`#[serde(rename = "type")]`, e.g.
+    /// `ChatCompletionTool.tool_type`) must resolve to the PHP binding's property name
+    /// (`toolType`, off the Rust field), not a blind camelCase of the wire key itself
+    /// (`type`). Regression for the liter-llm `tool_calling` e2e defect. ~keep
+    #[test]
+    fn wire_renamed_field_resolves_to_the_php_property_name() {
+        let type_defs = [TypeDef {
+            name: "ChatCompletionTool".into(),
+            fields: vec![FieldDef {
+                name: "tool_type".into(),
+                ty: TypeRef::String,
+                serde_rename: Some("type".into()),
+                ..FieldDef::default()
+            }],
+            ..TypeDef::default()
+        }];
+
+        let rendered = json_to_php_camel_keys_with_types(
+            &serde_json::json!({"type": "function"}),
+            Some("ChatCompletionTool"),
+            Some("camelCase"),
+            &type_defs,
+        );
+
+        assert_eq!(rendered, "[\"toolType\" => \"function\"]");
+    }
+
+    /// A `Vec<Named>` field (e.g. `ChatCompletionRequest.tools: Vec<ChatCompletionTool>`) must
+    /// propagate its unwrapped element type to array elements, not just an `Option<Named>`
+    /// field -- otherwise every element recurses with no owner type and the wire-renamed field
+    /// above is unreachable from a real request body.
+    #[test]
+    fn array_of_struct_field_propagates_element_type_to_items() {
+        let type_defs = [
+            TypeDef {
+                name: "ChatCompletionRequest".into(),
+                fields: vec![FieldDef {
+                    name: "tools".into(),
+                    ty: TypeRef::Vec(Box::new(TypeRef::Named("ChatCompletionTool".into()))),
+                    ..FieldDef::default()
+                }],
+                ..TypeDef::default()
+            },
+            TypeDef {
+                name: "ChatCompletionTool".into(),
+                fields: vec![FieldDef {
+                    name: "tool_type".into(),
+                    ty: TypeRef::String,
+                    serde_rename: Some("type".into()),
+                    ..FieldDef::default()
+                }],
+                ..TypeDef::default()
+            },
+        ];
+
+        let rendered = json_to_php_camel_keys_with_types(
+            &serde_json::json!({"tools": [{"type": "function"}]}),
+            Some("ChatCompletionRequest"),
+            Some("camelCase"),
+            &type_defs,
+        );
+
+        assert_eq!(rendered, "[\"tools\" => [[\"toolType\" => \"function\"]]]");
     }
 }

--- a/src/e2e/codegen/typescript/json.rs
+++ b/src/e2e/codegen/typescript/json.rs
@@ -125,6 +125,97 @@ pub(super) fn json_to_js_camel(value: &serde_json::Value) -> String {
     }
 }
 
+/// Find the `FieldDef` on `owner_type` that fixture key `key` refers to, matching either the
+/// field's Rust name or its wire name (`#[serde(rename = ...)]` / a container `rename_all`) --
+/// mirrors `typescript::test_file::builders::resolve_owner_field` and PHP's own equivalent
+/// (`php::values::resolve_field`), all three needing the same fixture-key -> `FieldDef` reverse
+/// lookup for the same reason.
+fn resolve_owner_field<'a>(
+    owner_type: Option<&'a crate::core::ir::TypeDef>,
+    key: &str,
+) -> Option<&'a crate::core::ir::FieldDef> {
+    let definition = owner_type?;
+    definition.fields.iter().find(|field| {
+        field.name == key
+            || crate::codegen::naming::wire_field_name(
+                &field.name,
+                field.serde_rename.as_deref(),
+                definition.serde_rename_all.as_deref(),
+            ) == key
+    })
+}
+
+/// Like [`json_to_js_camel`], but resolves each object key through the core IR when the
+/// current object's owner type is known, rather than blindly camelCasing the fixture's wire
+/// key.
+///
+/// NAPI's `#[napi(object)]` derive names a JS field from the RUST FIELD, never from a
+/// `#[serde(rename = ...)]` on that field (its `FromNapiValue` impl does not consult serde at
+/// all -- see `codegen::naming::wire`'s module doc). `json_to_js_camel` camelCases the fixture's
+/// WIRE key, which is only ever the same string when a field is not serde-renamed
+/// (`max_tokens` -> `maxTokens` either way). A field like `ChatCompletionTool.tool_type`
+/// (`#[serde(rename = "type")]`) diverges: the fixture's wire key is `type`, camelCasing it
+/// stays `type`, and the binding only accepts `toolType`, silently leaving the field at its
+/// `#[serde(default)]` value.
+///
+/// Deliberately narrow in what it changes: only the KEY is resolved through the IR; every VALUE
+/// is still rendered by the plain, non-type-aware converters (`json_to_js`/`json_to_js_camel`
+/// for values whose own nested owner type could not be resolved). This module intentionally does
+/// not reach for `ts_builder_expression`'s enum-literal synthesis
+/// (`declared_enum_member_for_prefixed`/`node_tagged_unit_variant_literal`) here: that machinery
+/// assumes an enum-typed field's fixture value is always one of the enum's declared variants,
+/// which does not hold for an untagged string/composite union modeled as an IR enum over
+/// arbitrary free text (e.g. `ModerationRequest.input: ModerationInput`) or for a fixture that
+/// deliberately sends an undeclared value to exercise an error path (e.g.
+/// `CreateFileRequest.purpose: "invalid-purpose"`) -- routing either through that synthesis
+/// manufactures a nonexistent enum member reference (`ModerationInput.` for an empty string,
+/// `FilePurpose.InvalidPurpose` for a value with no matching variant), a hard compile error in
+/// the first case and a silently wrong test in the second. Every host binding's `ts_type`
+/// override for an enum-typed field already accepts the plain wire string as an alternative
+/// (`ts_type = "ToolType | 'function'"`), so leaving values as plain JS literals is not a
+/// downgrade -- `toolType: "function"` type-checks exactly as `toolType: ToolType.Function`
+/// does. ~keep
+pub(super) fn json_to_js_camel_with_types(
+    value: &serde_json::Value,
+    current_type_name: Option<&str>,
+    type_defs: &[crate::core::ir::TypeDef],
+) -> String {
+    let owner_type = current_type_name.and_then(|name| type_defs.iter().find(|definition| definition.name == name));
+    match value {
+        serde_json::Value::Object(map) => {
+            let entries: Vec<String> = map
+                .iter()
+                .map(|(k, v)| {
+                    let (key, nested_type_name) = match resolve_owner_field(owner_type, k) {
+                        Some(field) => (
+                            js_object_key(&crate::codegen::naming::to_node_name(&field.name)),
+                            crate::e2e::codegen::call_ir::named_type(&field.ty).map(str::to_string),
+                        ),
+                        None => (js_object_key(&underscore_camel_case(k)), None),
+                    };
+                    format!(
+                        "{key}: {}",
+                        json_to_js_camel_with_types(v, nested_type_name.as_deref(), type_defs)
+                    )
+                })
+                .collect();
+            format!("{{ {} }}", entries.join(", "))
+        }
+        serde_json::Value::Array(arr) => {
+            // Array elements share the CONTAINER field's already-unwrapped `current_type_name`
+            // (`named_type` unwraps `Vec` alongside `Option`), not a per-index lookup -- there is
+            // no key to resolve a field through at this level, only the element type carried
+            // down from the field that held this array.
+            let items: Vec<String> = arr
+                .iter()
+                .map(|item| json_to_js_camel_with_types(item, current_type_name, type_defs))
+                .collect();
+            format!("[{}]", items.join(", "))
+        }
+        other => json_to_js(other),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +238,71 @@ mod tests {
         let out = json_to_js_camel(&val);
         assert!(out.contains("myField"), "got: {out}");
         assert!(!out.contains("my_field"), "got: {out}");
+    }
+
+    /// A field keyed by its WIRE name (`#[serde(rename = "type")]`, e.g.
+    /// `ChatCompletionTool.tool_type`) must resolve to the napi binding's JS field name
+    /// (`toolType`, off the Rust field), not a blind camelCase of the wire key itself
+    /// (`type`, which is already single-word and would not change). Regression for the
+    /// liter-llm `tool_calling` e2e defect. ~keep
+    #[test]
+    fn wire_renamed_field_resolves_to_the_node_property_name() {
+        let type_defs = [crate::core::ir::TypeDef {
+            name: "ChatCompletionTool".into(),
+            fields: vec![crate::core::ir::FieldDef {
+                name: "tool_type".into(),
+                ty: crate::core::ir::TypeRef::String,
+                serde_rename: Some("type".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }];
+
+        let out = json_to_js_camel_with_types(
+            &serde_json::json!({"type": "function"}),
+            Some("ChatCompletionTool"),
+            &type_defs,
+        );
+
+        assert_eq!(out, "{ toolType: \"function\" }");
+    }
+
+    /// A `Vec<Named>` field (e.g. `ChatCompletionRequest.tools: Vec<ChatCompletionTool>`) must
+    /// propagate its unwrapped element type to array elements, otherwise every element
+    /// recurses with no owner type and the wire-renamed field above is unreachable from a real
+    /// request body.
+    #[test]
+    fn array_of_struct_field_propagates_element_type_to_items() {
+        let type_defs = [
+            crate::core::ir::TypeDef {
+                name: "ChatCompletionRequest".into(),
+                fields: vec![crate::core::ir::FieldDef {
+                    name: "tools".into(),
+                    ty: crate::core::ir::TypeRef::Vec(Box::new(crate::core::ir::TypeRef::Named(
+                        "ChatCompletionTool".into(),
+                    ))),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            crate::core::ir::TypeDef {
+                name: "ChatCompletionTool".into(),
+                fields: vec![crate::core::ir::FieldDef {
+                    name: "tool_type".into(),
+                    ty: crate::core::ir::TypeRef::String,
+                    serde_rename: Some("type".into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ];
+
+        let out = json_to_js_camel_with_types(
+            &serde_json::json!({"tools": [{"type": "function"}]}),
+            Some("ChatCompletionRequest"),
+            &type_defs,
+        );
+
+        assert_eq!(out, "{ tools: [{ toolType: \"function\" }] }");
     }
 }

--- a/src/e2e/codegen/typescript/test_file.rs
+++ b/src/e2e/codegen/typescript/test_file.rs
@@ -10,7 +10,7 @@ use crate::e2e::fixture::Fixture;
 use heck::ToUpperCamelCase;
 
 use super::assertions::render_assertion_with_streaming_item_type;
-use super::json::{js_object_key, json_to_js, json_to_js_camel, json_to_js_multiline};
+use super::json::{js_object_key, json_to_js, json_to_js_camel, json_to_js_camel_with_types, json_to_js_multiline};
 use super::visitors::build_typescript_visitor;
 
 mod args;

--- a/src/e2e/codegen/typescript/test_file/args.rs
+++ b/src/e2e/codegen/typescript/test_file/args.rs
@@ -1,10 +1,12 @@
 use super::*;
 
-/// `target` is what the core IR declares about the parameters these arguments fill. Only the
-/// documentation-snippet caller supplies a real one; the e2e test-file callers pass
-/// [`crate::e2e::codegen::call_ir::TargetParams::IrAbsent`], which licenses no claim, so every
-/// rendering below falls back to exactly what it emitted before the seam existed. Mirrors the
-/// `go` emitter, which threads the same seam to the same two kinds of caller. ~keep
+/// `target` is what the core IR declares about the parameters these arguments fill. Both the
+/// documentation-snippet caller and the e2e test-file caller supply a real one (via
+/// `ResolvedE2eCallRecipe::target_params`, opted into IR-aware lowering with `.with_functions`);
+/// a handful of unit tests below still pass
+/// [`crate::e2e::codegen::call_ir::TargetParams::IrAbsent`] directly, which licenses no claim, so
+/// every rendering falls back to exactly what it emitted before the seam existed for those.
+/// Mirrors the `go` emitter, which threads the same seam to the same two kinds of caller. ~keep
 #[allow(clippy::too_many_arguments)]
 pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
     input: &serde_json::Value,
@@ -506,16 +508,34 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                         } else {
                             parts.push(format!("{} as {opts_type}", json_to_js_camel(v)));
                         }
-                    } else if lang == "node" {
-                        // For node (napi-rs), tagged-data enum discriminants are
-                        // always exposed as `"kind"` in TypeScript, regardless of the
-                        // original Rust serde_tag attribute. Pre-process the JSON to
-                        // rename serde_tag keys (e.g. `role`, `type`) to `"kind"` when
-                        // the value matches a known enum variant, then convert to JS.
-                        let preprocessed = rename_napi_serde_tags_to_kind(v, enums);
-                        parts.push(json_to_js_camel(&preprocessed));
                     } else {
-                        parts.push(json_to_js_camel(v));
+                        // No `options_type`/`element_type` was configured for this
+                        // call/language -- e.g. node's `chat` call, whose binding needs no
+                        // runtime constructor for a plain `ChatCompletionRequest` object
+                        // literal, so nobody configured one. Ask the core IR what this
+                        // argument's parameter is actually declared as, so the fallback
+                        // converter below can resolve a serde-renamed field's key correctly
+                        // instead of blindly camelCasing the fixture's wire key -- see
+                        // `json_to_js_camel_with_types`'s doc for why it is that (narrower)
+                        // converter and not the full `ts_builder_expression` typed-object
+                        // path. A resolved name absent from `type_defs` (an external/opaque
+                        // type) is filtered out: there is no declared field set to resolve
+                        // against, so `json_to_js_camel_with_types` would behave identically
+                        // to the blind converter anyway. ~keep
+                        let declared_type_name = target
+                            .declared_type_name(&arg.name, idx)
+                            .filter(|declared| type_defs.iter().any(|definition| &definition.name == declared));
+                        if lang == "node" {
+                            // For node (napi-rs), tagged-data enum discriminants are
+                            // always exposed as `"kind"` in TypeScript, regardless of the
+                            // original Rust serde_tag attribute. Pre-process the JSON to
+                            // rename serde_tag keys (e.g. `role`, `type`) to `"kind"` when
+                            // the value matches a known enum variant, then convert to JS.
+                            let preprocessed = rename_napi_serde_tags_to_kind(v, enums);
+                            parts.push(json_to_js_camel_with_types(&preprocessed, declared_type_name, type_defs));
+                        } else {
+                            parts.push(json_to_js_camel_with_types(v, declared_type_name, type_defs));
+                        }
                     }
                     continue;
                 } else {

--- a/src/e2e/codegen/typescript/test_file/test_case.rs
+++ b/src/e2e/codegen/typescript/test_file/test_case.rs
@@ -204,6 +204,17 @@ pub(in crate::e2e::codegen::typescript::test_file) fn render_test_case(
 
     let handle_config_type = per_call_override.and_then(|o| o.handle_config_type.clone());
 
+    // `recipe` was already opted into IR-aware lowering via `.with_functions(functions)` above
+    // (for `ir_is_async`), so this e2e test-file call is just as entitled to ask `target_params`
+    // what the core IR declares about its arguments as the documentation-snippet path
+    // (`snippet.rs`), which was the only caller that did before this. Without it, a
+    // `json_object` arg with no `options_type` configured (node's `chat` call has none; every
+    // other language's `chat` override does) had no way to discover its declared type and fell
+    // all the way to `json_to_js_camel`'s blind per-key camelCase -- correct only when every
+    // field's wire name matches its Rust name, and wrong for a `#[serde(rename = "type")]`
+    // field like `ChatCompletionTool.tool_type`. ~keep
+    let target_params = recipe.target_params(lang);
+
     let (mut setup_lines, mut args_str) = build_args_and_setup(
         &fixture.input,
         args,
@@ -220,7 +231,7 @@ pub(in crate::e2e::codegen::typescript::test_file) fn render_test_case(
         config,
         false,
         referenced_enums,
-        crate::e2e::codegen::call_ir::TargetParams::IrAbsent,
+        target_params,
     );
     // The builders above recognise an undeclared fixture key many frames down, where nothing
     // knows which call or language is being served. This is the frame that does, and the only


### PR DESCRIPTION
Clears liter-llm's node and php E2E legs, and pre-empts the same failure in wasm.

liter-llm's core declares `#[serde(rename = "type")] pub tool_type: ToolType`, so the wire name is `type` and the Rust field is `tool_type`. The binding generators correctly name the host property from the Rust field — `toolType` — per alef's own centralized-naming rule. The e2e generators emitted the fixture's wire key, case-converted, and `camelCase("type")` is `type`. The two halves agree wherever the wire name equals the field name and diverge exactly on serde-renamed fields, so node threw `Missing field 'toolType'` and php silently dropped the key and reported `invalid value "" for field 'tool_type'`.

Node's `chat` call turned out to have no `options_type` configured, so its request body fell through to blind camelCase rather than the typed builder every other language uses. PHP's converter carried IR type context but never applied it to the key, and was missing the `Vec<Named>` unwrap, so array-of-struct fields never reached their element type at all.

Fallbacks are scoped, not blanket: both converters fall back to blind camelCase only when the owner type is genuinely unresolvable. One residual `type: "function"` inside `toolChoice` is correct — `JsToolChoice(pub serde_json::Value)` is a raw JSON passthrough with no field mapping.

Verified on regenerated output: `chat.test.ts` has `toolType: "function"` and no `type: "function"` at tool-object depth; `ToolCallingTest.php` likewise. Empty node/php diffs on crawlberg, tree-sitter-language-pack and html-to-markdown. Neutralisation reproduces the wrong output on all four new tests. `cargo test --lib` 11828 passed.