### PR TITLE
fix(e2e): stop asserting stream_complete on fixtures that never declared it

### DIFF
--- a/src/e2e/codegen/csharp/streaming.rs
+++ b/src/e2e/codegen/csharp/streaming.rs
@@ -381,11 +381,7 @@ pub(super) fn render_streaming_test_method(
     // whole `await foreach` drive, so a verdict taken over all of it would answer "this example
     // asserts something" for every fixture — the drive is executable text.
     let assertions_start = body.len();
-    let mut had_explicit_complete = false;
     for assertion in &fixture.assertions {
-        if assertion.field.as_deref() == Some("stream_complete") {
-            had_explicit_complete = true;
-        }
         if is_chat_stream {
             emit_chat_stream_assertion(&mut body, assertion);
         } else {
@@ -397,13 +393,12 @@ pub(super) fn render_streaming_test_method(
             emit_non_chat_stream_assertion(&mut body, assertion, e2e_config.effective_result_fields(call_config));
         }
     }
-    // Only a chat-shaped stream declares `streamComplete`, so the implicit "the stream finished"
-    // check rides along only there. A non-chat item type has no terminal marker to read, and
-    // synthesising a passing check for an assertion no fixture declared is exactly the vacuous
-    // green this whole path is being pulled back from. ~keep
-    if !had_explicit_complete && is_chat_stream {
-        body.push_str("        Assert.True(streamComplete);\n");
-    }
+    // `streamComplete` is asserted only where the fixture itself declares that field --
+    // `emit_chat_stream_assertion` above already renders `Assert.<op>(streamComplete)` (or a
+    // skip marker) for every declared assertion. A fixture that never mentions `stream_complete`
+    // (e.g. `empty_stream`, which declares `count_min chunks >= 0` -- an explicit statement that
+    // zero chunks is acceptable) gets no expectation synthesised here; inventing
+    // `Assert.True(streamComplete)` would contradict such a fixture rather than check it. ~keep
 
     crate::e2e::codegen::fail_on_unavailable_field_markers(
         &body[assertions_start..],

--- a/src/e2e/codegen/csharp/tests.rs
+++ b/src/e2e/codegen/csharp/tests.rs
@@ -1255,3 +1255,119 @@ fn a_fixture_with_no_declared_assertions_keeps_its_smoke_test_shape() {
         "a fixture with no assertions must never be recorded as refused"
     );
 }
+
+/// Regression test for the fabricated-completion defect: a chat-shaped fixture that never
+/// declares `stream_complete` (here, `empty_stream`'s real shape -- `count_min chunks >= 0`
+/// plus `equals stream_content == ""`, an explicit statement that zero chunks is acceptable)
+/// must not have `Assert.True(streamComplete);` invented on its behalf. That expectation would
+/// contradict rather than check a fixture like this one. ~keep
+#[test]
+fn a_fixture_that_never_declares_stream_complete_gets_no_invented_expectation() {
+    let fixture = Fixture {
+        id: "empty_stream".into(),
+        description: "Streaming chat completion that produces no content chunks".into(),
+        assertions: vec![
+            Assertion {
+                assertion_type: "count_min".into(),
+                field: Some("chunks".into()),
+                value: Some(serde_json::json!(0)),
+                ..Assertion::default()
+            },
+            Assertion {
+                assertion_type: "equals".into(),
+                field: Some("stream_content".into()),
+                value: Some(serde_json::json!("")),
+                ..Assertion::default()
+            },
+        ],
+        ..Fixture::default()
+    };
+    let call_config = CallConfig::default();
+    let e2e_config = E2eConfig::default();
+    let config = ResolvedCrateConfig {
+        name: "sample".into(),
+        ..ResolvedCrateConfig::default()
+    };
+
+    let mut out = String::new();
+    super::render_streaming_test_method(
+        &mut out,
+        &fixture,
+        "Widget",
+        &call_config,
+        None,
+        &e2e_config,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        "WidgetException",
+        &[],
+        &config,
+        &[],
+        &[],
+        &[],
+        Some("ChatCompletionChunk"),
+    );
+
+    assert!(
+        !out.contains("Assert.True(streamComplete);"),
+        "no expectation may be invented for a field this fixture never declared. got:\n{out}"
+    );
+}
+
+/// The other half: a chat-shaped fixture that DOES declare `stream_complete` (the real
+/// liter-llm `stream_done_signal` shape) must still get a real, falsifiable expectation -- the
+/// fix must not regress the declared case into silence.
+#[test]
+fn a_fixture_that_declares_stream_complete_still_gets_a_real_expectation() {
+    let fixture = Fixture {
+        id: "stream_done_signal".into(),
+        description: "Verify that the DONE sentinel terminates the stream".into(),
+        assertions: vec![
+            Assertion {
+                assertion_type: "equals".into(),
+                field: Some("stream_content".into()),
+                value: Some(serde_json::json!("done")),
+                ..Assertion::default()
+            },
+            Assertion {
+                assertion_type: "is_true".into(),
+                field: Some("stream_complete".into()),
+                ..Assertion::default()
+            },
+        ],
+        ..Fixture::default()
+    };
+    let call_config = CallConfig::default();
+    let e2e_config = E2eConfig::default();
+    let config = ResolvedCrateConfig {
+        name: "sample".into(),
+        ..ResolvedCrateConfig::default()
+    };
+
+    let mut out = String::new();
+    super::render_streaming_test_method(
+        &mut out,
+        &fixture,
+        "Widget",
+        &call_config,
+        None,
+        &e2e_config,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        "WidgetException",
+        &[],
+        &config,
+        &[],
+        &[],
+        &[],
+        Some("ChatCompletionChunk"),
+    );
+
+    assert_eq!(
+        out.matches("Assert.True(streamComplete);").count(),
+        1,
+        "a declared `stream_complete` assertion must render exactly once. got:\n{out}"
+    );
+}

--- a/src/e2e/codegen/ruby/examples.rs
+++ b/src/e2e/codegen/ruby/examples.rs
@@ -3,7 +3,6 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::config::ResolvedCrateConfig;
-use crate::e2e::codegen::field_skip::FieldSkip;
 use crate::e2e::config::E2eConfig;
 use crate::e2e::escape::{ruby_regex_literal, ruby_string_literal, sanitize_ident};
 use crate::e2e::field_access::FieldResolver;
@@ -251,25 +250,12 @@ pub(super) fn render_chat_stream_example(
         );
     }
 
-    // Ride the implicit "the stream finished" check along only where `stream_complete` was
-    // actually derived. Synthesising a passing expectation for an assertion no fixture declared
-    // is exactly the vacuous green this path is being pulled back from, so the alternative is a
-    // marker the skip ledger can see rather than a check that cannot fail. ~keep
-    if !fixture
-        .assertions
-        .iter()
-        .any(|a| a.field.as_deref() == Some("stream_complete"))
-    {
-        if stream_complete_expr.is_some() {
-            assertions_body.push_str("    expect(stream_complete).to be(true)\n");
-        } else {
-            assertions_body.push_str(&format!(
-                "    # skipped: {}; this stream's chunks carry no terminal finish_reason, \
-so completion is not observable here\n",
-                FieldSkip::StreamingAssertionOnUnsupportedField.message("stream_complete")
-            ));
-        }
-    }
+    // `stream_complete` is asserted only where the fixture itself declares that field --
+    // `emit_chat_stream_assertion` above already renders it (or its skip marker) for every
+    // declared assertion. A fixture that never mentions `stream_complete` gets no expectation
+    // synthesised here: e.g. `empty_stream` declares `count_min chunks >= 0`, an explicit
+    // statement that zero chunks is acceptable, so inventing `expect(stream_complete).to
+    // be(true)` would contradict the fixture rather than check it. ~keep
 
     crate::e2e::codegen::fail_on_unavailable_field_markers(&assertions_body, "ruby", &fixture.id, &fixture.assertions);
     crate::e2e::codegen::fail_on_unsupported_assertion_type_markers(&assertions_body, "ruby", &fixture.id);
@@ -324,6 +310,99 @@ so completion is not observable here\n",
 
     out.push_str("  end\n");
     out
+}
+
+#[cfg(test)]
+mod stream_complete_declaration_gate_tests {
+    use super::render_chat_stream_example;
+    use crate::core::config::ResolvedCrateConfig;
+    use crate::e2e::config::E2eConfig;
+    use crate::e2e::fixture::{Assertion, Fixture};
+
+    fn render(id: &str, assertions: Vec<Assertion>) -> String {
+        let fixture = Fixture {
+            id: id.to_string(),
+            description: "test".to_string(),
+            assertions,
+            ..Fixture::default()
+        };
+        render_chat_stream_example(
+            &fixture,
+            "chat_stream",
+            "client",
+            "SampleCrate",
+            &[],
+            None,
+            &std::collections::HashMap::new(),
+            &E2eConfig::default(),
+            None,
+            &[],
+            None,
+            None,
+            &ResolvedCrateConfig::default(),
+            &[],
+        )
+    }
+
+    /// Regression test for the fabricated-completion defect: a fixture that never declares
+    /// `stream_complete` (here, `empty_stream`'s real shape -- `count_min chunks >= 0` plus
+    /// `equals stream_content == ""`, an explicit statement that zero chunks is acceptable)
+    /// must not have `expect(stream_complete).to be(true)` invented on its behalf. That
+    /// expectation would contradict rather than check a fixture like this one. ~keep
+    #[test]
+    fn a_fixture_that_never_declares_stream_complete_gets_no_invented_expectation() {
+        let out = render(
+            "empty_stream",
+            vec![
+                Assertion {
+                    assertion_type: "count_min".to_string(),
+                    field: Some("chunks".to_string()),
+                    value: Some(serde_json::json!(0)),
+                    ..Default::default()
+                },
+                Assertion {
+                    assertion_type: "equals".to_string(),
+                    field: Some("stream_content".to_string()),
+                    value: Some(serde_json::json!("")),
+                    ..Default::default()
+                },
+            ],
+        );
+
+        assert!(
+            !out.contains("expect(stream_complete)"),
+            "no expectation may be invented for a field this fixture never declared. got:\n{out}"
+        );
+    }
+
+    /// The other half: a fixture that DOES declare `stream_complete` (the two real liter-llm
+    /// fixtures `local_stream_ollama` and `stream_done_signal` shape) must still get a real,
+    /// falsifiable expectation -- the fix must not regress the declared case into silence.
+    #[test]
+    fn a_fixture_that_declares_stream_complete_still_gets_a_real_expectation() {
+        let out = render(
+            "stream_done_signal",
+            vec![
+                Assertion {
+                    assertion_type: "equals".to_string(),
+                    field: Some("stream_content".to_string()),
+                    value: Some(serde_json::json!("done")),
+                    ..Default::default()
+                },
+                Assertion {
+                    assertion_type: "is_true".to_string(),
+                    field: Some("stream_complete".to_string()),
+                    ..Default::default()
+                },
+            ],
+        );
+
+        assert_eq!(
+            out.matches("expect(stream_complete).to be(true)").count(),
+            1,
+            "a declared `stream_complete` assertion must render exactly once. got:\n{out}"
+        );
+    }
 }
 
 /// The example emitted in place of one whose assertions all funnelled into skip markers.


### PR DESCRIPTION
Clears liter-llm's ruby E2E leg and one of four csharp failures.

The ruby and csharp streaming emitters rode an implicit "the stream finished" assertion onto any chat-shaped fixture that had not declared one. `fixtures/streaming/empty_stream.json` serves zero chunks and declares exactly two assertions — `count_min chunks >= 0` and `equals stream_content == ""` — and never mentions `stream_complete`. The derived accessor is `!chunks.empty? && ...`, so the generator synthesised an expectation the fixture not only never asked for but explicitly contradicts: `count_min: 0` states that zero chunks is acceptable.

The gate had already been tightened once, from an unconditional `true` to "only where derived". The remaining gate asked whether the value *could* be derived; the correct question is whether the fixture *asked* for it. Both riders are removed — the per-assertion emitters already render `stream_complete` correctly, as a real assertion or an honest skip comment, whenever a fixture declares it.

Census across all 15 other languages: every one routes `stream_complete` through the shared resolver keyed on the declared field name, never as a literal outside that loop. Only ruby and csharp fabricated it. C already treats it as universally unsupported with its own regression tests for this defect class.

Regenerated liter-llm: ruby 9 → 6 occurrences, csharp 9 → 6, matching exactly the six fixtures that declare it. crawlberg additionally drops a fabricated skip comment and an inflated declared-assertion count from eight CrawlEvent-stream fixtures — the same defect firing harder than described. Empty e2e diffs on tree-sitter-language-pack and html-to-markdown. Neutralisation reproduces the fabricated assertion verbatim.