### PR TITLE
fix(pyo3): re-export error-info companions from the public package

### DIFF
--- a/src/backends/pyo3/gen_bindings/errors.rs
+++ b/src/backends/pyo3/gen_bindings/errors.rs
@@ -297,6 +297,19 @@ pub(super) fn gen_init_py(
     imports_from_native.extend(needed_data_enums.iter().cloned());
     native_return_types.sort();
     imports_from_native.extend(native_return_types.iter().cloned());
+    // Each error with whitelisted introspection methods gets a companion `{Error}Info`
+    // #[pyclass] and a `{error}_info` free #[pyfunction], both registered directly on the
+    // native module (`pyo3::gen_bindings::methods::gen_module_init`) rather than flowing
+    // through `api.functions`/`api.types`. Without this, the public facade never re-exports
+    // them even though the native module does (liter-llm `liter_llm_error_info` gap).
+    let mut error_info_names: Vec<String> = Vec::new();
+    for error in &api.errors {
+        if crate::codegen::error_gen::pyo3_error_has_methods(error) {
+            error_info_names.push(crate::codegen::error_gen::pyo3_error_info_struct_name(error));
+            error_info_names.push(crate::codegen::error_gen::pyo3_error_info_fn_name(error));
+        }
+    }
+    imports_from_native.extend(error_info_names);
     imports_from_native.retain(|n| !capsule_types.contains_key(n));
     // are external references not registered as #[pyclass] in the native module, so they must
     // Opaque types WITHOUT a capsule override DO get a binding-side #[pyclass] wrapper struct
@@ -759,6 +772,130 @@ mod tests {
         assert!(
             !result.contains("drop_async"),
             "excluded async fn leaked into __all__:\n{result}"
+        );
+    }
+
+    /// Regression (liter-llm E2E `test_batches.py`/`test_files.py`/`test_list_models.py`/
+    /// `test_responses.py`): an error with whitelisted introspection methods gets a companion
+    /// `{Error}Info` #[pyclass] and a `{error}_info` free #[pyfunction] registered directly on
+    /// the native module (see `pyo3_error_has_methods`/`pyo3_error_info_fn_name` in
+    /// `codegen::error_gen`), bypassing `api.functions`/`api.types` entirely. Without this,
+    /// `__init__.py` never re-exports either symbol, so `AttributeError: module 'liter_llm' has
+    /// no attribute 'liter_llm_error_info'` fires for any e2e call whose override does not
+    /// force `native_module` to the internal bindings module.
+    #[test]
+    fn gen_init_py_reexports_error_info_class_and_function() {
+        use crate::core::ir::{ErrorDef, MethodDef};
+
+        let mut api = empty_api();
+        api.errors.push(ErrorDef {
+            name: "LiterLlmError".to_string(),
+            rust_path: "liter_llm::LiterLlmError".to_string(),
+            original_rust_path: String::new(),
+            variants: vec![],
+            doc: String::new(),
+            methods: vec![
+                MethodDef {
+                    name: "status_code".to_string(),
+                    ..Default::default()
+                },
+                MethodDef {
+                    name: "is_transient".to_string(),
+                    ..Default::default()
+                },
+            ],
+            binding_excluded: false,
+            binding_exclusion_reason: None,
+            version: Default::default(),
+        });
+
+        let dto = DtoConfig::default();
+        let extra = std::collections::BTreeMap::new();
+        let caps = std::collections::HashMap::new();
+        let adapters = vec![];
+        let opaque = std::collections::HashMap::new();
+        let result = gen_init_py(
+            &api,
+            "_internal_bindings",
+            "1.2.3",
+            &dto,
+            &[],
+            &[],
+            &extra,
+            &caps,
+            &adapters,
+            &opaque,
+            &ahash::AHashSet::new(),
+        );
+
+        let import_line = result
+            .lines()
+            .find(|l| l.starts_with("from ._internal_bindings import"))
+            .unwrap_or_else(|| panic!("no native import statement in:\n{result}"));
+        assert!(
+            import_line.contains("liter_llm_error_info"),
+            "liter_llm_error_info missing from the native import statement: {import_line}",
+        );
+        assert!(
+            import_line.contains("LiterLlmErrorInfo"),
+            "LiterLlmErrorInfo missing from the native import statement: {import_line}",
+        );
+        assert!(
+            result.contains("\"liter_llm_error_info\""),
+            "liter_llm_error_info missing from __all__:\n{result}",
+        );
+        assert!(
+            result.contains("\"LiterLlmErrorInfo\""),
+            "LiterLlmErrorInfo missing from __all__:\n{result}",
+        );
+    }
+
+    /// An error with NO whitelisted introspection methods gets no companion info class/function
+    /// (`gen_pyo3_error_methods_impl` returns an empty string and nothing is registered on the
+    /// native module for it), so `gen_init_py` must not invent one either.
+    #[test]
+    fn gen_init_py_omits_error_info_when_error_has_no_methods() {
+        use crate::core::ir::ErrorDef;
+
+        let mut api = empty_api();
+        api.errors.push(ErrorDef {
+            name: "PlainError".to_string(),
+            rust_path: "lib::PlainError".to_string(),
+            original_rust_path: String::new(),
+            variants: vec![],
+            doc: String::new(),
+            methods: vec![],
+            binding_excluded: false,
+            binding_exclusion_reason: None,
+            version: Default::default(),
+        });
+
+        let dto = DtoConfig::default();
+        let extra = std::collections::BTreeMap::new();
+        let caps = std::collections::HashMap::new();
+        let adapters = vec![];
+        let opaque = std::collections::HashMap::new();
+        let result = gen_init_py(
+            &api,
+            "_internal_bindings",
+            "1.2.3",
+            &dto,
+            &[],
+            &[],
+            &extra,
+            &caps,
+            &adapters,
+            &opaque,
+            &ahash::AHashSet::new(),
+        );
+
+        assert!(
+            !result.contains("plain_error_info"),
+            "no info function should exist for a method-less error:\n{result}",
+        );
+        assert!(
+            !result.contains("PlainErrorInfo"),
+            "no info class should exist for a method-less error:\n{result}",
         );
     }
 }

--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -334,6 +334,31 @@ pub fn gen_stubs(
         }
     }
 
+    // Companion `{Error}Info` class + `{error}_info` free function for each error with
+    // whitelisted introspection methods -- see `gen_init_py`'s matching block in
+    // `gen_bindings/errors.rs` for why these must be declared here too (they never flow
+    // through `api.functions`/`api.types`, so nothing else in this file would emit them).
+    {
+        let mut info_lines: Vec<String> = Vec::new();
+        for error in &api.errors {
+            if !crate::codegen::error_gen::pyo3_error_has_methods(error) {
+                continue;
+            }
+            let struct_name = crate::codegen::error_gen::pyo3_error_info_struct_name(error);
+            let fn_name = crate::codegen::error_gen::pyo3_error_info_fn_name(error);
+            info_lines.push(format!("class {struct_name}:"));
+            for (field, py_type) in crate::codegen::error_gen::pyo3_error_info_field_specs(error) {
+                info_lines.push(format!("    {field}: {py_type}"));
+            }
+            info_lines.push("".to_string());
+            info_lines.push(format!("def {fn_name}(err: Any) -> {struct_name}: ..."));
+        }
+        if !info_lines.is_empty() {
+            body_lines.extend(info_lines);
+            body_lines.push("".to_string());
+        }
+    }
+
     for func in api.functions.iter().filter(|f| !exclude_functions.contains(&f.name)) {
         body_lines.push(gen_function_stub(
             func,
@@ -643,6 +668,86 @@ module_name = "test_lib"
         assert!(
             !stub.contains("def from_json"),
             "unexpected from_json declaration:\n{stub}"
+        );
+    }
+
+    /// Regression (liter-llm E2E failures): the `.pyi` stub must declare the companion
+    /// `{Error}Info` class and `{error}_info` free function alongside every other symbol the
+    /// native module exports -- see the matching regression test in `gen_bindings/errors.rs`
+    /// for why these are otherwise invisible (they never flow through `api.functions`/
+    /// `api.types`).
+    #[test]
+    fn gen_stubs_declares_error_info_class_and_function() {
+        use crate::core::ir::{ErrorDef, MethodDef};
+
+        let api = ApiSurface {
+            errors: vec![ErrorDef {
+                name: "LiterLlmError".to_string(),
+                rust_path: "liter_llm::LiterLlmError".to_string(),
+                original_rust_path: String::new(),
+                variants: vec![],
+                doc: String::new(),
+                methods: vec![MethodDef {
+                    name: "status_code".to_string(),
+                    ..Default::default()
+                }],
+                binding_excluded: false,
+                binding_exclusion_reason: None,
+                version: Default::default(),
+            }],
+            ..Default::default()
+        };
+
+        let stub = gen_stubs(&api, &[], &python_config(), &ahash::AHashSet::default());
+
+        assert!(
+            stub.contains("class LiterLlmErrorInfo:"),
+            "missing LiterLlmErrorInfo class declaration:\n{stub}"
+        );
+        assert!(
+            stub.contains("    code: int"),
+            "missing code: int field:\n{stub}"
+        );
+        assert!(
+            stub.contains("    status_code: int"),
+            "missing status_code: int field:\n{stub}"
+        );
+        assert!(
+            stub.contains("def liter_llm_error_info(err: Any) -> LiterLlmErrorInfo: ..."),
+            "missing liter_llm_error_info function declaration:\n{stub}"
+        );
+    }
+
+    /// An error with no whitelisted introspection methods gets no companion info class or
+    /// function -- `gen_stubs` must not invent one either.
+    #[test]
+    fn gen_stubs_omits_error_info_when_error_has_no_methods() {
+        use crate::core::ir::ErrorDef;
+
+        let api = ApiSurface {
+            errors: vec![ErrorDef {
+                name: "PlainError".to_string(),
+                rust_path: "lib::PlainError".to_string(),
+                original_rust_path: String::new(),
+                variants: vec![],
+                doc: String::new(),
+                methods: vec![],
+                binding_excluded: false,
+                binding_exclusion_reason: None,
+                version: Default::default(),
+            }],
+            ..Default::default()
+        };
+
+        let stub = gen_stubs(&api, &[], &python_config(), &ahash::AHashSet::default());
+
+        assert!(
+            !stub.contains("PlainErrorInfo"),
+            "no info class should exist for a method-less error:\n{stub}"
+        );
+        assert!(
+            !stub.contains("plain_error_info"),
+            "no info function should exist for a method-less error:\n{stub}"
         );
     }
 }

--- a/src/codegen/error_gen.rs
+++ b/src/codegen/error_gen.rs
@@ -19,7 +19,8 @@ pub use native::{
 };
 pub use pyo3::{
     converter_fn_name, gen_pyo3_error_converter, gen_pyo3_error_methods_impl, gen_pyo3_error_registration,
-    gen_pyo3_error_types, pyo3_error_has_methods, pyo3_error_info_fn_name, pyo3_error_info_struct_name,
+    gen_pyo3_error_types, pyo3_error_has_methods, pyo3_error_info_field_specs, pyo3_error_info_fn_name,
+    pyo3_error_info_struct_name,
 };
 pub use shared::{acronym_aware_snake_phrase, python_exception_name, strip_thiserror_placeholders};
 

--- a/src/codegen/error_gen/pyo3.rs
+++ b/src/codegen/error_gen/pyo3.rs
@@ -121,6 +121,25 @@ pub fn converter_fn_name(error: &ErrorDef) -> String {
     format!("{}_to_py_err", to_snake_case(&error.name))
 }
 
+/// Field specs `(name, Python type annotation)` for the `{Error}Info` companion class,
+/// derived from `error.methods`. `code` is always present; the rest are whitelisted
+/// introspection methods the error type actually implements. Shared by
+/// `gen_pyo3_error_methods_impl` (the native `#[pyclass]`) and the pyo3 backend's `.pyi`
+/// stub generator so the two can never drift on which fields the info class exposes.
+pub fn pyo3_error_info_field_specs(error: &ErrorDef) -> Vec<(&'static str, &'static str)> {
+    let mut specs = vec![("code", "int")];
+    if error.methods.iter().any(|m| m.name == "status_code") {
+        specs.push(("status_code", "int"));
+    }
+    if error.methods.iter().any(|m| m.name == "is_transient") {
+        specs.push(("is_transient", "bool"));
+    }
+    if error.methods.iter().any(|m| m.name == "error_type") {
+        specs.push(("error_type", "str"));
+    }
+    specs
+}
+
 pub fn gen_pyo3_error_methods_impl(error: &ErrorDef) -> String {
     if error.methods.is_empty() {
         return String::new();
@@ -129,6 +148,10 @@ pub fn gen_pyo3_error_methods_impl(error: &ErrorDef) -> String {
     let struct_name = format!("{}Info", error.name);
     let snake_name = to_snake_case(&error.name);
     let fn_name = format!("{snake_name}_info");
+    let field_specs = pyo3_error_info_field_specs(error);
+    let has_status_code = field_specs.iter().any(|(name, _)| *name == "status_code");
+    let has_is_transient = field_specs.iter().any(|(name, _)| *name == "is_transient");
+    let has_error_type = field_specs.iter().any(|(name, _)| *name == "error_type");
 
     let mut fields = vec!["    pub code: u32,".to_string()];
     let mut getters = vec![
@@ -142,10 +165,6 @@ pub fn gen_pyo3_error_methods_impl(error: &ErrorDef) -> String {
         )
         .to_string(),
     ];
-
-    let has_status_code = error.methods.iter().any(|m| m.name == "status_code");
-    let has_is_transient = error.methods.iter().any(|m| m.name == "is_transient");
-    let has_error_type = error.methods.iter().any(|m| m.name == "error_type");
 
     if has_status_code {
         fields.push("    pub status_code: u16,".to_string());

--- a/src/e2e/codegen/python/test_function/error_assertions.rs
+++ b/src/e2e/codegen/python/test_function/error_assertions.rs
@@ -160,7 +160,13 @@ pub(super) fn emit_error_assertion(
 /// native module (`m.add_function(wrap_pyfunction!({info_fn}, m)?)?;` in
 /// `pyo3::gen_bindings::methods::gen_module_init`) — asked for by name via
 /// `pyo3_error_info_fn_name` rather than re-derived, so this can never spell a function the
-/// native module does not actually export.
+/// native module does not actually export. That guarantee covers the NAME only, not the
+/// MODULE: `native_module` here is whatever the caller passed (see `test_function.rs`'s
+/// `from_json_module` resolution), which for a body-less call falls back to the public facade
+/// package, not the native extension module. `gen_init_py` (`gen_bindings/errors.rs`) now
+/// re-exports every `pyo3_error_info_fn_name`/`pyo3_error_info_struct_name` pair from the
+/// facade too, so both resolutions work — but if that re-export ever regresses, this function
+/// would silently render an assertion against a name the target module does not carry.
 fn emit_resolved_error_field_assertions(
     out: &mut String,
     resolved_fields: &[ResolvedErrorField<'_>],


### PR DESCRIPTION
Clears liter-llm's `E2E (python)` leg — 7 failures across `test_batches.py`, `test_files.py`, `test_list_models.py` and `test_responses.py`, all `AttributeError: module 'liter_llm' has no attribute 'liter_llm_error_info'`.

The native module registers both the `{Error}Info` pyclass and the `{error}_info` free function, but the generated `__init__.py` published a curated re-export list that omitted both. A generated e2e error assertion qualifies against `from_json_module` when a call sets one and falls back to the public facade when it does not — so every body-less call reached for a name the facade never exported. That predicts the failure set exactly: each failing file is a body-less call whose python override omits `from_json_module`.

Of the two possible fixes — make the facade honest, or make the e2e reach past it — this takes the first. The re-export list, `__all__` and the `.pyi` stub now all carry the error-info companions, so the public package describes what the native module actually exposes.

Note the doc at `error_assertions.rs:157-163` claimed this construction "can never spell a function the native module does not actually export" — true of the function *name*, silent about the *module*, which is where the miss was. Updated.

`cargo test --lib` 11862 passed / 0 failed on the rebase.