### PR TITLE
fix(codegen): keep serde defaults on mirror fields, deref optional go numerics

### DIFF
--- a/src/backends/go/emission_facts.rs
+++ b/src/backends/go/emission_facts.rs
@@ -10,6 +10,15 @@ pub(crate) struct GoEmissionFacts<'a> {
     pub(crate) unit_enums: HashSet<&'a str>,
     pub(crate) passthrough_enums: HashSet<&'a str>,
     pub(crate) data_enums: HashSet<&'a str>,
+    /// Enums [`super::go_enum_representation`] classifies as
+    /// [`super::GoEnumRepresentation::ExternallyTaggedStruct`] -- `gen_externally_tagged_union_type`
+    /// emits one struct field per variant, unconditionally typed `*<payload struct>` (every
+    /// variant but the active one is absent, so every field must tolerate nil). Recorded here so
+    /// `e2e::field_access::ir_result_fields` can extend its owner/field walk across a tagged-union
+    /// projection like `format.excel` with the SAME authority a literal struct field gets, instead
+    /// of guessing: the pointer-ness is a fact this backend's own generator template always
+    /// produces, not an inference over incomplete information. ~keep
+    pub(crate) externally_tagged_struct_enums: HashSet<&'a str>,
 }
 
 impl<'a> GoEmissionFacts<'a> {
@@ -60,6 +69,13 @@ impl<'a> GoEmissionFacts<'a> {
             data_enums: emitted_enums
                 .iter()
                 .filter(|definition| super::is_data_interface_struct_field_enum(definition))
+                .map(|definition| definition.name.as_str())
+                .collect(),
+            externally_tagged_struct_enums: emitted_enums
+                .iter()
+                .filter(|definition| {
+                    super::go_enum_representation(definition) == super::GoEnumRepresentation::ExternallyTaggedStruct
+                })
                 .map(|definition| definition.name.as_str())
                 .collect(),
         }

--- a/src/codegen/generators/structs.rs
+++ b/src/codegen/generators/structs.rs
@@ -93,6 +93,34 @@ pub fn struct_wants_deserialize_delegation(
         && struct_deserialize_delegation_field_sound(typ, opaque_type_names, serializable_opaque_type_names)
 }
 
+/// Render `field.default` (the core field's `#[serde(default)]` / `#[serde(default = "path")]`,
+/// see [`FieldDef::default`]) back into the literal attribute text for the mirror field, for use
+/// when whole-type `Deserialize` delegation does not fire (see [`struct_wants_deserialize_delegation`]
+/// and [`should_delegate_deserialize`]).
+///
+/// Delegation is all-or-nothing per type: one unsound field (an unwrapped opaque, a
+/// non-`Cow` sanitized field, a cfg-gated field) blocks it for the *entire* struct, including
+/// every other field that has nothing to do with the unsound one. Without this fallback, such a
+/// struct's derived, field-by-field `Deserialize` makes an absent-tolerant core field required on
+/// the mirror, rejecting a partial JSON payload the core type itself accepts (the same failure
+/// mode delegation exists to prevent, just not caught by it in this case). Mirroring the literal
+/// attribute here keeps that one field absent-tolerant even though the struct as a whole still
+/// uses the derived impl.
+///
+/// `extract_field` (see `extract::extractor::helpers::fields`) records a bare `#[serde(default)]`
+/// as the `"/* serde(default) */"` sentinel (not valid attribute syntax on its own -- it is a
+/// marker other call sites already match on verbatim, e.g. `backends::pyo3::gen_bindings::constructors`
+/// and `backends::pyo3::gen_bindings::functions::converters`) and `#[serde(default = "path")]` as
+/// the literal `"serde(default = \"path\")"` attribute text. Returns `None` when the core field
+/// carries no serde default. ~keep
+fn serde_default_field_attr(field: &crate::core::ir::FieldDef) -> Option<String> {
+    match field.default.as_deref() {
+        Some("/* serde(default) */") => Some("serde(default)".to_string()),
+        Some(text) if text.starts_with("serde(default") => Some(text.to_string()),
+        _ => None,
+    }
+}
+
 /// Compose the fully-qualified core type path for `typ`: applies crate remaps when
 /// `rust_path` already carries a module path, or falls back to `{core_import}::{name}` for a
 /// bare (unqualified) path. Shared by [`gen_delegating_default_impl`] and
@@ -300,6 +328,14 @@ pub fn gen_struct_with_per_field_attrs(
         {
             attrs.push("serde(skip)".to_string());
         }
+        // Whole-type delegation didn't fire for `typ` (or wasn't requested for it) -- mirror
+        // this field's own `#[serde(default)]` directly so it stays absent-tolerant even under
+        // the derived, field-by-field `Deserialize`. See `serde_default_field_attr`.
+        if has_serde && !delegate_deserialize && !attrs.iter().any(|a| a == "serde(skip)")
+            && let Some(default_attr) = serde_default_field_attr(field)
+        {
+            attrs.push(default_attr);
+        }
         sb.add_field_with_doc(&field.name, &ty, attrs, &sanitize_field_doc(&field.doc));
     }
     let mut result = sb.build();
@@ -423,6 +459,14 @@ pub fn gen_struct_with_rename(
         {
             attrs.push(format!("serde(rename = \"{rename}\")"));
         }
+        // Whole-type delegation didn't fire for `typ` (or wasn't requested for it) -- mirror
+        // this field's own `#[serde(default)]` directly so it stays absent-tolerant even under
+        // the derived, field-by-field `Deserialize`. See `serde_default_field_attr`.
+        if has_serde && !delegate_deserialize && !attrs.iter().any(|a| a == "serde(skip)")
+            && let Some(default_attr) = serde_default_field_attr(field)
+        {
+            attrs.push(default_attr);
+        }
         let emit_name = name_override.unwrap_or_else(|| field.name.clone());
         sb.add_field_with_doc(&emit_name, &ty, attrs, &sanitize_field_doc(&field.doc));
     }
@@ -513,6 +557,14 @@ pub fn gen_struct(typ: &TypeDef, mapper: &dyn TypeMapper, cfg: &RustBindingConfi
         let emit_name = crate::core::keywords::rust_raw_ident(&field.name);
         if emit_name != field.name && !attrs.iter().any(|a| a.starts_with("serde(rename")) {
             attrs.push(format!("serde(rename = \"{}\")", field.name));
+        }
+        // Whole-type delegation didn't fire for `typ` (or wasn't requested for it) -- mirror
+        // this field's own `#[serde(default)]` directly so it stays absent-tolerant even under
+        // the derived, field-by-field `Deserialize`. See `serde_default_field_attr`.
+        if !delegate_deserialize
+            && let Some(default_attr) = serde_default_field_attr(field)
+        {
+            attrs.push(default_attr);
         }
         sb.add_field_with_doc(&emit_name, &ty, attrs, &sanitize_field_doc(&field.doc));
     }

--- a/src/codegen/generators/structs/tests.rs
+++ b/src/codegen/generators/structs/tests.rs
@@ -530,6 +530,96 @@ fn gen_struct_bare_delegates_for_container_level_serde_default() {
     );
 }
 
+// --- Per-field `#[serde(default)]` fallback when whole-type delegation cannot fire ------------
+//
+// Regression coverage for the `ExtractionConfig` bug: the core struct had one field
+// (`mime_detection_policy`) carrying a bare `#[serde(default)]`, and a *different*, unrelated
+// field referencing an opaque handle type (`ocr: Option<OcrConfig>`, mapped via `#[serde(skip)]`
+// on the mirror). `struct_deserialize_delegation_field_sound` correctly refuses whole-type
+// delegation because of the unrelated opaque field, which used to mean `mime_detection_policy`
+// silently lost its `#[serde(default)]` too -- `ExtractionConfig.from_json("{}")` raised
+// `ValueError: missing field 'mime_detection_policy'` even though the core type accepted the
+// omission. These tests build the same shape (one opaque-blocked field, one sibling with a bare
+// serde default) for each of the three struct generators and assert the sibling still gets
+// `#[serde(default)]` on the derived, field-by-field `Deserialize` mirror.
+
+fn opaque_field(name: &str) -> FieldDef {
+    plain_field(name, TypeRef::Named("OpaqueHandle".to_string()))
+}
+
+#[test]
+fn gen_struct_with_per_field_attrs_mirrors_serde_default_when_delegation_blocked_by_sibling_field() {
+    let typ = type_with_fields(
+        "ExtractionConfig",
+        vec![opaque_field("ocr"), field_with_serde_default("mime_detection_policy")],
+        Default::default(),
+    );
+    let delegatable: AHashSet<String> = ["ExtractionConfig".to_string()].into_iter().collect();
+    let opaque = vec!["OpaqueHandle".to_string()];
+    let cfg = RustBindingConfig {
+        delegate_deserialize_to_core_for_types: Some(&delegatable),
+        opaque_type_names: &opaque,
+        ..base_cfg()
+    };
+    let rendered = gen_struct_with_per_field_attrs(&typ, &IdentityMapper, &cfg, |_| vec![]);
+
+    assert!(
+        derive_line(&rendered).contains("serde::Deserialize"),
+        "delegation must NOT fire while an unrelated field is opaque-blocked: {rendered}"
+    );
+    assert!(
+        !rendered.contains("impl<'de> serde::Deserialize<'de> for ExtractionConfig {"),
+        "no delegating impl expected: {rendered}"
+    );
+    assert!(
+        rendered.contains("#[serde(default)]") && rendered.contains("pub mime_detection_policy"),
+        "the sibling field must keep its own serde(default) on the derived mirror: {rendered}"
+    );
+}
+
+#[test]
+fn gen_struct_with_rename_mirrors_serde_default_when_delegation_blocked_by_sibling_field() {
+    let typ = type_with_fields(
+        "ExtractionConfig",
+        vec![opaque_field("ocr"), field_with_serde_default("mime_detection_policy")],
+        Default::default(),
+    );
+    let delegatable: AHashSet<String> = ["ExtractionConfig".to_string()].into_iter().collect();
+    let opaque = vec!["OpaqueHandle".to_string()];
+    let cfg = RustBindingConfig {
+        delegate_deserialize_to_core_for_types: Some(&delegatable),
+        opaque_type_names: &opaque,
+        ..base_cfg()
+    };
+    let rendered = gen_struct_with_rename(&typ, &IdentityMapper, &cfg, |_| vec![], |_| None);
+
+    assert!(
+        derive_line(&rendered).contains("serde::Deserialize"),
+        "delegation must NOT fire while an unrelated field is opaque-blocked: {rendered}"
+    );
+    assert!(
+        rendered.contains("#[serde(default)]") && rendered.contains("pub mime_detection_policy"),
+        "the sibling field must keep its own serde(default) on the derived mirror: {rendered}"
+    );
+}
+
+#[test]
+fn gen_struct_bare_mirrors_serde_default_path_when_delegation_not_requested() {
+    let mut field = f64_field("retries");
+    field.default = Some("serde(default = \"default_retries\")".to_string());
+    let typ = type_with_fields("Retry", vec![field], Default::default());
+    // No `delegate_deserialize_to_core_for_types` entry for "Retry" -- delegation is never even
+    // attempted for this type in this run.
+    let cfg = base_cfg();
+    let rendered = gen_struct(&typ, &IdentityMapper, &cfg);
+
+    assert!(derive_line(&rendered).contains("serde::Deserialize"), "{rendered}");
+    assert!(
+        rendered.contains("serde(default = \"default_retries\")"),
+        "a `default = \"path\"` field must also be mirrored verbatim: {rendered}"
+    );
+}
+
 #[test]
 fn gen_struct_with_rename_delegates_for_field_with_serde_with_codec() {
     let mut field = f64_field("elapsed");

--- a/src/e2e/codegen/go/test_function/call_resolver.rs
+++ b/src/e2e/codegen/go/test_function/call_resolver.rs
@@ -27,7 +27,7 @@ impl GoCrateResolverFacts {
         let (ir_reachable_fields, ir_known_excluded_fields, ir_optional_fields) =
             FieldResolver::ir_field_sets(type_defs);
         let emission = crate::backends::go::emission_facts::GoEmissionFacts::from_config(type_defs, enums, config);
-        let ir_result_fields = FieldResolver::go_ir_result_field_facts_from_emission(type_defs, &emission);
+        let ir_result_fields = FieldResolver::go_ir_result_field_facts_from_emission(type_defs, enums, &emission);
         let ir_collection_fields = FieldResolver::ir_collection_fields(type_defs);
         let reserved_type_names = emission
             .structs

--- a/src/e2e/field_access/ir_result_fields.rs
+++ b/src/e2e/field_access/ir_result_fields.rs
@@ -83,11 +83,12 @@ pub(super) fn build_ir_result_field_map_with_enums(
     rule: OptionalityRule,
 ) -> IrResultFieldMap {
     let emitted = GoEmissionFacts::new(type_defs, enums, HashSet::new(), HashSet::new());
-    build_go_ir_result_field_map(type_defs, rule, &emitted)
+    build_go_ir_result_field_map(type_defs, enums, rule, &emitted)
 }
 
 pub(super) fn build_go_ir_result_field_map(
     type_defs: &[TypeDef],
+    enums: &[EnumDef],
     rule: OptionalityRule,
     emitted: &GoEmissionFacts<'_>,
 ) -> IrResultFieldMap {
@@ -96,6 +97,7 @@ pub(super) fn build_go_ir_result_field_map(
         enums: &emitted.unit_enums,
         passthrough_enums: &emitted.passthrough_enums,
         data_enums: &emitted.data_enums,
+        externally_tagged_struct_enums: &emitted.externally_tagged_struct_enums,
     };
     let mut map = IrResultFieldMap::default();
     for type_def in type_defs
@@ -106,7 +108,56 @@ pub(super) fn build_go_ir_result_field_map(
             record_ir_result_field(&mut map, type_def, field, rule, &names);
         }
     }
+    for enum_def in enums
+        .iter()
+        .filter(|definition| emitted.externally_tagged_struct_enums.contains(definition.name.as_str()))
+    {
+        record_externally_tagged_enum_variants(&mut map, enum_def, names.structs);
+    }
     map
+}
+
+/// Extend the map across an `ExternallyTaggedStruct` enum's variant boundary the same way a
+/// literal struct field does -- see [`GoEmissionFacts::externally_tagged_struct_enums`].
+///
+/// Mirrors `backends::go::gen_bindings::types::enums::gen_externally_tagged_union_type`'s own
+/// iteration exactly (`variant.fields.first()` narrowed to `TypeRef::Named`, keyed by
+/// `wire_variant_value`) so the two can never name a different field for the same variant.
+/// Every recorded field is unconditionally a pointer: that generator emits `*<payload>` for
+/// every variant field, not just some, because at most one variant is ever populated -- this is
+/// the Go template's own fact, not an inference over an unresolved field. ~keep
+fn record_externally_tagged_enum_variants(map: &mut IrResultFieldMap, enum_def: &EnumDef, struct_names: &HashSet<&str>) {
+    for variant in &enum_def.variants {
+        let Some(field) = variant.fields.first() else {
+            continue;
+        };
+        let TypeRef::Named(struct_type_name) = &field.ty else {
+            continue;
+        };
+        let wire_name = crate::codegen::naming::wire_variant_value(
+            &variant.name,
+            variant.serde_rename.as_deref(),
+            enum_def.serde_rename_all.as_deref(),
+        );
+        map.declared_fields
+            .entry(enum_def.name.clone())
+            .or_default()
+            .insert(wire_name.clone());
+        map.pointer_fields
+            .entry(enum_def.name.clone())
+            .or_default()
+            .insert(wire_name.clone());
+        map.optional_fields
+            .entry(enum_def.name.clone())
+            .or_default()
+            .insert(wire_name.clone());
+        if struct_names.contains(struct_type_name.as_str()) {
+            map.field_types
+                .entry(enum_def.name.clone())
+                .or_default()
+                .insert(wire_name, struct_type_name.clone());
+        }
+    }
 }
 
 struct GoFieldTypeNames<'a> {
@@ -114,6 +165,7 @@ struct GoFieldTypeNames<'a> {
     enums: &'a HashSet<&'a str>,
     passthrough_enums: &'a HashSet<&'a str>,
     data_enums: &'a HashSet<&'a str>,
+    externally_tagged_struct_enums: &'a HashSet<&'a str>,
 }
 
 fn record_ir_result_field(
@@ -153,15 +205,10 @@ fn record_ir_result_field(
             .or_default()
             .insert(field.name.clone());
     }
-    record_ir_result_field_kind(map, type_def, field, names.structs);
+    record_ir_result_field_kind(map, type_def, field, names);
 }
 
-fn record_ir_result_field_kind(
-    map: &mut IrResultFieldMap,
-    type_def: &TypeDef,
-    field: &FieldDef,
-    struct_names: &HashSet<&str>,
-) {
+fn record_ir_result_field_kind(map: &mut IrResultFieldMap, type_def: &TypeDef, field: &FieldDef, names: &GoFieldTypeNames<'_>) {
     if type_ref_is_display_safe(&field.ty) {
         map.display_safe_fields
             .entry(type_def.name.clone())
@@ -171,7 +218,11 @@ fn record_ir_result_field_kind(
     let Some(named) = named_type(&field.ty) else {
         return;
     };
-    let target = if struct_names.contains(named) {
+    // A field typed as an `ExternallyTaggedStruct` enum also advances the walk: its own
+    // variants are recorded as this enum's pseudo-fields by `record_externally_tagged_enum_variants`,
+    // so a path like `metadata.format.excel` can cross `format` the same way it crosses any
+    // literal struct field, instead of stopping at `path_crosses_unwalkable_field`.
+    let target = if names.structs.contains(named) || names.externally_tagged_struct_enums.contains(named) {
         &mut map.field_types
     } else {
         map.unresolvable_named_fields

--- a/src/e2e/field_access/resolver/construct.rs
+++ b/src/e2e/field_access/resolver/construct.rs
@@ -548,14 +548,20 @@ impl FieldResolver {
             excluded_names.clone(),
             HashSet::new(),
         );
-        super::super::ir_result_fields::build_go_ir_result_field_map(type_defs, OptionalityRule::DeclaredType, &emitted)
+        super::super::ir_result_fields::build_go_ir_result_field_map(
+            type_defs,
+            enums,
+            OptionalityRule::DeclaredType,
+            &emitted,
+        )
     }
 
     pub(crate) fn go_ir_result_field_facts_from_emission(
         type_defs: &[crate::core::ir::TypeDef],
+        enums: &[crate::core::ir::EnumDef],
         emitted: &crate::backends::go::emission_facts::GoEmissionFacts<'_>,
     ) -> IrResultFieldMap {
-        super::super::ir_result_fields::build_go_ir_result_field_map(type_defs, OptionalityRule::DeclaredType, emitted)
+        super::super::ir_result_fields::build_go_ir_result_field_map(type_defs, enums, OptionalityRule::DeclaredType, emitted)
     }
 
     /// Attach IR field facts anchored at `root_type` — the IR type name the call's declared


### PR DESCRIPTION
Two defects from the xberg audit.

**`#[serde(default)]` was dropped from mirror DTOs.** A core field carrying the attribute produced a mirror field without it whenever whole-type `Deserialize` delegation did not fire — and delegation is all-or-nothing per type, so a single unsound field (an unwrapped opaque, a non-`Cow` sanitized field, a cfg-gated field) blocks it for the entire struct, including every field with nothing to do with the unsound one. The result: an absent-tolerant core field became required on the mirror, and `ExtractionConfig.from_json("{}")` raised `missing field 'mime_detection_policy'` where the core type accepts the omission.

That field also carries `alef(since = "1.1.0")`, which is precisely the case where dropping the default breaks callers whose JSON predates the field — so this would bite every future `since`-added field, not just this one.

**Go null-checked an optional numeric then compared the pointer.** `if x.SheetCount != nil { if x.SheetCount < 2 {` — `invalid operation: mismatched types *uint32 and untyped int`. The emitter knew the field was optional (it emitted the guard) and then compared the pointer itself. The pointer-ness of an externally-tagged union's variant fields is now recorded as an emission fact the go generator always produces, so the field-access walk crosses a projection like `format.excel` with the same authority a literal struct field gets rather than inferring it.

`cargo test --lib` 11866 passed / 0 failed.