### PR TITLE
fix(e2e): type wasm handle-config scalars against the IR

### DIFF
--- a/src/e2e/codegen/typescript/test_file.rs
+++ b/src/e2e/codegen/typescript/test_file.rs
@@ -72,7 +72,7 @@ pub(crate) use snippet::{SnippetContext, render_node_snippet_body, render_snippe
 pub(in crate::e2e::codegen::typescript::test_file) use args::build_args_and_setup;
 pub(in crate::e2e::codegen::typescript::test_file) use builders::{
     node_enum_string_literal, node_typed_value_expression, rename_napi_serde_tags_to_kind, ts_builder_expression,
-    ts_builder_expression_inner,
+    ts_builder_expression_inner, wasm_scalar_value_expression,
 };
 pub(in crate::e2e::codegen::typescript::test_file) use bytes::ts_bytes_value_expression;
 pub(in crate::e2e::codegen::typescript::test_file) use cache::{

--- a/src/e2e/codegen/typescript/test_file/args.rs
+++ b/src/e2e/codegen/typescript/test_file/args.rs
@@ -278,6 +278,10 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                         // inside a list fell to `json_to_js_camel` and stayed a bare literal that
                         // wasm-bindgen rejects, even though the map already held the element's
                         // class (`derive_nested_types_for_wasm` unwraps `Vec<Named>`). ~keep
+                        // Strip the wasm binding prefix (`WasmEngineConfig` -> `EngineConfig`) so
+                        // scalar fields can be resolved against the IR's own type name, the same
+                        // way `ts_builder_expression_inner` derives `ir_owner_name`.
+                        let owner_type = config_type.strip_prefix(wasm_type_prefix).unwrap_or(config_type);
                         let context = HandleConfigContext {
                             nested_types,
                             effective_nested_types: &effective_nested,
@@ -287,6 +291,7 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                             type_defs,
                             enums,
                             wasm_type_prefix,
+                            owner_type: Some(owner_type),
                         };
                         for (key, val) in obj {
                             let camel_key = underscore_camel_case(key);

--- a/src/e2e/codegen/typescript/test_file/builders/mod.rs
+++ b/src/e2e/codegen/typescript/test_file/builders/mod.rs
@@ -260,13 +260,21 @@ fn to_bigint_literal(value_expr: &str) -> String {
 /// TypeScript type error, and at runtime a `TypeError: Cannot convert a Number to a BigInt`.
 /// The list stays honoured on top of this, since it also covers fields whose owner the IR
 /// lookup cannot resolve. Gated on `wasm`: NAPI (`lang == "node"`) marshals `i64` as `number`.
+///
+/// `TypeRef::Duration` is included alongside the bigint primitives: `TypeMapper::duration()`
+/// (default, unoverridden by [`crate::backends::wasm::type_map::WasmMapper`]) lowers every
+/// `Duration` field to Rust `u64` before wasm-bindgen ever sees it, in `gen_struct`'s field-type
+/// derivation and in the function-parameter input-DTO conversion alike — so a `Duration` field
+/// is a `bigint` setter on the wasm boundary exactly as if the IR had declared `u64` directly. ~keep
 fn wasm_bigint_field(lang: &str, field_type: Option<&crate::core::ir::TypeRef>) -> bool {
-    lang == "wasm"
-        && matches!(
-            field_type,
-            Some(crate::core::ir::TypeRef::Primitive(prim))
-                if crate::backends::wasm::gen_bindings::is_bigint_primitive(prim)
-        )
+    if lang != "wasm" {
+        return false;
+    }
+    matches!(
+        field_type,
+        Some(crate::core::ir::TypeRef::Primitive(prim))
+            if crate::backends::wasm::gen_bindings::is_bigint_primitive(prim)
+    ) || matches!(field_type, Some(crate::core::ir::TypeRef::Duration))
 }
 
 /// The BigInt literal for a fixture value assigned to a wasm-bindgen `u64`/`i64` setter.
@@ -294,6 +302,8 @@ fn wasm_typed_value_expression(val: &serde_json::Value, field_type: &TypeRef) ->
         TypeRef::Primitive(primitive) if crate::backends::wasm::gen_bindings::is_bigint_primitive(primitive) => {
             Some(bigint_value_literal(val))
         }
+        // `Duration` lowers to Rust `u64` on the wasm boundary — see `wasm_bigint_field`. ~keep
+        TypeRef::Duration => Some(bigint_value_literal(val)),
         TypeRef::Vec(inner) => {
             let values = val.as_array()?;
             let constructor = match inner.as_ref() {
@@ -340,6 +350,71 @@ fn resolve_owner_field<'a>(owner_type: Option<&'a TypeDef>, key: &str) -> Option
                 definition.serde_rename_all.as_deref(),
             ) == key
     })
+}
+
+/// Render a single wasm handle-config scalar field, resolving enum members and bigint literals
+/// from the field's IR type exactly as [`ts_builder_expression_inner`] does for the same field
+/// on a nested object.
+///
+/// `owner_type` is the un-prefixed IR name of the struct that declares `key` (e.g.
+/// `EngineConfig` for `WasmEngineConfig`), so the field's [`TypeRef`] can be resolved; `None`
+/// when the caller has no IR-resolved owner at this point (a fixture key inside a plain nested
+/// object this generator has no type mapping for), in which case only the `enum_fields`/
+/// `bigint_fields` override maps are consulted, matching the owner-less call sites in
+/// `node_value_expression`. ~keep
+#[allow(clippy::too_many_arguments)]
+pub(in crate::e2e::codegen::typescript::test_file) fn wasm_scalar_value_expression(
+    owner_type: Option<&str>,
+    key: &str,
+    camel_key: &str,
+    val: &serde_json::Value,
+    lang: &str,
+    enum_fields: &std::collections::HashMap<String, String>,
+    bigint_fields: &std::collections::BTreeSet<String>,
+    type_defs: &[TypeDef],
+    enums: &[EnumDef],
+    wasm_type_prefix: &str,
+    referenced_enums: &mut std::collections::BTreeSet<String>,
+) -> String {
+    let owner = owner_type.and_then(|name| type_defs.iter().find(|definition| definition.name == name));
+    let field_type = resolve_owner_field(owner, key).map(|field| match &field.ty {
+        crate::core::ir::TypeRef::Optional(inner) => inner.as_ref(),
+        other => other,
+    });
+
+    if lang == "wasm"
+        && let Some(field_type) = field_type
+        && let Some(expression) = wasm_typed_value_expression(val, field_type)
+    {
+        return expression;
+    }
+
+    if let Some(crate::core::ir::TypeRef::Named(enum_type)) = field_type
+        && enums.iter().any(|definition| definition.name == *enum_type)
+        && !wasm_enum_bridged_as_raw_value(enum_type, enums, wasm_type_prefix)
+        && let serde_json::Value::String(variant) = val
+    {
+        let member = declared_enum_member_for_prefixed(enum_type, enums, wasm_type_prefix, variant);
+        let enum_type = wasm_prefixed_wrapped_type(lang, enum_type, type_defs, enums, wasm_type_prefix);
+        return enum_member_reference(&enum_type, &member, referenced_enums);
+    }
+
+    if let Some(enum_type) = resolve_enum_type(enum_fields, owner_type, key, camel_key)
+        && !wasm_enum_bridged_as_raw_value(enum_type, enums, wasm_type_prefix)
+        && let serde_json::Value::String(s) = val
+    {
+        let enum_type = wasm_prefixed_wrapped_type(lang, enum_type, type_defs, enums, wasm_type_prefix);
+        let member = declared_enum_member_for_prefixed(&enum_type, enums, wasm_type_prefix, s);
+        return enum_member_reference(&enum_type, &member, referenced_enums);
+    }
+
+    let is_bigint =
+        bigint_fields.contains(camel_key) || bigint_fields.contains(key) || wasm_bigint_field(lang, field_type);
+    if is_bigint {
+        return bigint_value_literal(val);
+    }
+
+    json_to_js(val)
 }
 
 /// Resolve the napi-rs / wasm-bindgen public JS field identifier for fixture key `key` on

--- a/src/e2e/codegen/typescript/test_file/handle_values.rs
+++ b/src/e2e/codegen/typescript/test_file/handle_values.rs
@@ -12,7 +12,16 @@ use super::*;
 /// over the only two things that actually change as it descends: the JSON key and its value.
 /// `nested_types` is the raw call override and `effective_nested_types` is that override merged
 /// over the IR-derived classes — [`ts_builder_expression_inner`] re-derives its own merge for
-/// whatever type it is handed, so it must keep receiving the raw override, not the merged map. ~keep
+/// whatever type it is handed, so it must keep receiving the raw override, not the merged map.
+///
+/// `owner_type` is the un-prefixed IR name of the struct whose fields are being rendered at the
+/// current recursion depth (the handle's config type at the top level), so a scalar field can be
+/// resolved back to its IR [`crate::core::ir::TypeRef`] and routed through the same enum/bigint
+/// typing [`ts_builder_expression_inner`] already applies to nested objects. It is cleared to
+/// `None` when recursion descends into a plain object this generator has no type mapping for —
+/// that object's fields belong to some other, unknown struct, and resolving them against the
+/// outer `owner_type` would attribute a field to the wrong owner. ~keep
+#[derive(Clone, Copy)]
 pub(in crate::e2e::codegen::typescript::test_file) struct HandleConfigContext<'a> {
     pub nested_types: &'a std::collections::HashMap<String, String>,
     pub effective_nested_types: &'a std::collections::HashMap<String, String>,
@@ -22,6 +31,7 @@ pub(in crate::e2e::codegen::typescript::test_file) struct HandleConfigContext<'a
     pub type_defs: &'a [TypeDef],
     pub enums: &'a [EnumDef],
     pub wasm_type_prefix: &'a str,
+    pub owner_type: Option<&'a str>,
 }
 
 /// Render one handle-config field value as a TypeScript expression.
@@ -98,16 +108,37 @@ fn render_value(
                 )
             }
             None => {
+                // This object has no known IR type, so its fields cannot be resolved against
+                // `context.owner_type` — that name belongs to a different struct. ~keep
+                let inner_context = HandleConfigContext {
+                    owner_type: None,
+                    ..*context
+                };
                 let entries: Vec<String> = fields
                     .iter()
                     .map(|(field, field_value)| {
-                        let rendered = render_value(field, field_value, context, used_types, referenced_enums);
+                        let rendered = render_value(field, field_value, &inner_context, used_types, referenced_enums);
                         format!("{}: {rendered}", js_object_key(&underscore_camel_case(field)))
                     })
                     .collect();
                 format!("{{ {} }}", entries.join(", "))
             }
         },
-        scalar => json_to_js(scalar),
+        scalar => {
+            let camel_key = underscore_camel_case(key);
+            wasm_scalar_value_expression(
+                context.owner_type,
+                key,
+                &camel_key,
+                scalar,
+                context.lang,
+                context.enum_fields,
+                context.bigint_fields,
+                context.type_defs,
+                context.enums,
+                context.wasm_type_prefix,
+                referenced_enums,
+            )
+        }
     }
 }

--- a/src/e2e/codegen/typescript/test_file/handle_values_tests.rs
+++ b/src/e2e/codegen/typescript/test_file/handle_values_tests.rs
@@ -29,6 +29,7 @@ fn render(key: &str, value: &serde_json::Value, classes: &[(&str, &str)]) -> Str
         type_defs: &[],
         enums: &[],
         wasm_type_prefix: "Wasm",
+        owner_type: None,
     };
     build_handle_config_value(key, value, &context, &mut std::collections::BTreeSet::new())
 }
@@ -44,10 +45,87 @@ fn collect(key: &str, value: &serde_json::Value, classes: &[(&str, &str)]) -> st
         type_defs: &[],
         enums: &[],
         wasm_type_prefix: "Wasm",
+        owner_type: None,
     };
     let mut used_types = std::collections::BTreeSet::new();
     collect_used_handle_config_types(key, value, &context, &mut used_types);
     used_types
+}
+
+fn field(name: &str, ty: TypeRef) -> crate::core::ir::FieldDef {
+    crate::core::ir::FieldDef {
+        name: name.to_string(),
+        ty,
+        ..Default::default()
+    }
+}
+
+/// An `EngineConfig` IR type carrying the three field shapes the wasm scalar path must
+/// distinguish: an enum-typed field, a `Duration` (bigint on the wasm boundary — see
+/// `wasm_bigint_field`) field, and a plain `u32` field.
+///
+/// `request_timeout` is declared `Duration`, not `TypeRef::Primitive(U64)`, on purpose: that is
+/// crawlberg's actual IR shape (`crates/crawlberg/src/types/config.rs`'s `CrawlConfig::
+/// request_timeout: Duration`), and it is the shape that first exposed the gap — `Duration`
+/// lowers to Rust `u64` at the wasm-bindgen boundary just as directly as a primitive `u64` field
+/// does, but was not itself recognised as bigint-typed. ~keep
+fn engine_config_type_def() -> TypeDef {
+    TypeDef {
+        name: "EngineConfig".to_string(),
+        fields: vec![
+            field("crawl_strategy", TypeRef::Named("CrawlStrategyKind".to_string())),
+            field("request_timeout", TypeRef::Duration),
+            field(
+                "max_body_size",
+                TypeRef::Optional(Box::new(TypeRef::Primitive(crate::core::ir::PrimitiveType::U64))),
+            ),
+            field("max_depth", TypeRef::Primitive(crate::core::ir::PrimitiveType::U32)),
+        ],
+        ..Default::default()
+    }
+}
+
+fn crawl_strategy_enum() -> EnumDef {
+    EnumDef {
+        name: "CrawlStrategyKind".to_string(),
+        variants: vec![
+            crate::core::ir::EnumVariant {
+                name: "Bfs".to_string(),
+                ..Default::default()
+            },
+            crate::core::ir::EnumVariant {
+                name: "Dfs".to_string(),
+                ..Default::default()
+            },
+        ],
+        serde_rename_all: Some("snake_case".to_string()),
+        ..Default::default()
+    }
+}
+
+/// Renders a top-level `EngineConfig` scalar field through the real traversal, with the IR
+/// registry populated so `owner_type` resolution can find the field's declared type.
+fn render_engine_config_field(
+    key: &str,
+    value: &serde_json::Value,
+    referenced_enums: &mut std::collections::BTreeSet<String>,
+) -> String {
+    let type_defs = [engine_config_type_def()];
+    let enums = [crawl_strategy_enum()];
+    let empty_map = std::collections::HashMap::new();
+    let empty_set = std::collections::BTreeSet::new();
+    let context = HandleConfigContext {
+        nested_types: &empty_map,
+        effective_nested_types: &empty_map,
+        lang: "wasm",
+        enum_fields: &empty_map,
+        bigint_fields: &empty_set,
+        type_defs: &type_defs,
+        enums: &enums,
+        wasm_type_prefix: "Wasm",
+        owner_type: Some("EngineConfig"),
+    };
+    build_handle_config_value(key, value, &context, referenced_enums)
 }
 
 fn built(class_name: &str, body: &str) -> String {
@@ -205,4 +283,70 @@ fn handle_config_list_entries_are_constructed_through_build_args_and_setup() {
         !setup.contains("engineConfig.rules = [{ deny: true }];"),
         "must not fall back to the untyped json_to_js_camel dump: {setup}"
     );
+}
+
+/// A top-level handle-config scalar whose IR field type is a wasm-bindgen C-style enum must
+/// render as an `EnumType.Member` reference, not the fixture's raw wire string. Before the
+/// `owner_type` seam existed, `engineConfig.crawlStrategy = "dfs"` compiled and ran, but
+/// `ToInt32("dfs")` coerces to `0`, which is `WasmCrawlStrategyKind.Bfs` — the test silently
+/// exercised the wrong algorithm.
+#[test]
+fn should_render_a_top_level_enum_scalar_as_a_member_reference() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field("crawl_strategy", &serde_json::json!("dfs"), &mut referenced_enums);
+    assert_eq!(rendered, "WasmCrawlStrategyKind.Dfs");
+    assert!(
+        referenced_enums.contains("WasmCrawlStrategyKind"),
+        "enum member reference must register its import: {referenced_enums:?}"
+    );
+}
+
+/// A top-level handle-config scalar whose IR field type is a wasm `u64`/`i64` must render as a
+/// BigInt literal — wasm-bindgen's setter rejects a plain `Number`, throwing `TypeError: Cannot
+/// convert 500 to a BigInt` at run time for `engineConfig.requestTimeout = 500;`.
+#[test]
+fn should_render_a_top_level_bigint_scalar_as_a_bigint_literal() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field("request_timeout", &serde_json::json!(500), &mut referenced_enums);
+    assert_eq!(rendered, "500n");
+}
+
+/// Zero is exact-integer-shaped too, and must not be special-cased away from the `n` suffix.
+#[test]
+fn should_render_a_top_level_bigint_scalar_of_zero_as_a_bigint_literal() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field("request_timeout", &serde_json::json!(0), &mut referenced_enums);
+    assert_eq!(rendered, "0n");
+}
+
+/// A magnitude past `2^53` must survive intact: routing the JSON number through an f64/i64 round
+/// trip before appending `n` would already have lost precision by the time the suffix is added.
+#[test]
+fn should_preserve_bigint_precision_past_the_f64_safe_integer_range() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field(
+        "request_timeout",
+        &serde_json::json!(9_007_199_254_740_993u64),
+        &mut referenced_enums,
+    );
+    assert_eq!(rendered, "9007199254740993n");
+}
+
+/// A `TypeRef::Primitive(U64)` field — the original, narrower bigint case — must still render as
+/// a BigInt literal alongside the `Duration` case above.
+#[test]
+fn should_render_a_top_level_primitive_u64_scalar_as_a_bigint_literal() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field("max_body_size", &serde_json::json!(1024), &mut referenced_enums);
+    assert_eq!(rendered, "1024n");
+}
+
+/// A plain scalar field (neither enum nor bigint) must keep rendering as an ordinary JS literal —
+/// proving the new `owner_type` resolution does not misclassify unrelated fields.
+#[test]
+fn should_leave_a_plain_scalar_field_unaffected_by_owner_type_resolution() {
+    let mut referenced_enums = std::collections::BTreeSet::new();
+    let rendered = render_engine_config_field("max_depth", &serde_json::json!(3), &mut referenced_enums);
+    assert_eq!(rendered, "3");
+    assert!(referenced_enums.is_empty());
 }

--- a/src/e2e/codegen/typescript/test_file/render.rs
+++ b/src/e2e/codegen/typescript/test_file/render.rs
@@ -42,6 +42,9 @@ fn handle_config_classes(
     // Only the class map and the JSON shape decide which classes get constructed; `enum_fields`
     // and `bigint_fields` steer scalar rendering, whose string this caller discards. ~keep
     let bigint_fields: std::collections::BTreeSet<String> = override_config.bigint_fields.iter().cloned().collect();
+    let owner_type = handle_config_type
+        .strip_prefix(wasm_type_prefix)
+        .unwrap_or(handle_config_type);
     let context = HandleConfigContext {
         nested_types: &override_config.nested_types,
         effective_nested_types: &effective_nested_types,
@@ -51,6 +54,7 @@ fn handle_config_classes(
         type_defs,
         enums,
         wasm_type_prefix,
+        owner_type: Some(owner_type),
     };
     for arg in call_config.args.iter().filter(|arg| arg.arg_type == "handle") {
         let field = arg.field.strip_prefix("input.").unwrap_or(&arg.field);


### PR DESCRIPTION
The wasm handle-config setter path rendered every scalar through `json_to_js`, unlike the nested-object path in `ts_builder_expression_inner` which already resolves a field's IR type. `HandleConfigContext` did not even carry the owner type name, so the scalar arm could not consult the symbol table it was holding.

Two consequences, and the second is the one that matters:

- `requestTimeout = 500` against a `u64` setter throws `TypeError: Cannot convert 500 to a BigInt` — a loud failure.
- `crawlStrategy = "dfs"` against a numeric C-style `#[wasm_bindgen]` enum does NOT throw. `ToInt32("dfs")` is 0, which is `Bfs`, so the test silently ran the wrong strategy and asserted against a BFS-shaped result.

And `contentFilter = "bm25"` was **passing by arithmetic accident**: `ToInt32("bm25")` is also 0, which happens to be `Bm25`. Reordering either enum's variants would have flipped both outcomes with no signal.

Verified on regenerated crawlberg output, not just unit tests:

    filter.test.ts:66     contentFilter  = WasmContentFilterKind.Bm25
    strategy.test.ts:64   crawlStrategy  = WasmCrawlStrategyKind.BestFirst
    validation.test.ts:291 requestTimeout = 0n
    error.test.ts:300      requestTimeout = 500n
    residual bare-string enum assignments: 0

Rebased onto `39f7eb3b8`; the import-list conflict against the wire-name fix was resolved as a union. `cargo test --lib` 11857 passed / 0 failed, `cargo fmt --check` clean.