### PR TITLE
fix(magnus): preserve fallible plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-deriving the name would not reliably catch it. An empty map renders byte-identically, so no
   other language moves.
 
+- **magnus (trait bridge plugin lifecycle):** generated plugin super-trait
+  implementations now preserve a fallible `version` signature from the
+  extracted super-trait. Previously Magnus always emitted `fn version() ->
+  String`, returned a silent default after Ruby failures, and failed to compile
+  when the source contract declared `Result<String, E>`.
+
 - **e2e (node/napi): an enum-typed assertion compared the whole tagged object as a scalar.** The
   napi backend lowers a tagged data enum to an internally-tagged object (`{ type: "Function" }`),
   but the TypeScript e2e generator emitted `String(e.kind).includes("Function")`, and

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -69,6 +69,15 @@ pub fn gen_trait_bridge(
                 .collect();
         let forwardable_defaulted =
             crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
+        let plugin_version_is_fallible = bridge_cfg
+            .super_trait
+            .as_deref()
+            .and_then(|name| {
+                let short_name = name.rsplit("::").next().unwrap_or(name);
+                api.types.iter().find(|typ| typ.is_trait && typ.name == short_name)
+            })
+            .and_then(|typ| typ.methods.iter().find(|method| method.name == "version"))
+            .is_some_and(|method| method.error_type.is_some());
         let generator = MagnusBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
@@ -77,6 +86,7 @@ pub fn gen_trait_bridge(
             struct_param_types,
             struct_return_types,
             forwardable_defaulted,
+            plugin_version_is_fallible,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types
@@ -146,6 +156,8 @@ struct MagnusBridgeGenerator {
     /// threads where the Ruby object cannot be probed. Methods absent here keep
     /// the trait's Rust default unconditionally.
     forwardable_defaulted: std::collections::HashSet<String>,
+    /// Whether the extracted plugin super-trait returns `Result` from `version`.
+    plugin_version_is_fallible: bool,
 }
 
 impl MagnusBridgeGenerator {
@@ -195,6 +207,10 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
 
     fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         Some(format!("self.has_{}", method.name))
+    }
+
+    fn plugin_version_is_fallible(&self) -> bool {
+        self.plugin_version_is_fallible
     }
 
     fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
@@ -682,6 +698,7 @@ mod forwarding_tests {
             struct_param_types: std::collections::HashSet::new(),
             struct_return_types: std::collections::HashSet::new(),
             forwardable_defaulted: std::collections::HashSet::new(),
+            plugin_version_is_fallible: false,
         }
     }
 

--- a/src/codegen/generators/trait_bridge/generator.rs
+++ b/src/codegen/generators/trait_bridge/generator.rs
@@ -90,6 +90,16 @@ pub trait TraitBridgeGenerator {
         None
     }
 
+    /// Whether the configured plugin super-trait declares `version` as fallible.
+    ///
+    /// The shared plugin implementation historically assumed `fn version() ->
+    /// String`. Backends that can inspect the configured super-trait must opt in
+    /// when its extracted signature is `Result<String, E>` so generated code
+    /// preserves the source trait contract and propagates host failures.
+    fn plugin_version_is_fallible(&self) -> bool {
+        false
+    }
+
     /// Extra fields on the wrapper struct, as `(name, rust_type)` pairs.
     ///
     /// Backends whose foreign objects cannot be probed safely at call time

--- a/src/codegen/generators/trait_bridge/wrapper.rs
+++ b/src/codegen/generators/trait_bridge/wrapper.rs
@@ -59,6 +59,7 @@ pub fn gen_bridge_plugin_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridg
     };
 
     let error_path = spec.error_path();
+    let version_is_fallible = generator.plugin_version_is_fallible();
 
     let version_method = MethodDef {
         name: "version".to_string(),
@@ -66,7 +67,7 @@ pub fn gen_bridge_plugin_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridg
         return_type: crate::core::ir::TypeRef::String,
         is_async: false,
         is_static: false,
-        error_type: None,
+        error_type: version_is_fallible.then(|| error_path.clone()),
         doc: String::new(),
         receiver: Some(crate::core::ir::ReceiverKind::Ref),
         cfg: None,
@@ -143,6 +144,7 @@ pub fn gen_bridge_plugin_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridg
             wrapper_name => wrapper,
             error_path => error_path,
             version_lines => version_lines,
+            version_is_fallible => version_is_fallible,
             init_lines => init_lines,
             shutdown_lines => shutdown_lines,
         },

--- a/src/codegen/templates/generators/trait_bridge/plugin_impl.jinja
+++ b/src/codegen/templates/generators/trait_bridge/plugin_impl.jinja
@@ -3,7 +3,7 @@ impl {{ super_trait_path }} for {{ wrapper_name }} {
         &self.cached_name
     }
 
-    fn version(&self) -> String {
+    fn version(&self) -> {% if version_is_fallible %}std::result::Result<String, {{ error_path }}>{% else %}String{% endif %} {
 {% for line in version_lines %}
         {{ line }}
 {% endfor %}

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -1793,6 +1793,39 @@ mod trait_bridge {
     }
 
     #[test]
+    fn test_plugin_bridge_preserves_fallible_version_from_super_trait() {
+        let trait_def = make_trait_def(
+            "PostProcessor",
+            vec![make_method("process", TypeRef::String, true, false)],
+        );
+        let cfg = make_plugin_bridge_cfg("PostProcessor");
+        let mut api = make_api();
+        api.types.push(make_trait_def(
+            "Plugin",
+            vec![make_method("version", TypeRef::String, true, false)],
+        ));
+
+        let code = gen_trait_bridge(
+            &trait_def,
+            &cfg,
+            "my_lib",
+            "MyError",
+            "MyError::Plugin {{ message: {msg}, plugin_name: String::new() }}",
+            &api,
+        )
+        .expect("trait bridge generation should succeed");
+
+        assert!(
+            code.contains("fn version(&self) -> std::result::Result<String, my_lib::MyError>"),
+            "fallible plugin version signature must match the source trait:\n{code}"
+        );
+        assert!(
+            code.contains("Ruby method 'version' failed") && !code.contains("method = \"version\""),
+            "Ruby version failures must propagate instead of returning a default:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_plugin_bridge_emits_trait_impl() {
         let trait_def = make_trait_def(
             "Validator",


### PR DESCRIPTION
Recovers #282, which went CONFLICTING and 15 commits behind. `structuredmerge` is an organisation-owned fork, and GitHub only honours "allow edits by maintainers" for user-owned forks, so the branch could not be rebased in place. The commit is cherry-picked unchanged with Peter H. Boling preserved as author; only CHANGELOG.md conflicted.

The shared plugin-impl generator hardcoded `fn version(&self) -> String`, so a core super-trait declaring `version() -> Result<String, E>` produced code that did not compile, and Ruby-side failures were swallowed into a default. A defaulted `plugin_version_is_fallible()` on the `TraitBridgeGenerator` trait keeps every other backend on the old path; the Magnus generator resolves the super-trait's `version` method and checks `error_type.is_some()`.

Approved by Goldziher on the original PR. `cargo test --test backends_magnus_gen_bindings_test`: 53 passed, 0 failed on current main.

Closes #282.