### PR TITLE
fix(magnus): preserve trait bridge bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lifecycle callbacks, and lock boundaries instead of forcing callbacks beneath an
   Alef-generated registry write lock. Existing registry-getter configurations are unchanged.
 
+- **magnus (trait bridges): preserve `Bytes` as binary Ruby strings in both callback directions.**
+  Rust-to-Ruby callback arguments previously passed `Vec<u8>` through
+  `String::from_utf8_lossy` and `Ruby::str_new`, replacing invalid UTF-8 and changing the value's
+  encoding instead of preserving source bytes. Ruby-to-Rust callback returns then used generic
+  `TryConvert<Vec<u8>>`, which expects a Ruby Array rather than the String exposed for `Bytes` by
+  the rest of the Magnus binding. Trait bridges now create ASCII-8BIT strings with
+  `Ruby::str_from_slice` and copy returned `RString` bytes directly, preserving NULs and arbitrary
+  byte sequences without transcoding.
+
 - **e2e (node/napi): an enum-typed assertion compared the whole tagged object as a scalar.** The
   napi backend lowers a tagged data enum to an internally-tagged object (`{ type: "Function" }`),
   but the TypeScript e2e generator emitted `String(e.kind).includes("Function")`, and

--- a/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
@@ -1,11 +1,11 @@
 {%- if bytes_return %}
 {% if has_error %}
 {{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
-{{ indent }}    .map(|bytes| unsafe { bytes.as_slice().to_vec() })
+{{ indent }}    .map(|bytes| unsafe { bytes.as_slice() }.to_vec())
 {{ indent }}    .map_err(|e| {{ err_convert }})
 {% else %}
 {{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
-{{ indent }}    .map(|bytes| unsafe { bytes.as_slice().to_vec() })
+{{ indent }}    .map(|bytes| unsafe { bytes.as_slice() }.to_vec())
 {{ indent }}    .unwrap_or_else(|e| {
 {{ indent }}        tracing::warn!(wrapper = "{{ wrapper }}", method = "{{ method_name }}", error = %e, "host returned a non-string byte value; returning default");
 {{ indent }}        Default::default()

--- a/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
@@ -1,4 +1,17 @@
-{%- if native_return_binding %}
+{%- if bytes_return %}
+{% if has_error %}
+{{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
+{{ indent }}    .map(|bytes| unsafe { bytes.as_slice().to_vec() })
+{{ indent }}    .map_err(|e| {{ err_convert }})
+{% else %}
+{{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
+{{ indent }}    .map(|bytes| unsafe { bytes.as_slice().to_vec() })
+{{ indent }}    .unwrap_or_else(|e| {
+{{ indent }}        tracing::warn!(wrapper = "{{ wrapper }}", method = "{{ method_name }}", error = %e, "host returned a non-string byte value; returning default");
+{{ indent }}        Default::default()
+{{ indent }}    })
+{%- endif %}
+{%- elif native_return_binding %}
 {{ indent }}// Native-object return: the binding struct's `TryConvert` accepts the host's native wrapped
 {{ indent }}// object (and still a Hash/JSON via `to_json`); `From<{{ native_return_binding }}>` yields core.
 {% if has_error %}

--- a/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
@@ -1,9 +1,15 @@
 {%- if bytes_return %}
 {% if has_error %}
+{{ indent }}// SAFETY: `bytes` is the `RString` just converted from `val`, still rooted by the
+{{ indent }}// caller for the duration of this expression; the slice is copied into an owned
+{{ indent }}// `Vec` immediately, before any further Ruby API call can invalidate it.
 {{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
 {{ indent }}    .map(|bytes| unsafe { bytes.as_slice() }.to_vec())
 {{ indent }}    .map_err(|e| {{ err_convert }})
 {% else %}
+{{ indent }}// SAFETY: `bytes` is the `RString` just converted from `val`, still rooted by the
+{{ indent }}// caller for the duration of this expression; the slice is copied into an owned
+{{ indent }}// `Vec` immediately, before any further Ruby API call can invalidate it.
 {{ indent }}<magnus::RString as magnus::TryConvert>::try_convert(val)
 {{ indent }}    .map(|bytes| unsafe { bytes.as_slice() }.to_vec())
 {{ indent }}    .unwrap_or_else(|e| {

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -632,6 +632,7 @@ impl MagnusBridgeGenerator {
                 has_error => has_error,
                 needs_json => self.needs_json_marshalling(&method.return_type),
                 native_return_binding => self.native_struct_return(&method.return_type),
+                bytes_return => matches!(method.return_type, TypeRef::Bytes),
                 indent => indent,
                 rust_ty => rust_ty,
                 err_non_json => err_non_json,
@@ -666,8 +667,12 @@ impl MagnusBridgeGenerator {
     fn ruby_arg_expr_custom(&self, ty: &TypeRef, var: &str) -> String {
         match ty {
             TypeRef::String => format!("ruby.str_new(AsRef::<str>::as_ref(&{var})).as_value()"),
+            // `str_from_slice` (not `str_new(String::from_utf8_lossy(..))`) preserves NULs and
+            // arbitrary byte sequences as an ASCII-8BIT Ruby string instead of lossily
+            // transcoding to UTF-8, matching the String this binding exposes for `Bytes`
+            // everywhere else (type_map.rs, the `.rbs`, sorbet).
             TypeRef::Bytes => {
-                format!("ruby.str_new(String::from_utf8_lossy(AsRef::<[u8]>::as_ref(&{var})).as_ref()).as_value()")
+                format!("ruby.str_from_slice(AsRef::<[u8]>::as_ref(&{var})).as_value()")
             }
             // fields (`{Binding}::from(core_value)`). The `#[magnus::wrap]` struct implements
             TypeRef::Named(n) if self.is_native_struct_param(n) => {

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -1678,6 +1678,49 @@ mod trait_bridge {
     }
 
     #[test]
+    fn test_plugin_bridge_bytes_preserve_binary_strings_in_both_directions() {
+        let mut round_trip = make_method("round_trip", TypeRef::Bytes, true, false);
+        round_trip.params.push(ParamDef {
+            name: "payload".to_string(),
+            ty: TypeRef::Bytes,
+            ..ParamDef::default()
+        });
+        let trait_def = make_trait_def("BinaryBackend", vec![round_trip]);
+        let cfg = make_plugin_bridge_cfg("BinaryBackend");
+
+        let code = gen_trait_bridge(
+            &trait_def,
+            &cfg,
+            "sample_crate",
+            "MyError",
+            "MyError::Plugin {{ message: {msg}, plugin_name: String::new() }}",
+            &make_api(),
+        )
+        .expect("trait bridge generation should succeed");
+
+        assert!(
+            code.contains("ruby.str_from_slice(AsRef::<[u8]>::as_ref(&payload)).as_value()"),
+            "byte params must become binary Ruby strings without transcoding:\n{code}"
+        );
+        assert!(
+            !code.contains("String::from_utf8_lossy"),
+            "byte params must not use lossy UTF-8 conversion:\n{code}"
+        );
+        assert!(
+            code.contains("<magnus::RString as magnus::TryConvert>::try_convert(val)"),
+            "byte returns must decode from a Ruby string:\n{code}"
+        );
+        assert!(
+            code.contains(".map(|bytes| unsafe { bytes.as_slice().to_vec() })"),
+            "byte returns must copy the Ruby string's exact bytes:\n{code}"
+        );
+        assert!(
+            !code.contains("<Vec<u8> as magnus::TryConvert>::try_convert(val)"),
+            "byte returns must not require a Ruby array of integers:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_plugin_bridge_emits_struct_when_register_fn_configured() {
         let trait_def = make_trait_def(
             "OcrBackend",

--- a/tests/backends_magnus_gen_bindings_test.rs
+++ b/tests/backends_magnus_gen_bindings_test.rs
@@ -1711,7 +1711,7 @@ mod trait_bridge {
             "byte returns must decode from a Ruby string:\n{code}"
         );
         assert!(
-            code.contains(".map(|bytes| unsafe { bytes.as_slice().to_vec() })"),
+            code.contains(".map(|bytes| unsafe { bytes.as_slice() }.to_vec())"),
             "byte returns must copy the Ruby string's exact bytes:\n{code}"
         );
         assert!(


### PR DESCRIPTION
Recovers #280 by Peter H. Boling, which could not be rebased in place: `structuredmerge` is an org-owned fork, and GitHub only honours "allow edits by maintainers" for user-owned forks, so pushes to the PR branch 403. Cherry-picked both commits (`cd598bdef`, `bb1ddece5`) onto current `main`, preserving original authorship, plus one follow-up commit adding a `// SAFETY:` comment to the unsafe block the second commit narrowed.

**What it does:** Magnus trait bridges route `TypeRef::Bytes` through `String::from_utf8_lossy` + `Ruby::str_new` on the Rust-to-Ruby direction (lossy, and produces a UTF-8-tagged string), and generic `TryConvert<Vec<u8>>` on the Ruby-to-Rust direction (expects a Ruby Array, contradicting the RString every other `Bytes` path in this binding uses). Rust-to-Ruby now uses `Ruby::str_from_slice`, producing an ASCII-8BIT string that preserves NULs and arbitrary bytes. Ruby-to-Rust now converts via `<magnus::RString as TryConvert>`, copying the string's exact bytes, with `map_err` on the fallible path and a `tracing::warn!` + default on the infallible one.

Both commits conflicted with `#291` and `#296`, which had since threaded an ambient `ruby: &magnus::Ruby` closure parameter through the sync/async callback bodies. Resolved by keeping that ambient-`ruby` calling convention (dropping this PR's now-unnecessary `unsafe { magnus::Ruby::get_unchecked() }` wrapper) while keeping this PR's substantive fix — `str_from_slice` instead of the lossy `str_new`/`from_utf8_lossy` conversion.

Closes #280.