### PR TITLE
feat(magnus): support direct host registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   String`, returned a silent default after Ruby failures, and failed to compile
   when the source contract declared `Result<String, E>`.
 
+- **Magnus trait bridges can delegate registration to the core crate.** When a bridge
+  configures `register_fn` without `registry_getter`, generated Ruby registration now calls
+  that core host function with the bridged `Arc`. This lets the core own validation,
+  lifecycle callbacks, and lock boundaries instead of forcing callbacks beneath an
+  Alef-generated registry write lock. Existing registry-getter configurations are unchanged.
+
 - **e2e (node/napi): an enum-typed assertion compared the whole tagged object as a scalar.** The
   napi backend lowers a tagged data enum to an internally-tagged object (`{ type: "Function" }`),
   but the TypeScript e2e generator emitted `String(e.kind).includes("Function")`, and

--- a/src/backends/magnus/templates/trait_bridge_registration_fn.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_registration_fn.rs.jinja
@@ -15,7 +15,7 @@ pub fn {{ register_fn }}(rb_obj: magnus::Value, name: String) -> Result<(), magn
     let wrapper = {{ wrapper }}::new(rb_obj, name)?;
     let arc: Arc<dyn {{ trait_path }}> = Arc::new(wrapper);
 
-    {{ registry_getter }}().write().register(arc{{ register_extra_args }}).map_err(|e| {
+    {{ registration_call }}.map_err(|e| {
         let ruby = unsafe { magnus::Ruby::get_unchecked() };
         magnus::Error::new(ruby.exception_runtime_error(), format!("register failed: {}", e))
     })?;

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -472,9 +472,6 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
         let Some(register_fn) = spec.bridge_config.register_fn.as_deref() else {
             return String::new();
         };
-        let Some(registry_getter) = spec.bridge_config.registry_getter.as_deref() else {
-            return String::new();
-        };
         let wrapper = spec.wrapper_name();
         let trait_path = spec.trait_path();
         let required_methods: Vec<_> = spec
@@ -490,16 +487,21 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
             .as_deref()
             .map(|a| format!(", {a}"))
             .unwrap_or_default();
+        let registration_call = if let Some(registry_getter) = spec.bridge_config.registry_getter.as_deref() {
+            format!("{registry_getter}().write().register(arc{register_extra_args})")
+        } else {
+            let host_path = crate::codegen::generators::trait_bridge::host_function_path(spec, register_fn);
+            format!("{host_path}(arc{register_extra_args})")
+        };
 
         crate::backends::magnus::template_env::render(
             "trait_bridge_registration_fn.rs.jinja",
             minijinja::context! {
                 register_fn => register_fn,
-                registry_getter => registry_getter,
                 wrapper => wrapper,
                 trait_path => trait_path,
                 required_methods => required_methods,
-                register_extra_args => register_extra_args,
+                registration_call => registration_call,
             },
         )
     }

--- a/src/core/config/new_config.rs
+++ b/src/core/config/new_config.rs
@@ -281,19 +281,6 @@ impl NewAlefConfig {
                     )));
                 }
             }
-            // Every backend's `gen_registration_fn` needs a registry to insert into and emits
-            // nothing without one, so this configuration silently produces no registration
-            // function anywhere — say so rather than let the consumer discover it as a missing
-            // binding. Not an error: the bridge's wrapper struct and trait impl are still
-            // generated and usable. ~keep
-            if trait_bridge.register_fn.is_some() && trait_bridge.registry_getter.is_none() {
-                tracing::warn!(
-                    crate_name = %krate.name,
-                    trait_name = %trait_bridge.trait_name,
-                    "trait bridge register_fn is set without registry_getter; no registration \
-                     function will be generated for any language"
-                );
-            }
         }
 
         let contract_names: std::collections::HashSet<&str> = krate

--- a/src/core/config/trait_bridge.rs
+++ b/src/core/config/trait_bridge.rs
@@ -16,11 +16,14 @@ pub struct TraitBridgeConfig {
     /// Rust path to the registry getter function
     /// (e.g., `"sample_core::plugins::registry::get_ocr_backend_registry"`).
     /// Optional — when set, the generated registration function inserts the bridge into a registry.
+    /// When omitted, supporting backends call the core host function named by `register_fn`
+    /// directly, allowing the core to own validation, lifecycle, and locking.
     #[serde(default)]
     pub registry_getter: Option<String>,
     /// Name of the registration function to generate
     /// (e.g., `"register_ocr_backend"`).
-    /// Optional — when set, a `#[pyfunction]` registration function is generated.
+    /// Optional — when set, a host-language registration function is generated. If
+    /// `registry_getter` is absent, this is also the core host function name.
     /// When absent, only the wrapper struct and trait impl are emitted (per-call bridge pattern).
     #[serde(default)]
     pub register_fn: Option<String>,

--- a/src/core/config/validation/mod.rs
+++ b/src/core/config/validation/mod.rs
@@ -58,21 +58,31 @@ fn validate_dart_library_name(config: &ResolvedCrateConfig) -> Result<(), AlefEr
         .map_err(|detail| AlefError::Config(format!("crate `{}`: {detail}", config.name)))
 }
 
-/// Reject a trait bridge that declares a registration function it cannot emit.
+/// Reject direct host registration for backends that cannot emit it.
 ///
-/// `registry_getter` is `Option` on the config struct, but the FFI backend's registration
-/// emitter needs it and `expect`s it — so a bridge with `register_fn` and no `registry_getter`
-/// passed validation, survived extraction, and panicked several stages later inside binding
-/// generation, naming an internal function rather than the config key at fault. Checking it here
-/// fails at load with the bridge named, before any file is written. ~keep
+/// Magnus can resolve `register_fn` as a core host function when no `registry_getter` is
+/// configured. Other backends still need the getter: FFI expects it and some scripting
+/// backends otherwise omit the registration function. Fail those mixed or non-Ruby configs
+/// before generation while permitting a Ruby-only bridge to delegate lifecycle and locking.
 fn validate_trait_bridges(config: &ResolvedCrateConfig) -> Result<(), AlefError> {
     for bridge in &config.trait_bridges {
         if bridge.register_fn.is_some() && bridge.registry_getter.is_none() {
-            return Err(AlefError::Config(format!(
-                "trait bridge `{}` sets `register_fn` but no `registry_getter`. Add `registry_getter` \
-                 to `[[crates.trait_bridges]]` for `{}`, or drop `register_fn`.",
-                bridge.trait_name, bridge.trait_name
-            )));
+            let unsupported_languages = config
+                .languages
+                .iter()
+                .filter(|language| **language != Language::Ruby && bridge.is_active_for(&language.to_string()))
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            if !unsupported_languages.is_empty() {
+                return Err(AlefError::Config(format!(
+                    "trait bridge `{}` sets `register_fn` but no `registry_getter`; direct host \
+                     registration is not supported for active language(s): {}. Add \
+                     `registry_getter`, exclude those languages from this bridge, or drop \
+                     `register_fn`.",
+                    bridge.trait_name,
+                    unsupported_languages.join(", ")
+                )));
+            }
         }
     }
     Ok(())
@@ -605,5 +615,49 @@ python = "packages/python"
             "fixture must carry the hazard through unvalidated"
         );
         validate_resolved(&config).expect("a crate not targeting dart must not be checked");
+    }
+
+    #[test]
+    fn ruby_trait_bridge_accepts_direct_host_registration() {
+        let config = resolve_first(
+            r#"
+[workspace]
+languages = ["ruby"]
+
+[[crates]]
+name = "sample-core"
+sources = ["src/lib.rs"]
+
+[[crates.trait_bridges]]
+trait_name = "SamplePlugin"
+register_fn = "register_sample_plugin"
+"#,
+        );
+
+        validate_resolved(&config).expect("Magnus supports direct core host registration");
+    }
+
+    #[test]
+    fn non_ruby_trait_bridge_rejects_direct_host_registration() {
+        let config = resolve_first(
+            r#"
+[workspace]
+languages = ["ruby", "python"]
+
+[[crates]]
+name = "sample-core"
+sources = ["src/lib.rs"]
+
+[[crates.trait_bridges]]
+trait_name = "SamplePlugin"
+register_fn = "register_sample_plugin"
+"#,
+        );
+
+        let error = validate_resolved(&config).expect_err("Python still requires a registry getter");
+        assert!(
+            error.to_string().contains("active language(s): python"),
+            "error must identify the unsupported active language: {error}"
+        );
     }
 }

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -1770,6 +1770,40 @@ mod trait_bridge {
     }
 
     #[test]
+    fn test_plugin_bridge_can_register_through_core_host_function() {
+        let trait_def = make_trait_def(
+            "EmbeddingBackend",
+            vec![make_method(
+                "embed",
+                TypeRef::Vec(Box::new(TypeRef::Primitive(PrimitiveType::F64))),
+                true,
+                false,
+            )],
+        );
+        let mut cfg = make_plugin_bridge_cfg("EmbeddingBackend");
+        cfg.registry_getter = None;
+
+        let code = gen_trait_bridge(
+            &trait_def,
+            &cfg,
+            "sample_crate",
+            "MyError",
+            "MyError::Plugin {{ message: {msg}, plugin_name: String::new() }}",
+            &make_api(),
+        )
+        .expect("trait bridge generation should succeed");
+
+        assert!(
+            code.contains("sample_crate::plugins::register_embedding_backend(arc).map_err"),
+            "registration without a registry getter must delegate locking and lifecycle to the core host function:\n{code}"
+        );
+        assert!(
+            !code.contains(".write().register(arc)"),
+            "direct core registration must not acquire a generated registry lock:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_plugin_bridge_emits_plugin_impl() {
         let trait_def = make_trait_def(
             "PostProcessor",


### PR DESCRIPTION
Recovers #284, which went CONFLICTING and 15 commits behind, on an organisation-owned fork that cannot be rebased in place. Both commits cherry-picked unchanged with Peter H. Boling preserved as author; only CHANGELOG.md conflicted.

Relaxes the rule that `register_fn` requires `registry_getter`. The registration call is now either the existing `{registry_getter}().write().register(arc, ..)` or a direct `{host_path}(arc, ..)` resolved through `host_function_path`. `validate_trait_bridges` moves from a hard error to a Ruby-only allowance, rejecting the config only when a non-Ruby language is active for the bridge and naming the offending languages. Motivation per the original: let the core crate own validation, lifecycle callbacks and lock boundaries rather than running host callbacks beneath an alef-generated registry write lock.

This is the change #292 (recovering #290) depended on — the two-argument constructor that left both call-site emitters behind. Landing it completes that story.

Approved by Goldziher on the original PR. Verified on current main: `cargo test --lib` 11835 passed / 0 failed, `cargo test --test backends_magnus_gen_bindings_test` 54 passed / 0 failed. The config-validation change is the part worth a second look, since it touches `src/core/config/` where 0.82.0's breaking removal landed — the full lib suite covers it.

Closes #284.