### PR TITLE
fix(e2e): parenthesise the elixir stream accessor, stop C# HTML-escaping

### DIFF
--- a/src/e2e/codegen/csharp.rs
+++ b/src/e2e/codegen/csharp.rs
@@ -1011,6 +1011,17 @@ use streaming::{render_streaming_test_method, resolve_csharp_streaming_item_type
 use values::{json_to_csharp, render_sealed_display};
 use visitor::{build_csharp_visitor, resolve_csharp_visitor_config};
 
+/// A `new JsonSerializerOptions { ... }` expression that disables HTML-safe escaping.
+///
+/// `JsonSerializer.Serialize` with no options argument uses `JavaScriptEncoder.Default`, which
+/// escapes `+ ' < > &` as `\uXXXX` sequences. Any generated assertion that round-trips an actual
+/// wire value through `Serialize(...).Trim('"')` to compare it against a plain string literal
+/// must pass this options object, or the comparison fails on any expected text containing one of
+/// those characters (e.g. `"4 + 4 equals 8."`, `"I'm running locally."`) while passing silently
+/// for text that happens not to need escaping. ~keep
+pub(super) const UNESCAPED_JSON_SERIALIZER_OPTIONS: &str =
+    "new System.Text.Json.JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping }";
+
 /// Build a C# call expression for a `method_result` assertion on a sample_language Tree.
 ///
 /// Maps well-known method names to the appropriate C# static helper calls on the

--- a/src/e2e/codegen/csharp/assertions.rs
+++ b/src/e2e/codegen/csharp/assertions.rs
@@ -474,9 +474,10 @@ pub(super) fn render_assertion(
                 // (e.g. `DataNodeKind`, which has no `rename_all`). ~keep
                 if field_is_enum && expected.is_string() {
                     let expected_wire = expected.as_str().unwrap_or_default();
+                    let serializer_options = super::UNESCAPED_JSON_SERIALIZER_OPTIONS;
                     let _ = writeln!(
                         out,
-                        "        Assert.Equal(\"{}\", {field_expr} == null ? null : System.Text.Json.JsonSerializer.Serialize({field_expr}).Trim('\"'));",
+                        "        Assert.Equal(\"{}\", {field_expr} == null ? null : System.Text.Json.JsonSerializer.Serialize({field_expr}, {serializer_options}).Trim('\"'));",
                         escape_csharp(expected_wire)
                     );
                     return;

--- a/src/e2e/codegen/csharp/enum_field_classification_tests.rs
+++ b/src/e2e/codegen/csharp/enum_field_classification_tests.rs
@@ -248,8 +248,13 @@ fn enum_equals_assertion_compares_the_real_wire_value_unmodified() {
         "must not guess a naming-policy transform; it must serialize through the enum's own converter, got:\n{out}"
     );
     assert!(
-        out.contains("System.Text.Json.JsonSerializer.Serialize(result.Kind).Trim('\"')"),
-        "expected the actual value serialized through the enum's own JsonConverter, got:\n{out}"
+        out.contains(
+            "System.Text.Json.JsonSerializer.Serialize(result.Kind, new System.Text.Json.JsonSerializerOptions { \
+             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping }).Trim('\"')"
+        ),
+        "expected the actual value serialized through the enum's own JsonConverter with \
+         HTML-safe escaping disabled (otherwise wire values containing `+ ' < > &` mismatch \
+         the plain-string expectation), got:\n{out}"
     );
 }
 

--- a/src/e2e/codegen/csharp/streaming.rs
+++ b/src/e2e/codegen/csharp/streaming.rs
@@ -324,8 +324,15 @@ pub(super) fn render_streaming_test_method(
             // (e.g. "tool_calls") that assertions compare against, not the .NET name.
             body.push_str("                if (choice.FinishReason.HasValue)\n");
             body.push_str("                {\n");
-            body.push_str(
-                "                    lastFinishReason = System.Text.Json.JsonSerializer.Serialize(choice.FinishReason.Value).Trim('\"');\n",
+            // Same HTML-safe-escaping hazard as the enum-field equality bypass in
+            // `assertions.rs`: without this options argument, `+ ' < > &` in the wire value
+            // come back as `\uXXXX` escapes and the comparison against a plain string literal
+            // fails. `FinishReason` values happen not to contain those characters today, but
+            // the accessor should not depend on that staying true. ~keep
+            let _ = writeln!(
+                body,
+                "                    lastFinishReason = System.Text.Json.JsonSerializer.Serialize(choice.FinishReason.Value, {}).Trim('\"');",
+                super::UNESCAPED_JSON_SERIALIZER_OPTIONS
             );
             body.push_str("                }\n");
         }

--- a/src/e2e/codegen/elixir/streaming_pipe_precedence_tests.rs
+++ b/src/e2e/codegen/elixir/streaming_pipe_precedence_tests.rs
@@ -38,6 +38,17 @@ const STREAM_CONTENT_ACCESSOR: &str = "Enum.join(Enum.map(chunks, fn c -> \
 
 /// The exact `stream_complete` accessor the Elixir backend must emit.
 const STREAM_COMPLETE_ACCESSOR: &str = concat!(
+    "(case List.last(chunks) do nil -> false; c -> case ",
+    "List.first(Map.get(c, :choices, []) || []) do nil -> false; ",
+    "choice -> Map.get(choice, :finish_reason) != nil end end)"
+);
+
+/// The pre-fix `stream_complete` accessor: a `case/do/end` emitted as a bare paren-less
+/// expression. Pasted into `assert <expr>`, Elixir's `do` block binds to the OUTERMOST
+/// paren-less call (`assert`) rather than `case`, reparsing the clause list as `assert`'s own
+/// do-block and failing to compile with "misplaced operator ->". Kept verbatim so the scanner
+/// below can be shown to reject the shape that actually broke a consumer build. ~keep
+const DEFECTIVE_STREAM_COMPLETE_ACCESSOR: &str = concat!(
     "case List.last(chunks) do nil -> false; c -> case ",
     "List.first(Map.get(c, :choices, []) || []) do nil -> false; ",
     "choice -> Map.get(choice, :finish_reason) != nil end end"
@@ -77,6 +88,50 @@ fn has_top_level_pipe(expr: &str) -> bool {
             b'(' | b'[' | b'{' => depth += 1,
             b')' | b']' | b'}' => depth -= 1,
             b'|' if depth == 0 && bytes.get(index + 1) == Some(&b'>') => return true,
+            _ => {}
+        }
+        index += 1;
+    }
+    false
+}
+
+/// True when `expr` contains a keyword `do` block (`case`/`fn`/`if`/`cond`/... `do ... end`)
+/// outside every bracket group — the shape that cannot be pasted into `assert <expr>` or
+/// `<expr> not in [...]`. Elixir's `do` block binds to the OUTERMOST paren-less call in its
+/// statement, so a bare `case ... do ... end` substituted into `assert <expr>` reparses as
+/// `assert(case(...), do: [...])`: the clause list becomes `assert`'s own do-block and the
+/// generated file fails to compile with "misplaced operator ->". A `do` nested inside `(...)`,
+/// `[...]` or `%{...}` is already a self-contained primary expression and parses correctly, so
+/// only a depth-0 `do` is flagged. String literals are skipped so a `"do"` inside a generated
+/// Elixir string is not mistaken for the keyword. ~keep
+fn has_top_level_do_block(expr: &str) -> bool {
+    let bytes = expr.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if in_string {
+            match byte {
+                b'\\' => index += 1,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'd' if depth == 0 && bytes[index..].starts_with(b"do") => {
+                let is_identifier_byte = |b: u8| (b as char).is_alphanumeric() || b == b'_';
+                let before_is_boundary = index == 0 || !is_identifier_byte(bytes[index - 1]);
+                let after_is_boundary = bytes.get(index + 2).is_none_or(|&b| !is_identifier_byte(b));
+                if before_is_boundary && after_is_boundary {
+                    return true;
+                }
+            }
             _ => {}
         }
         index += 1;
@@ -302,9 +357,10 @@ fn not_empty_on_stream_content_emits_a_parsable_membership_test() {
     );
 }
 
-/// Defect-class sweep: NO Elixir streaming accessor may lead with a pipe, not just the two that
-/// did. A future accessor written as `chunks |> ...` fails here even if nothing asserts
-/// `not_empty` on it yet.
+/// Defect-class sweep: NO Elixir streaming accessor may lead with a pipe or a bare `do` block,
+/// not just the instances that actually broke a consumer build. A future accessor written as
+/// `chunks |> ...` or `case ... do ... end` fails here even if nothing pastes it into an
+/// operator or paren-less context yet.
 #[test]
 fn no_elixir_streaming_accessor_leads_with_a_top_level_pipe() {
     let mut fields: Vec<&str> = STREAMING_VIRTUAL_FIELDS.to_vec();
@@ -351,6 +407,12 @@ fn no_elixir_streaming_accessor_leads_with_a_top_level_pipe() {
             "elixir accessor for '{field}' leads with a pipe and cannot be pasted before \
              `not in [...]`: {expr}"
         );
+        assert!(
+            !has_top_level_do_block(expr),
+            "elixir accessor for '{field}' leads with a bare `do` block and cannot be pasted \
+             into `assert <expr>` -- Elixir's `do` would bind to the outermost paren-less call \
+             instead of this accessor's own keyword construct: {expr}"
+        );
     }
 }
 
@@ -368,6 +430,26 @@ fn the_top_level_pipe_scanner_flags_the_shape_that_broke_the_build() {
     // report it, or "no top-level pipe" would degrade into "no pipe anywhere". ~keep
     assert!(!has_top_level_pipe("Enum.join(a |> Enum.map(f), \"\")"));
     assert!(!has_top_level_pipe("Enum.map(c, fn x -> x |> to_string() end)"));
+}
+
+/// Same wiring proof for the `do`-block scanner: the verbatim pre-fix `stream_complete`
+/// accessor (a bare `case ... do ... end`) must be flagged, and the shipped, parenthesized one
+/// must not. ~keep
+#[test]
+fn the_top_level_do_block_scanner_flags_the_shape_that_broke_the_build() {
+    assert!(
+        has_top_level_do_block(DEFECTIVE_STREAM_COMPLETE_ACCESSOR),
+        "scanner missed the pre-fix accessor"
+    );
+    assert!(!has_top_level_do_block(STREAM_COMPLETE_ACCESSOR));
+    assert!(!has_top_level_do_block(TOOL_CALLS_ACCESSOR));
+    assert!(!has_top_level_do_block(STREAM_CONTENT_ACCESSOR));
+    // A `do` nested inside a bracket group (e.g. an anonymous function literal passed as an
+    // argument) is delimited and legal — the scanner must not report it. ~keep
+    assert!(!has_top_level_do_block("Enum.map(c, fn x -> case x do y -> y end end)"));
+    // A `do` that is merely a substring of a longer identifier (e.g. `undo`) must not trip the
+    // word-boundary check.
+    assert!(!has_top_level_do_block("undo(chunks)"));
 }
 
 /// Control: a pipe in STATEMENT position is valid Elixir and must survive untouched. A "fix"

--- a/src/e2e/codegen/streaming_assertions/accessors.rs
+++ b/src/e2e/codegen/streaming_assertions/accessors.rs
@@ -251,11 +251,19 @@ impl StreamingFieldResolver {
                     format!("bool({chunks_var}) and {chunks_var}[-1]{choices_acc}[0]{finish_acc} is not None")
                 }
                 "elixir" => {
+                    // ~keep Wrapped in an outer `(...)`: a `case/do/end` is not a primary
+                    // expression, and call sites paste this accessor into paren-less contexts
+                    // (`assert <expr>`, `<expr> not in [...]`) they do not parenthesize
+                    // themselves. Without the wrapping parens, Elixir's `do` block binds to the
+                    // OUTERMOST paren-less call -- here `assert` -- instead of `case`, which
+                    // reparses the clause list as `assert`'s own do-block and fails to compile
+                    // with "misplaced operator ->". The parens make `case ... end` a
+                    // self-contained primary expression before it is ever handed to a caller.
                     format!(
                         concat!(
-                            "case List.last({chunks_var}) do nil -> false; c -> case ",
+                            "(case List.last({chunks_var}) do nil -> false; c -> case ",
                             "List.first(Map.get(c, :choices, []) || []) do nil -> false; ",
-                            "choice -> Map.get(choice, :finish_reason) != nil end end"
+                            "choice -> Map.get(choice, :finish_reason) != nil end end)"
                         ),
                         chunks_var = chunks_var
                     )


### PR DESCRIPTION
Two independent defects in liter-llm's e2e output.

**Elixir.** The `stream_complete` accessor emitted a bare `case ... do ... end`. In Elixir a `do` block binds to the outermost paren-less call, so pasted into `assert <expr>` it reparsed as `assert(case(X), do: <clauses>)` — `case` with one argument and no clauses, and the clause list handed to `assert`, which does not take clauses. `misplaced operator ->`, and the whole generated test failed to compile. It parses well enough that `mix format` reflows it, which is why it survived review.

The module that owns this already stated the rule — `streaming_pipe_precedence_tests.rs:13-15`: every Elixir streaming accessor is emitted as a primary expression, never a bare pipe chain, because call sites paste it into operator contexts they do not parenthesise. A `case/do/end` is not a primary expression either, and the scanner only implemented `has_top_level_pipe`. The accessor is now parenthesised and a `has_top_level_do_block` scanner guards the class rather than this instance.

**C#.** The enum-equality bypass and the streaming FinishReason accessor serialised through `JsonSerializer` with no options, so the default `JavaScriptEncoder` HTML-escaped `+ ' < > &`. Any expected text containing one mismatched the escaped actual — which is why exactly the two fixtures whose text contains `+` or `'` failed while `Assert.Equal("stop", ...)` on the same construct passed. Now passes `UnsafeRelaxedJsonEscaping` explicitly.

`cargo test --lib` 11859 passed / 0 failed on the rebase.