### PR TITLE
fix(kotlin): materialise required constructor params and map Duration in e2e fixtures

### DIFF
--- a/src/backends/kotlin/gen_bindings/mod.rs
+++ b/src/backends/kotlin/gen_bindings/mod.rs
@@ -20,7 +20,7 @@ use crate::core::ir::{ApiSurface, EnumDef, ErrorDef, FunctionDef, MethodDef, Par
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-pub(crate) use object_wrapper::default_constructible_type_names;
+pub(crate) use object_wrapper::{default_constructible_type_names, kotlin_field_default};
 pub use shared::{
     ValueMethodBridge, escape_kotlin_ident, kotlin_field_name, kotlin_field_name_with_type, to_lower_camel,
     to_lower_camel_unescaped, to_pascal_case, to_screaming_snake,

--- a/src/backends/kotlin/gen_bindings/object_wrapper.rs
+++ b/src/backends/kotlin/gen_bindings/object_wrapper.rs
@@ -31,4 +31,4 @@ pub(crate) use dto::emit_type_with_imports;
 pub(crate) use enums::emit_enum;
 pub(crate) use errors::emit_error_type_with_imports;
 pub(crate) use methods::{emit_function, format_param_with_imports};
-pub(crate) use types::{default_constructible_type_names, kotlin_type_with_string_imports};
+pub(crate) use types::{default_constructible_type_names, kotlin_field_default, kotlin_type_with_string_imports};

--- a/src/backends/kotlin/gen_bindings/object_wrapper/types.rs
+++ b/src/backends/kotlin/gen_bindings/object_wrapper/types.rs
@@ -90,7 +90,7 @@ fn render_type_ref_with_string_imports(ty: &TypeRef, imports: &mut BTreeSet<Stri
 /// optional fields with default values, and feature-gated fields. Without a
 /// Kotlin-side default the deserialization fails with
 /// `MissingKotlinParameterException`.
-pub(super) fn kotlin_field_default(
+pub(crate) fn kotlin_field_default(
     ty: &TypeRef,
     optional: bool,
     typed_default: Option<&crate::core::ir::DefaultValue>,

--- a/src/backends/kotlin/mod.rs
+++ b/src/backends/kotlin/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod type_map;
 
 pub use gen_bindings::KotlinBackend;
 
-pub(crate) use gen_bindings::default_constructible_type_names;
+pub(crate) use gen_bindings::{default_constructible_type_names, kotlin_field_default};
 pub use gen_bindings::{
     ValueMethodBridge, emit_enum_pub, emit_error_type_pub, emit_function_jvm, emit_jvm_client_class,
     emit_jvm_client_class_with_package, emit_kdoc_pub, emit_type_pub,

--- a/src/e2e/codegen/kotlin/args.rs
+++ b/src/e2e/codegen/kotlin/args.rs
@@ -57,6 +57,17 @@ pub(super) struct KotlinArgsContext<'a> {
     pub(super) target_params: TargetParams<'a>,
 }
 
+/// Everything `normalize_typed_json`'s `kotlin_android_style` field-filling needs to decide
+/// whether a bare constructor parameter can be honestly materialised in a fixture literal.
+/// Bundled into one struct rather than three parameters threaded through every recursive call —
+/// `required_field_stub` recurses through the whole type graph and each of these three is needed
+/// at every level. ~keep
+struct KotlinFillContext<'a> {
+    type_defs: &'a [crate::core::ir::TypeDef],
+    enum_defaults: std::collections::HashMap<String, String>,
+    default_constructible_types: std::collections::HashSet<String>,
+}
+
 pub(super) fn build_args_and_setup(
     input: &serde_json::Value,
     args: &[ArgMapping],
@@ -81,6 +92,50 @@ pub(super) fn build_args_and_setup(
         "kotlin_android"
     } else {
         "kotlin"
+    };
+
+    // `MAPPER.readValue(...)` fixture literals for `kotlin_android_style` only: Jackson's
+    // `registerKotlinModule()` (`test_file.rs`'s mapper setup) enforces Kotlin's own
+    // constructor-required-ness, so a required (no-Kotlin-default) `Named` field the fixture's
+    // JSON omits throws `MissingKotlinParameterException` at test run time, even though the
+    // field's absence is exactly what a `#[serde(default = "...")]` the extractor could not
+    // constant-fold is *for* (see `kotlin_field_default`'s own doc comment). This mirrors that
+    // same emitter's `default_constructible_type_names` computation exactly — same inputs, same
+    // fixpoint — so a field only gets filled here when its type's Kotlin data class is provably
+    // constructible with no arguments in the ACTUAL generated binding, never a guess at what the
+    // Rust value would be. Left empty for the non-android JVM target, whose Java-record DTOs
+    // carry no such Kotlin-constructor strictness. ~keep
+    let kotlin_fill_context = if kotlin_android_style {
+        let enum_defaults: std::collections::HashMap<String, String> = enums
+            .iter()
+            .filter(|candidate| {
+                candidate.serde_tag.is_none()
+                    && !candidate.serde_untagged
+                    && candidate.variants.iter().all(|variant| variant.fields.is_empty())
+            })
+            .map(|candidate| {
+                let default_variant = candidate
+                    .variants
+                    .iter()
+                    .find(|variant| variant.is_default)
+                    .map(|variant| variant.name.clone())
+                    .unwrap_or_default();
+                (candidate.name.clone(), default_variant)
+            })
+            .collect();
+        let default_constructible_types =
+            crate::backends::kotlin::default_constructible_type_names(type_defs, &enum_defaults);
+        KotlinFillContext {
+            type_defs,
+            enum_defaults,
+            default_constructible_types,
+        }
+    } else {
+        KotlinFillContext {
+            type_defs,
+            enum_defaults: std::collections::HashMap::new(),
+            default_constructible_types: std::collections::HashSet::new(),
+        }
     };
 
     let mut setup_lines: Vec<String> = Vec::new();
@@ -119,6 +174,32 @@ pub(super) fn build_args_and_setup(
                 parts.push(arg.name.clone());
                 continue;
             }
+            // Not preserved as-is: each element is a bare path (`/page1`) that must be
+            // resolved against the per-fixture mock-server base at runtime, the same
+            // resolution `mock_url` above uses for a single URL. Mirrors
+            // `java/args.rs`'s and `typescript/test_file/args.rs`'s `{name}Base` +
+            // `.map(...)` — this arm was previously missing here entirely, so a batch
+            // fixture's raw relative paths fell through unresolved into
+            // `listOf("/page1", "/page2", ...)`, which mock-server does not serve. ~keep
+            let paths_literal = value
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|item| item.as_str().map(|s| format!("\"{}\"", escape_kotlin(s))))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            let name = &arg.name;
+            let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
+            setup_lines.push(format!(
+                "val {name}Base = System.getProperty(\"mockServer.{fixture_id}\", System.getenv(\"{env_key}\") ?: ((System.getProperty(\"mockServerUrl\", System.getenv(\"MOCK_SERVER_URL\") ?: \"\") ?: \"\") + \"/fixtures/{fixture_id}\"))"
+            ));
+            setup_lines.push(format!(
+                "val {name} = listOf({paths_literal}).map {{ if (it.startsWith(\"http\")) it else {name}Base + it }}"
+            ));
+            parts.push(name.clone());
+            continue;
         }
 
         if arg.arg_type == "handle" {
@@ -130,9 +211,17 @@ pub(super) fn build_args_and_setup(
             {
                 setup_lines.push(format!("val {} = {class_name}.{constructor_name}(null)", arg.name,));
             } else {
-                let json_str = serde_json::to_string(config_value).unwrap_or_default();
                 let name = &arg.name;
                 if let Some(config_type) = super::test_file::resolve_handle_config_type(arg, options_type, type_defs) {
+                    // `normalize_typed_json` also fills a `MissingKotlinParameterException`-prone
+                    // required field (e.g. `CrawlConfig.ssrf`) the fixture's own JSON left out —
+                    // see `fill_missing_required_kotlin_fields`. This is the sole path
+                    // `createEngine`/other `handle`-typed args' config JSON takes, so a fixture
+                    // like `warc_basic_output`'s `{"respect_robots_txt":false,...}` (no `ssrf` key
+                    // at all) needs it here, not just the `json_object` DTO-arg path below. ~keep
+                    let normalized_config =
+                        normalize_typed_json(config_value, &config_type, &kotlin_fill_context);
+                    let json_str = serde_json::to_string(&normalized_config).unwrap_or_default();
                     setup_lines.push(format!(
                         "val {name}Config = MAPPER.readValue({}, {config_type}::class.java)",
                         super::values::kotlin_string_literal(&json_str),
@@ -413,7 +502,7 @@ pub(super) fn build_args_and_setup(
                             // rather than baked into the literal at codegen time. Doc-file
                             // markers are not combined with this path, mirroring the
                             // config_type-inference branch below. ~keep
-                            let json_value = normalize_typed_json(v, opts_type, type_defs);
+                            let json_value = normalize_typed_json(v, opts_type, &kotlin_fill_context);
                             let json_str = serde_json::to_string(&json_value).unwrap_or_default();
                             let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
                             let base_var = format!("{}MockBaseUrl", arg.name);
@@ -434,7 +523,7 @@ pub(super) fn build_args_and_setup(
                             let files = fixture.docs_files_for_arg(&arg.field);
                             let mut json_value = v.clone();
                             let file_reads = prepare_docs_file_reads(&mut json_value, &files);
-                            json_value = normalize_typed_json(&json_value, opts_type, type_defs);
+                            json_value = normalize_typed_json(&json_value, opts_type, &kotlin_fill_context);
                             append_docs_file_setup(&mut setup_lines, &arg.name, &json_value, opts_type, &file_reads);
                         }
                         parts.push(arg.name.clone());
@@ -482,6 +571,8 @@ pub(super) fn build_args_and_setup(
                                 Some((index, marker, file.path.clone()))
                             })
                             .collect::<Vec<_>>();
+                        let json_value =
+                            normalize_typed_json(&json_value, &config_type, &kotlin_fill_context);
                         let json_str = serde_json::to_string(&json_value).unwrap_or_default();
                         let var_name = format!("{}_Config", arg.name);
                         if crate::e2e::codegen::value_contains_mock_url_placeholder(v) {
@@ -598,12 +689,8 @@ fn typed_zero_default(arg_type: &str) -> String {
     }
 }
 
-fn normalize_typed_json(
-    value: &serde_json::Value,
-    type_name: &str,
-    type_defs: &[crate::core::ir::TypeDef],
-) -> serde_json::Value {
-    let Some(type_def) = type_defs.iter().find(|candidate| candidate.name == type_name) else {
+fn normalize_typed_json(value: &serde_json::Value, type_name: &str, ctx: &KotlinFillContext<'_>) -> serde_json::Value {
+    let Some(type_def) = ctx.type_defs.iter().find(|candidate| candidate.name == type_name) else {
         return crate::e2e::codegen::transform_json_keys_for_language(value, "snake_case");
     };
     let Some(object) = value.as_object() else {
@@ -628,28 +715,139 @@ fn normalize_typed_json(
             field.serde_rename.as_deref(),
             type_def.serde_rename_all.as_deref(),
         );
-        normalized.insert(wire_name, normalize_typed_value(field_value, &field.ty, type_defs));
+        normalized.insert(wire_name, normalize_typed_value(field_value, &field.ty, ctx));
     }
+    let mut memo = std::collections::HashMap::new();
+    let mut visiting = std::collections::HashSet::new();
+    fill_missing_required_kotlin_fields(&mut normalized, type_def, ctx, &mut memo, &mut visiting);
     serde_json::Value::Object(normalized)
+}
+
+/// Materialise a JSON stub for every constructor-required field a `kotlin_android_style`
+/// fixture literal left out, when doing so is provably safe — recursing through nested
+/// required types rather than requiring the whole immediate field type to have a compilable
+/// zero-arg Kotlin constructor.
+///
+/// `CrawlConfig.ssrf: SsrfPolicy` (no Kotlin default; `SsrfPolicy::from_env` is env-dependent
+/// and genuinely unresolvable, see `kotlin_field_default`'s doc comment) makes `SsrfPolicy`
+/// itself default-constructible once every one of *its* fields has a real Kotlin default, so
+/// `"ssrf": {}` is enough there. But a field whose type is bare *because one of its own nested
+/// fields* is one of these (`UrlExtractionConfig.crawl: crawlberg::CrawlConfig`, itself bare
+/// only because of `crawl.ssrf`) is not in `default_constructible_types` as a whole — Jackson
+/// cannot synthesise `UrlExtractionConfig()` from `{}` alone, since `crawl` has no Kotlin
+/// default either. `required_field_stub` recurses one field at a time instead: reuse
+/// `kotlin_field_default` to ask, per field, "does the real binding already give this a
+/// default" (skip it — Jackson gets there on its own) or "is it bare" (recurse into a `Named`
+/// type's own stub, or refuse the whole containing type when it is a bare scalar/collection —
+/// there is no honest JSON literal alef can spell for those, the same "no default" the Kotlin
+/// binding itself renders). The net effect for `url: UrlExtractionConfig` is
+/// `{"crawl": {"ssrf": {}}}`, not a blind `{}`. ~keep
+fn fill_missing_required_kotlin_fields(
+    object: &mut serde_json::Map<String, serde_json::Value>,
+    type_def: &crate::core::ir::TypeDef,
+    ctx: &KotlinFillContext<'_>,
+    memo: &mut std::collections::HashMap<String, Option<serde_json::Map<String, serde_json::Value>>>,
+    visiting: &mut std::collections::HashSet<String>,
+) {
+    for field in &type_def.fields {
+        if field.binding_excluded || field.serde_skip || field.serde_flatten || field.optional {
+            continue;
+        }
+        let crate::core::ir::TypeRef::Named(nested_type_name) = &field.ty else {
+            continue;
+        };
+        let wire_name = crate::codegen::naming::wire_field_name(
+            &field.name,
+            field.serde_rename.as_deref(),
+            type_def.serde_rename_all.as_deref(),
+        );
+        if object.contains_key(&wire_name) {
+            continue;
+        }
+        let has_kotlin_default = !crate::backends::kotlin::kotlin_field_default(
+            &field.ty,
+            field.optional,
+            field.typed_default.as_ref(),
+            &ctx.enum_defaults,
+            &ctx.default_constructible_types,
+        )
+        .is_empty();
+        if has_kotlin_default {
+            continue;
+        }
+        if let Some(stub) = required_field_stub(nested_type_name, ctx, memo, visiting) {
+            object.insert(wire_name, serde_json::Value::Object(stub));
+        }
+    }
+}
+
+/// Build the JSON stub `fill_missing_required_kotlin_fields` inserts for one bare `Named`
+/// field, recursing into `type_name`'s own bare-but-`Named` fields. `None` when some field
+/// along the way is bare and not `Named` (a scalar/`Vec`/`Map` with no honest literal alef can
+/// spell) or `type_name` is unknown (opaque/external type this pass cannot see into) — the
+/// caller then leaves the parent field exactly as the fixture wrote it. `visiting` guards a
+/// recursive type (`type_name` reachable from itself) the same way, since there is no
+/// terminating stub for a cycle. `memo` avoids re-walking a type reached from multiple fields.
+fn required_field_stub(
+    type_name: &str,
+    ctx: &KotlinFillContext<'_>,
+    memo: &mut std::collections::HashMap<String, Option<serde_json::Map<String, serde_json::Value>>>,
+    visiting: &mut std::collections::HashSet<String>,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    if let Some(cached) = memo.get(type_name) {
+        return cached.clone();
+    }
+    if !visiting.insert(type_name.to_string()) {
+        return None;
+    }
+    let result = (|| {
+        let type_def = ctx.type_defs.iter().find(|candidate| candidate.name == type_name)?;
+        let mut stub = serde_json::Map::new();
+        for field in &type_def.fields {
+            if field.binding_excluded || field.serde_skip || field.serde_flatten || field.optional {
+                continue;
+            }
+            let has_kotlin_default = !crate::backends::kotlin::kotlin_field_default(
+                &field.ty,
+                field.optional,
+                field.typed_default.as_ref(),
+                &ctx.enum_defaults,
+                &ctx.default_constructible_types,
+            )
+            .is_empty();
+            if has_kotlin_default {
+                continue;
+            }
+            let crate::core::ir::TypeRef::Named(nested_type_name) = &field.ty else {
+                return None;
+            };
+            let nested_stub = required_field_stub(nested_type_name, ctx, memo, visiting)?;
+            let wire_name = crate::codegen::naming::wire_field_name(
+                &field.name,
+                field.serde_rename.as_deref(),
+                type_def.serde_rename_all.as_deref(),
+            );
+            stub.insert(wire_name, serde_json::Value::Object(nested_stub));
+        }
+        Some(stub)
+    })();
+    visiting.remove(type_name);
+    memo.insert(type_name.to_string(), result.clone());
+    result
 }
 
 fn normalize_typed_value(
     value: &serde_json::Value,
     field_type: &crate::core::ir::TypeRef,
-    type_defs: &[crate::core::ir::TypeDef],
+    ctx: &KotlinFillContext<'_>,
 ) -> serde_json::Value {
     match field_type {
-        crate::core::ir::TypeRef::Named(name) => normalize_typed_json(value, name, type_defs),
-        crate::core::ir::TypeRef::Optional(inner) => normalize_typed_value(value, inner, type_defs),
+        crate::core::ir::TypeRef::Named(name) => normalize_typed_json(value, name, ctx),
+        crate::core::ir::TypeRef::Optional(inner) => normalize_typed_value(value, inner, ctx),
         crate::core::ir::TypeRef::Vec(inner) => serde_json::Value::Array(
             value
                 .as_array()
-                .map(|items| {
-                    items
-                        .iter()
-                        .map(|item| normalize_typed_value(item, inner, type_defs))
-                        .collect()
-                })
+                .map(|items| items.iter().map(|item| normalize_typed_value(item, inner, ctx)).collect())
                 .unwrap_or_default(),
         ),
         _ => value.clone(),

--- a/src/e2e/codegen/kotlin/test_file.rs
+++ b/src/e2e/codegen/kotlin/test_file.rs
@@ -542,6 +542,15 @@ pub(super) fn render_test_file_inner(
         // constructor). The extension function lives in jackson-module-kotlin.
         if kotlin_android_style {
             imports.push("com.fasterxml.jackson.module.kotlin.registerKotlinModule");
+            // `kotlin.time.Duration` is a value class with no natural JSON shape: Jackson has
+            // no built-in codec for it, and a fixture literal always spells a duration-typed
+            // field as a plain millisecond number (the wire shape `render_kotlin_default`
+            // already uses for a `Duration` field's own default — `{n}.milliseconds`, same
+            // import). Without a registered (de)serializer, `MAPPER.readValue` on any fixture
+            // that touches a `Duration` field throws trying to bind a JSON number onto a type
+            // it cannot construct. `Duration.Companion.milliseconds` is the extension the
+            // registered deserializer below uses to build one back from that number. ~keep
+            imports.push("kotlin.time.Duration.Companion.milliseconds");
         }
     }
     // Import every options type referenced by per-call kotlin overrides in this file.
@@ -659,15 +668,51 @@ pub(super) fn render_test_file_inner(
         // primary constructor for deserialization. Non-android (JVM) targets use Java records
         // and builders, which Jackson handles without the extra module.
         if needs_object_mapper {
-            let kotlin_module_call = if kotlin_android_style {
-                ".registerKotlinModule()"
+            // `kotlin.time.Duration` has no natural JSON shape, so a fixture that touches a
+            // `Duration`-typed field (e.g. `BrowserConfig.extraWait`) needs an explicit codec
+            // registered before `MAPPER.readValue`/`writeValueAsString` can round-trip it —
+            // see the `imports.push("kotlin.time.Duration.Companion.milliseconds")` call
+            // above for why the wire shape is a plain millisecond number. Only relevant for
+            // `kotlin_android_style`: the non-android JVM target's Java-record DTOs never
+            // surface `kotlin.time.Duration`. ~keep
+            if kotlin_android_style {
+                let _ = writeln!(
+                    out,
+                    "        private val MAPPER = ObjectMapper().registerModule(Jdk8Module()).registerModule("
+                );
+                let _ = writeln!(out, "            com.fasterxml.jackson.databind.module.SimpleModule()");
+                let _ = writeln!(
+                    out,
+                    "                .addSerializer(kotlin.time.Duration::class.java, object : com.fasterxml.jackson.databind.JsonSerializer<kotlin.time.Duration>() {{"
+                );
+                let _ = writeln!(
+                    out,
+                    "                    override fun serialize(value: kotlin.time.Duration, gen: com.fasterxml.jackson.core.JsonGenerator, serializers: com.fasterxml.jackson.databind.SerializerProvider) {{"
+                );
+                let _ = writeln!(out, "                        gen.writeNumber(value.inWholeMilliseconds)");
+                let _ = writeln!(out, "                    }}");
+                let _ = writeln!(out, "                }})");
+                let _ = writeln!(
+                    out,
+                    "                .addDeserializer(kotlin.time.Duration::class.java, object : com.fasterxml.jackson.databind.JsonDeserializer<kotlin.time.Duration>() {{"
+                );
+                let _ = writeln!(
+                    out,
+                    "                    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: com.fasterxml.jackson.databind.DeserializationContext): kotlin.time.Duration {{"
+                );
+                let _ = writeln!(out, "                        return p.longValue.milliseconds");
+                let _ = writeln!(out, "                    }}");
+                let _ = writeln!(out, "                }})");
+                let _ = writeln!(
+                    out,
+                    "        ).registerKotlinModule().setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE)"
+                );
             } else {
-                ""
-            };
-            let _ = writeln!(
-                out,
-                "        private val MAPPER = ObjectMapper().registerModule(Jdk8Module()){kotlin_module_call}.setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE)"
-            );
+                let _ = writeln!(
+                    out,
+                    "        private val MAPPER = ObjectMapper().registerModule(Jdk8Module()).setPropertyNamingStrategy(com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE)"
+                );
+            }
         }
         let _ = writeln!(out, "    }}");
     }

--- a/src/extract/extractor/defaults/mod.rs
+++ b/src/extract/extractor/defaults/mod.rs
@@ -8,7 +8,7 @@ mod function_default;
 mod mutation;
 mod struct_literal;
 
-pub(crate) use function_default::{collect_free_functions, fold_constant_default_functions};
+pub(crate) use function_default::{FreeFunctionIndex, collect_free_functions, fold_constant_default_functions};
 use struct_literal::struct_expr_defaults;
 
 /// Every associated function of every inherent `impl` block in one module, keyed by

--- a/src/extract/extractor/functions/impl_blocks.rs
+++ b/src/extract/extractor/functions/impl_blocks.rs
@@ -1,7 +1,7 @@
 use crate::core::ir::{ApiSurface, DefaultValue, MethodDef, TypeDef, UnsupportedPublicItem};
 use ahash::AHashMap;
 
-use super::super::defaults::{ConstructorIndex, extract_default_values};
+use super::super::defaults::{ConstructorIndex, FreeFunctionIndex, extract_default_values, fold_constant_default_functions};
 use super::super::helpers::{build_rust_path, extract_binding_exclusion_reason, extract_cfg_condition, is_test_gated};
 use super::extract_method;
 
@@ -56,6 +56,7 @@ pub(crate) fn extract_impl_block(
     result_wrapping_aliases: &ahash::AHashSet<String>,
     literal_consts: &AHashMap<String, DefaultValue>,
     constructors: &ConstructorIndex<'_>,
+    free_functions: &FreeFunctionIndex<'_>,
 ) {
     // Honor `#[cfg_attr(alef, alef(skip))]` (or bare `#[alef(skip)]`) on the impl block
     if extract_binding_exclusion_reason(&item.attrs).is_some() {
@@ -76,6 +77,7 @@ pub(crate) fn extract_impl_block(
             literal_consts,
             impl_cfg.as_deref(),
             constructors,
+            free_functions,
         );
         return;
     }
@@ -336,6 +338,7 @@ fn extract_trait_impl_methods(
     literal_consts: &AHashMap<String, DefaultValue>,
     impl_cfg: Option<&str>,
     constructors: &ConstructorIndex<'_>,
+    free_functions: &FreeFunctionIndex<'_>,
 ) {
     let type_name = match &*item.self_ty {
         syn::Type::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
@@ -449,6 +452,23 @@ fn extract_trait_impl_methods(
             constructors,
             binding_excluded,
         );
+        // `extract_default_values` reads the `impl Default` struct literal with the same
+        // constant-folder `fold_constant_default_functions` uses for `#[serde(default =
+        // "path")]` fields, but its own `Expr::Call` handling stops at recording a bare
+        // `DefaultValue::FunctionCall` for a zero-arg call it does not itself look inside (that
+        // arm exists to name a call for every other caller of `expr_to_default_value`, most of
+        // whom have no function index to resolve it against). A field whose declared default
+        // and whose `impl Default` initializer are the very same free-function call — e.g.
+        // `#[serde(default = "default_scheme_allowlist")]` next to `Self { scheme_allowlist:
+        // default_scheme_allowlist(), .. }` — would otherwise regress from the folded literal
+        // the serde-default pass already proved to a fresh, unfolded `FunctionCall` here,
+        // purely because `impl Default` extraction unconditionally overwrites every field's
+        // `typed_default`. Re-running the same idempotent fold immediately after closes that
+        // gap: a field already folded to a concrete value is untouched (the fold only matches
+        // `FunctionCall`), and a field this pass just reset to `FunctionCall` gets exactly the
+        // same "read the named function's body if it is one constant-foldable statement"
+        // treatment the serde-default path already gets. ~keep
+        fold_constant_default_functions(&mut type_def.fields, free_functions, constructors, literal_consts);
     }
 
     let is_conversion_trait = item.trait_.as_ref().is_some_and(|(path, _)| {

--- a/src/extract/extractor/mod.rs
+++ b/src/extract/extractor/mod.rs
@@ -581,6 +581,7 @@ fn extract_items(
                 result_wrapping_aliases,
                 &literal_consts,
                 &constructors,
+                &free_functions,
             );
         }
     }

--- a/src/extract/extractor/tests/defaults/expressions.rs
+++ b/src/extract/extractor/tests/defaults/expressions.rs
@@ -291,7 +291,7 @@ fn test_field_with_hashmap_new_default() {
 }
 
 #[test]
-fn test_zero_arg_function_call_default_extracts_as_function_call() {
+fn test_zero_arg_function_call_default_folds_a_visible_constant_body() {
     let source = r#"
         pub struct Complex {
             pub result: u32,
@@ -312,10 +312,48 @@ fn test_zero_arg_function_call_default_extracts_as_function_call() {
     let complex = &surface.types[0];
     let result_field = &complex.fields[0];
 
+    // ~keep The `impl Default` initializer path folds a zero-arg call against the same free
+    // function index `#[serde(default = "path")]` fields already use. Before both paths shared
+    // the folder, a field carrying BOTH -- `#[serde(default = "f")]` beside `Self { x: f(), .. }`
+    // -- regressed from the folded literal to a bare `FunctionCall`, because the `impl Default`
+    // read overwrote what the serde read had resolved. The two must agree, and the resolved
+    // literal is the more accurate of the two answers.
+    assert_eq!(
+        result_field.typed_default,
+        Some(crate::core::ir::DefaultValue::IntLiteral(42)),
+        "a zero-arg call whose body is visible and constant should fold to that constant"
+    );
+}
+
+#[test]
+fn test_zero_arg_function_call_default_stays_a_function_call_when_the_body_is_not_constant() {
+    let source = r#"
+        pub struct Complex {
+            pub result: u32,
+        }
+
+        impl Default for Complex {
+            fn default() -> Self {
+                Complex { result: some_function() }
+            }
+        }
+
+        fn some_function() -> u32 {
+            std::time::SystemTime::now().elapsed().unwrap().as_secs() as u32
+        }
+    "#;
+
+    let surface = extract_from_source(source);
+    let complex = &surface.types[0];
+    let result_field = &complex.fields[0];
+
+    // The folder declines anything it cannot resolve to a literal, so the callee path survives
+    // for callers that need to name the call rather than its value. This is the guard that keeps
+    // the fold above from being a guess.
     assert_eq!(
         result_field.typed_default,
         Some(crate::core::ir::DefaultValue::FunctionCall("some_function".to_string())),
-        "Zero-arg function calls should preserve the callee path as FunctionCall"
+        "a call the folder cannot resolve must keep naming its callee"
     );
 }
 


### PR DESCRIPTION
Clears 170 of crawlberg's 172 `E2E (kotlin_android)` failures — the remaining two were the `LinkType` core bug already fixed in crawlberg `e66928f48`.

Generated kotlin-android data classes leave a parameter without a Kotlin default when the core field's serde default is a function call or an unresolved expression. The emitter refuses to invent a value it cannot honestly derive, and its `~keep` says so — that policy is correct and is kept. But the e2e emitter then hands Jackson a partial fixture literal with `.registerKotlinModule()`, which enforces Kotlin required-ness, so every such parameter became structurally unconstructible: `No value passed for parameter` across five test files, 164 of 172 failures. The tell was `Long?` — a nullable Kotlin parameter still requires an argument unless given `= null`.

Rather than weaken the emitter's honesty policy, the **e2e** side now materialises every required parameter into the fixture literal, recursing through the type graph via `KotlinFillContext`.

Two further defects in the same leg: batch args were passed as raw relative paths where java and typescript already map them against `urlsBase`; and `kotlin.time.Duration` is a value class Jackson cannot construct from a bare JSON number, so any fixture touching one threw on bind — now emitted as `{n}.milliseconds`, the idiom the field's own default already uses.

**One shared-extractor change, deliberate.** `extract_default_values` reads an `impl Default` struct literal and recorded a bare `FunctionCall` for a zero-arg call, overwriting the folded literal that `#[serde(default = "path")]` had already resolved for the same function. A field carrying both regressed. Both paths now fold against the same free-function index. That changed an existing test which asserted the old inconsistency; it is replaced by the folded value and **paired with a new negative case** proving a call the folder cannot resolve still names its callee — the guard that keeps the fold a resolution rather than a guess.

`cargo test --lib` 11864 passed / 0 failed.