### PR TITLE
fix(wasm): take typed wrappers for parameters that have them, not JsValue

### DIFF
--- a/src/backends/wasm/gen_bindings/functions/async_wrappers.rs
+++ b/src/backends/wasm/gen_bindings/functions/async_wrappers.rs
@@ -30,12 +30,27 @@ pub(super) fn gen_async_free_function(
             .iter()
             .map(|p| match &p.ty {
                 TypeRef::Named(name) if !opaque_types.contains(name.as_str()) => {
-                    let mapped_ty = if p.optional {
-                        "Option<JsValue>".to_string()
+                    let wasm_ty = mapper.map_type(&p.ty);
+                    if crate::codegen::shared::maps_to_js_value(&wasm_ty) {
+                        let mapped_ty = if p.optional {
+                            "Option<JsValue>".to_string()
+                        } else {
+                            "JsValue".to_string()
+                        };
+                        format!("{}: {}", p.name, mapped_ty)
                     } else {
-                        "JsValue".to_string()
-                    };
-                    format!("{}: {}", p.name, mapped_ty)
+                        // A dedicated `#[wasm_bindgen]` wrapper exists for this type (with a
+                        // `From<Wasm{name}>` conversion into the core type), so the parameter
+                        // takes the typed wrapper instead of a round-trip through
+                        // `serde_wasm_bindgen::from_value`. That round-trip deserializes by
+                        // asking the JS object for each of the core type's *snake_case* serde
+                        // field names, which never matches the camelCase getters wasm-bindgen
+                        // emits for the wrapper's own fields — every multi-word field silently
+                        // falls back to its serde default. `Option<...>` regardless of
+                        // `p.optional` preserves the existing "omit -> use default" ergonomics,
+                        // mirrored in the binding body below. ~keep
+                        format!("{}: Option<{}>", p.name, wasm_ty)
+                    }
                 }
                 _ => {
                     let ty = mapper.map_type(&p.ty);
@@ -54,25 +69,49 @@ pub(super) fn gen_async_free_function(
             if let TypeRef::Named(name) = &p.ty {
                 if !opaque_types.contains(name.as_str()) {
                     let core_path = format!("{}::{}", core_import, name);
-                    let err_conv = ".map_err(|e| JsValue::from_str(&e.to_string()))";
-                    if p.optional {
+                    let wasm_ty = mapper.map_type(&p.ty);
+                    if crate::codegen::shared::maps_to_js_value(&wasm_ty) {
+                        let err_conv = ".map_err(|e| JsValue::from_str(&e.to_string()))";
+                        if p.optional {
+                            serde_bindings.push_str(&crate::backends::wasm::template_env::render(
+                                "serde_named_optional",
+                                minijinja::context! {
+                                    param_name => &p.name,
+                                    core_path => &core_path,
+                                    err_conv => &err_conv,
+                                },
+                            ));
+                            serde_bindings.push_str("    ");
+                        } else {
+                            let has_default = type_has_default(name, api);
+                            serde_bindings.push_str(&crate::backends::wasm::template_env::render(
+                                "serde_named_required",
+                                minijinja::context! {
+                                    param_name => &p.name,
+                                    core_path => &core_path,
+                                    err_conv => &err_conv,
+                                    has_default => has_default,
+                                    is_mut => p.is_mut,
+                                },
+                            ));
+                            serde_bindings.push_str("    ");
+                        }
+                    } else if p.optional {
                         serde_bindings.push_str(&crate::backends::wasm::template_env::render(
-                            "serde_named_optional",
+                            "wasm_typed_named_optional",
                             minijinja::context! {
                                 param_name => &p.name,
                                 core_path => &core_path,
-                                err_conv => &err_conv,
                             },
                         ));
                         serde_bindings.push_str("    ");
                     } else {
                         let has_default = type_has_default(name, api);
                         serde_bindings.push_str(&crate::backends::wasm::template_env::render(
-                            "serde_named_required",
+                            "wasm_typed_named_required",
                             minijinja::context! {
                                 param_name => &p.name,
                                 core_path => &core_path,
-                                err_conv => &err_conv,
                                 has_default => has_default,
                                 is_mut => p.is_mut,
                             },

--- a/src/backends/wasm/gen_bindings/functions/tests.rs
+++ b/src/backends/wasm/gen_bindings/functions/tests.rs
@@ -654,3 +654,129 @@ fn async_free_function_returning_wrapper_mapped_type_keeps_from() {
         "a wrapper-mapped return must not detour through serde:\n{out}"
     );
 }
+
+/// Regression for the `extract`/`extract_batch`/`map_url` config-marshalling defect: a single
+/// `Named` async parameter backed by a generated `#[wasm_bindgen]` wrapper (i.e. the mapper does
+/// not redirect it to the opaque `JsValue`) must take the typed wrapper and `.into()` it, exactly
+/// like the sibling `Vec<Named>` path already does for `actions`/`inputs`. Routing it through
+/// `serde_wasm_bindgen::from_value::<CoreType>` instead is the bug: that walks the *core* struct's
+/// snake_case serde field names against the wasm-bindgen wrapper's camelCase getters, so every
+/// multi-word field misses and silently falls back to its serde default.
+#[test]
+fn async_named_param_with_wrapper_takes_typed_option_and_into() {
+    let mapper = WasmMapper::new(HashMap::new(), "Wasm".to_string());
+    let func = async_function(vec![param("config", TypeRef::Named("ExtractionConfig".to_string()))]);
+    let api = crate::core::ir::ApiSurface {
+        types: vec![crate::core::ir::TypeDef {
+            name: "ExtractionConfig".to_string(),
+            has_default: true,
+            ..Default::default()
+        }],
+        ..empty_surface()
+    };
+
+    let out = gen_function_with_emitted_dtos(
+        &func,
+        &mapper,
+        "sample_fixture",
+        &AHashSet::new(),
+        "Wasm",
+        &AHashSet::new(),
+        &api,
+        &AHashSet::new(),
+    );
+
+    assert!(
+        out.contains("config: Option<WasmExtractionConfig>"),
+        "a wrapper-backed Named param must take the typed wrapper, not JsValue:\n{out}"
+    );
+    assert!(
+        out.contains(
+            "let config_core: sample_fixture::ExtractionConfig = config.map(Into::into).unwrap_or_default();"
+        ),
+        "omitting the param must still fall back to the core type's Default:\n{out}"
+    );
+    assert!(
+        !out.contains("serde_wasm_bindgen::from_value::<sample_fixture::ExtractionConfig>"),
+        "must not round-trip a wrapper-backed type through serde_wasm_bindgen:\n{out}"
+    );
+}
+
+/// Same fixture, but the param is IR-optional. The Rust parameter type stays `Option<Wasm...>`
+/// either way (that's what lets an omitted argument still resolve to the core Default above); what
+/// changes is the binding, which keeps `None` as `None` instead of substituting a default.
+#[test]
+fn async_named_optional_param_with_wrapper_maps_into_option() {
+    let mapper = WasmMapper::new(HashMap::new(), "Wasm".to_string());
+    let func = async_function(vec![ParamDef {
+        optional: true,
+        ..param("config", TypeRef::Named("ExtractionConfig".to_string()))
+    }]);
+    let api = crate::core::ir::ApiSurface {
+        types: vec![crate::core::ir::TypeDef {
+            name: "ExtractionConfig".to_string(),
+            has_default: true,
+            ..Default::default()
+        }],
+        ..empty_surface()
+    };
+
+    let out = gen_function_with_emitted_dtos(
+        &func,
+        &mapper,
+        "sample_fixture",
+        &AHashSet::new(),
+        "Wasm",
+        &AHashSet::new(),
+        &api,
+        &AHashSet::new(),
+    );
+
+    assert!(
+        out.contains("config: Option<WasmExtractionConfig>"),
+        "an optional wrapper-backed Named param must still take the typed wrapper:\n{out}"
+    );
+    assert!(
+        out.contains("let config_core: Option<sample_fixture::ExtractionConfig> = config.map(Into::into);"),
+        "an optional param must map into an Option without a Default substitution:\n{out}"
+    );
+}
+
+/// Negative control: when a `wasm.type_overrides` entry redirects this Named type to the opaque
+/// `JsValue` (no generated wrapper exists to convert from), the original serde round-trip is the
+/// only route available and must be preserved.
+#[test]
+fn async_named_param_overridden_to_js_value_keeps_serde_round_trip() {
+    let mut overrides = HashMap::new();
+    overrides.insert("ExtractionConfig".to_string(), "JsValue".to_string());
+    let mapper = WasmMapper::new(overrides, "Wasm".to_string());
+    let func = async_function(vec![param("config", TypeRef::Named("ExtractionConfig".to_string()))]);
+    let api = crate::core::ir::ApiSurface {
+        types: vec![crate::core::ir::TypeDef {
+            name: "ExtractionConfig".to_string(),
+            has_default: true,
+            ..Default::default()
+        }],
+        ..empty_surface()
+    };
+
+    let out = gen_function_with_emitted_dtos(
+        &func,
+        &mapper,
+        "sample_fixture",
+        &AHashSet::new(),
+        "Wasm",
+        &AHashSet::new(),
+        &api,
+        &AHashSet::new(),
+    );
+
+    assert!(
+        out.contains("config: JsValue"),
+        "a JsValue-overridden Named param must keep the JsValue signature:\n{out}"
+    );
+    assert!(
+        out.contains("serde_wasm_bindgen::from_value::<sample_fixture::ExtractionConfig>(config)"),
+        "with no generated wrapper to convert from, the serde round-trip is the only route:\n{out}"
+    );
+}

--- a/src/backends/wasm/template_env.rs
+++ b/src/backends/wasm/template_env.rs
@@ -85,6 +85,14 @@ static TEMPLATES: &[(&str, &str)] = &[
         include_str!("templates/serde_named_required.jinja"),
     ),
     (
+        "wasm_typed_named_optional",
+        include_str!("templates/wasm_typed_named_optional.jinja"),
+    ),
+    (
+        "wasm_typed_named_required",
+        include_str!("templates/wasm_typed_named_required.jinja"),
+    ),
+    (
         "serde_vec_named_optional",
         include_str!("templates/serde_vec_named_optional.jinja"),
     ),

--- a/src/backends/wasm/templates/wasm_typed_named_optional.jinja
+++ b/src/backends/wasm/templates/wasm_typed_named_optional.jinja
@@ -1,0 +1,1 @@
+let {{ param_name }}_core: Option<{{ core_path }}> = {{ param_name }}.map(Into::into);

--- a/src/backends/wasm/templates/wasm_typed_named_required.jinja
+++ b/src/backends/wasm/templates/wasm_typed_named_required.jinja
@@ -1,0 +1,1 @@
+let {% if is_mut %}mut {% endif %}{{ param_name }}_core: {{ core_path }} = {% if has_default %}{{ param_name }}.map(Into::into).unwrap_or_default(){% else %}{{ param_name }}.map(Into::into).ok_or_else(|| JsValue::from_str("{{ param_name }} is required"))?{% endif %};


### PR DESCRIPTION
The single highest-yield fix in this release: roughly 40 of xberg's 45 failing `E2E (wasm)` tests, one cause. Found by the xberg 0.82.1 audit; I verified every load-bearing claim against the generated file before routing it.

A wasm entry point whose parameter has a dedicated `#[wasm_bindgen]` wrapper took `JsValue` and round-tripped through `serde_wasm_bindgen::from_value`. That deserializes by asking the JS object for each of the **core type's snake_case serde field names**, which never match the **camelCase getters wasm-bindgen emits** for the wrapper. Every multi-word field silently fell back to its serde default; single-word fields matched, so the walk descended far enough to look plausible and lost the leaves.

Two properties made it worse than an ordinary marshalling bug:

- **`deny_unknown_fields` cannot catch it.** `ExtractionConfig` carries the attribute, and you would expect a wasm-bindgen object to trip it on `__wbg_ptr`. It does not — serde never enumerates the object's own keys, so deserialization *succeeds* and returns an all-defaults config.
- **The correct values existed and were destroyed in transit.** The JS side held them; they were gone by the time Rust saw them.

That explains `denied by SSRF policy: loopback` against a loopback fixture, `output_format_bytes_markdown` receiving `plain`, `code_shebang_detection` getting `text/plain`, and four `error_*` tests resolving instead of rejecting.

The typed path was already proven **in the same signature**: `extract_batch` took `Vec<WasmExtractInput>` and mapped `Into::into` while its `config` argument did not. This makes the rest consistent with it, gated on `maps_to_js_value` so only types with a real wrapper and `From` impl change.

Also confirmed present in liter-llm (`refresh_catalog`), and absent from crawlberg, tree-sitter-language-pack and html-to-markdown — good negative controls.

`cargo test --lib` 11862 passed / 0 failed.