### PR TITLE
fix(codegen): stop the serde-default fallback emitting uncompilable mirrors

### DIFF
--- a/src/codegen/generators/structs.rs
+++ b/src/codegen/generators/structs.rs
@@ -112,8 +112,20 @@ pub fn struct_wants_deserialize_delegation(
 /// marker other call sites already match on verbatim, e.g. `backends::pyo3::gen_bindings::constructors`
 /// and `backends::pyo3::gen_bindings::functions::converters`) and `#[serde(default = "path")]` as
 /// the literal `"serde(default = \"path\")"` attribute text. Returns `None` when the core field
-/// carries no serde default. ~keep
-fn serde_default_field_attr(field: &crate::core::ir::FieldDef) -> Option<String> {
+/// carries no serde default.
+///
+/// `already_emitted_attrs` is the field's attribute list as built up so far by the caller. A
+/// backend's own `extra_field_attrs` callback (e.g. php's, which resolves a per-field default
+/// function through `serde_defaults::serde_default_fn_name` and pushes a valued
+/// `serde(default = "path")` itself) can already have written a serde default onto that list
+/// before this fallback runs. serde rejects two `#[serde(default...)]` attributes on one field
+/// outright, and the valued form is strictly more specific than the bare one this fallback
+/// would add, so this returns `None` whenever `already_emitted_attrs` already carries any
+/// `serde(default...)` rather than emitting a second, colliding one. ~keep
+fn serde_default_field_attr(field: &crate::core::ir::FieldDef, already_emitted_attrs: &[String]) -> Option<String> {
+    if already_emitted_attrs.iter().any(|a| a.starts_with("serde(default")) {
+        return None;
+    }
     match field.default.as_deref() {
         Some("/* serde(default) */") => Some("serde(default)".to_string()),
         Some(text) if text.starts_with("serde(default") => Some(text.to_string()),
@@ -334,7 +346,7 @@ pub fn gen_struct_with_per_field_attrs(
         if has_serde
             && !delegate_deserialize
             && !attrs.iter().any(|a| a == "serde(skip)")
-            && let Some(default_attr) = serde_default_field_attr(field)
+            && let Some(default_attr) = serde_default_field_attr(field, &attrs)
         {
             attrs.push(default_attr);
         }
@@ -467,7 +479,7 @@ pub fn gen_struct_with_rename(
         if has_serde
             && !delegate_deserialize
             && !attrs.iter().any(|a| a == "serde(skip)")
-            && let Some(default_attr) = serde_default_field_attr(field)
+            && let Some(default_attr) = serde_default_field_attr(field, &attrs)
         {
             attrs.push(default_attr);
         }
@@ -565,7 +577,7 @@ pub fn gen_struct(typ: &TypeDef, mapper: &dyn TypeMapper, cfg: &RustBindingConfi
         // Whole-type delegation didn't fire for `typ` (or wasn't requested for it) -- mirror
         // this field's own `#[serde(default)]` directly so it stays absent-tolerant even under
         // the derived, field-by-field `Deserialize`. See `serde_default_field_attr`.
-        if !delegate_deserialize && let Some(default_attr) = serde_default_field_attr(field) {
+        if !delegate_deserialize && let Some(default_attr) = serde_default_field_attr(field, &attrs) {
             attrs.push(default_attr);
         }
         sb.add_field_with_doc(&emit_name, &ty, attrs, &sanitize_field_doc(&field.doc));

--- a/src/codegen/generators/structs.rs
+++ b/src/codegen/generators/structs.rs
@@ -121,14 +121,35 @@ pub fn struct_wants_deserialize_delegation(
 /// before this fallback runs. serde rejects two `#[serde(default...)]` attributes on one field
 /// outright, and the valued form is strictly more specific than the bare one this fallback
 /// would add, so this returns `None` whenever `already_emitted_attrs` already carries any
-/// `serde(default...)` rather than emitting a second, colliding one. ~keep
+/// `serde(default...)` rather than emitting a second, colliding one.
+///
+/// A valued `#[serde(default = "path")]` is mirrored only when [`FieldDef::typed_default`] is
+/// `PublicFunctionCall` -- the classification `extract::extractor::postprocess` already assigns
+/// to a zero-argument default function proven callable from a generated binding crate. `path`
+/// itself is always just the literal identifier written after the core struct field (see
+/// `extract_field` in `extract::extractor::helpers::fields`, which folds it to `FunctionCall`
+/// before postprocessing decides whether it upgrades), with no information here about which
+/// module it lives in; a private or module-local function (still `FunctionCall`, e.g. one
+/// `#[cfg(feature = "serde")]`-gated or simply not `pub`) reads back fine on the *core* type,
+/// where the derive sees it in scope, but copied verbatim onto the mirror struct in a different
+/// crate/module it is an unresolvable path (`E0425: cannot find function`) -- exactly how
+/// `crawlberg`'s `SsrfPolicy::scheme_allowlist` (`default = "default_scheme_allowlist"`, private
+/// to `net::ssrf`) broke `crawlberg-php` once the duplicate-attribute defect above stopped
+/// masking it. Skipping the mirror in that case reproduces the pre-#305 gap (the field goes back
+/// to being required on the derived, field-by-field mirror) rather than shipping a crate that
+/// does not compile -- the same recovery this classification already backs for constructor
+/// defaults, see `codegen::shared::format_default_value`. ~keep
 fn serde_default_field_attr(field: &crate::core::ir::FieldDef, already_emitted_attrs: &[String]) -> Option<String> {
     if already_emitted_attrs.iter().any(|a| a.starts_with("serde(default")) {
         return None;
     }
     match field.default.as_deref() {
         Some("/* serde(default) */") => Some("serde(default)".to_string()),
-        Some(text) if text.starts_with("serde(default") => Some(text.to_string()),
+        Some(text) if text.starts_with("serde(default") => matches!(
+            field.typed_default,
+            Some(crate::core::ir::DefaultValue::PublicFunctionCall(_))
+        )
+        .then(|| text.to_string()),
         _ => None,
     }
 }

--- a/src/codegen/generators/structs/tests.rs
+++ b/src/codegen/generators/structs/tests.rs
@@ -6,7 +6,8 @@ use super::{
 use crate::codegen::generators::{AsyncPattern, RustBindingConfig};
 use crate::codegen::type_mapper::IdentityMapper;
 use crate::core::ir::{
-    CoreWrapper, FieldDef, MethodDef, PrimitiveType, ReceiverKind, SerdeContainerConversion, TypeDef, TypeRef,
+    CoreWrapper, DefaultValue, FieldDef, MethodDef, PrimitiveType, ReceiverKind, SerdeContainerConversion, TypeDef,
+    TypeRef,
 };
 use ahash::AHashSet;
 
@@ -607,6 +608,11 @@ fn gen_struct_with_rename_mirrors_serde_default_when_delegation_blocked_by_sibli
 fn gen_struct_bare_mirrors_serde_default_path_when_delegation_not_requested() {
     let mut field = f64_field("retries");
     field.default = Some("serde(default = \"default_retries\")".to_string());
+    // `extract_field` never produces the valued attribute text without also resolving
+    // `typed_default` to (at least) `FunctionCall`; postprocessing upgrades it to
+    // `PublicFunctionCall` once it proves `default_retries` is callable from a generated binding
+    // crate. Only the upgraded form is safe to mirror -- see `serde_default_field_attr`.
+    field.typed_default = Some(DefaultValue::PublicFunctionCall("default_retries".to_string()));
     let typ = type_with_fields("Retry", vec![field], Default::default());
     // No `delegate_deserialize_to_core_for_types` entry for "Retry" -- delegation is never even
     // attempted for this type in this run.
@@ -616,7 +622,34 @@ fn gen_struct_bare_mirrors_serde_default_path_when_delegation_not_requested() {
     assert!(derive_line(&rendered).contains("serde::Deserialize"), "{rendered}");
     assert!(
         rendered.contains("serde(default = \"default_retries\")"),
-        "a `default = \"path\"` field must also be mirrored verbatim: {rendered}"
+        "a `default = \"path\"` field proven callable from the binding crate must be mirrored verbatim: {rendered}"
+    );
+}
+
+// --- Regression: an unresolvable `default = "path"` must never be mirrored onto the binding --
+//
+// crawlberg's `SsrfPolicy::scheme_allowlist` carries `#[serde(default = "default_scheme_allowlist")]`
+// where `default_scheme_allowlist` is a private helper in `net::ssrf`. That reads fine on the
+// *core* type, where the derive sees the function in its own module, but delegation for
+// `SsrfPolicy` is blocked by an unrelated field, so this same per-field fallback used to copy the
+// attribute verbatim onto the php mirror -- a different crate and module -- producing
+// `error[E0425]: cannot find function 'default_scheme_allowlist' in this scope`. Extraction
+// already tells the two cases apart via `FieldDef::typed_default`: `FunctionCall` for a default
+// whose callability across crates postprocessing could not prove (this case), `PublicFunctionCall`
+// once it can (see the positive control above). Only the latter may be mirrored.
+#[test]
+fn gen_struct_bare_never_mirrors_a_default_path_not_proven_callable_from_the_binding_crate() {
+    let mut field = f64_field("scheme_allowlist");
+    field.default = Some("serde(default = \"default_scheme_allowlist\")".to_string());
+    field.typed_default = Some(DefaultValue::FunctionCall("default_scheme_allowlist".to_string()));
+    let typ = type_with_fields("SsrfPolicy", vec![field], Default::default());
+    let cfg = base_cfg();
+    let rendered = gen_struct(&typ, &IdentityMapper, &cfg);
+
+    assert!(
+        !rendered.contains("serde(default"),
+        "a default fn not proven callable from the binding crate must not be mirrored, \
+         it would not compile there: {rendered}"
     );
 }
 

--- a/src/codegen/generators/structs/tests.rs
+++ b/src/codegen/generators/structs/tests.rs
@@ -620,6 +620,93 @@ fn gen_struct_bare_mirrors_serde_default_path_when_delegation_not_requested() {
     );
 }
 
+// --- Regression: a field-level valued `#[serde(default = "path")]` must not be duplicated ----
+//
+// 0.82.1 (#305, "keep serde defaults on mirror fields") added the per-field mirroring above
+// unconditionally: it pushed the core field's own `#[serde(default...)]` even when the caller's
+// `extra_field_attrs` (php's `field_attrs_fn`, which resolves a per-field default function via
+// `serde_defaults::serde_default_fn_name` and pushes a valued `serde(default = "path")` itself)
+// had already written one. serde rejects two `#[serde(default...)]` attributes on one field
+// outright ("duplicate serde attribute `default`"), which is exactly what shipped as the
+// crawlberg-php / xberg-php regression: `capture_network_events` carried both
+// `serde(default = "crate::serde_defaults::browser_config_capture_network_events")` from the
+// backend's own attribute and a bare `serde(default)` from this fallback. These tests build the
+// same shape -- a bare core default plus a caller-supplied valued default on the same field --
+// for each of the three struct generators and assert exactly one `serde(default...)` survives.
+
+#[test]
+fn gen_struct_with_per_field_attrs_keeps_only_the_valued_default_already_emitted_by_the_caller() {
+    let typ = type_with_fields(
+        "BrowserConfig",
+        vec![field_with_serde_default("capture_network_events")],
+        Default::default(),
+    );
+    let cfg = base_cfg();
+    let rendered = gen_struct_with_per_field_attrs(&typ, &IdentityMapper, &cfg, |_| {
+        vec!["serde(default = \"crate::serde_defaults::browser_config_capture_network_events\")".to_string()]
+    });
+
+    let default_attr_count = rendered.matches("serde(default").count();
+    assert_eq!(
+        default_attr_count, 1,
+        "exactly one serde(default...) attribute must survive on the field, got {default_attr_count}: {rendered}"
+    );
+    assert!(
+        rendered.contains("serde(default = \"crate::serde_defaults::browser_config_capture_network_events\")"),
+        "the valued default from extra_field_attrs must win over the bare fallback: {rendered}"
+    );
+    assert!(
+        !rendered.contains("#[serde(default)]"),
+        "the bare fallback default must not also be emitted: {rendered}"
+    );
+}
+
+#[test]
+fn gen_struct_with_rename_keeps_only_the_valued_default_already_emitted_by_the_caller() {
+    let typ = type_with_fields(
+        "BrowserConfig",
+        vec![field_with_serde_default("capture_network_events")],
+        Default::default(),
+    );
+    let cfg = base_cfg();
+    let rendered = gen_struct_with_rename(
+        &typ,
+        &IdentityMapper,
+        &cfg,
+        |_| vec!["serde(default = \"crate::serde_defaults::browser_config_capture_network_events\")".to_string()],
+        |_| None,
+    );
+
+    let default_attr_count = rendered.matches("serde(default").count();
+    assert_eq!(
+        default_attr_count, 1,
+        "exactly one serde(default...) attribute must survive on the field, got {default_attr_count}: {rendered}"
+    );
+    assert!(!rendered.contains("#[serde(default)]"), "{rendered}");
+}
+
+#[test]
+fn gen_struct_bare_keeps_only_the_valued_default_already_present_in_field_attrs() {
+    let typ = type_with_fields(
+        "BrowserConfig",
+        vec![field_with_serde_default("capture_network_events")],
+        Default::default(),
+    );
+    let field_attrs = ["serde(default = \"crate::serde_defaults::browser_config_capture_network_events\")"];
+    let cfg = RustBindingConfig {
+        field_attrs: &field_attrs,
+        ..base_cfg()
+    };
+    let rendered = gen_struct(&typ, &IdentityMapper, &cfg);
+
+    let default_attr_count = rendered.matches("serde(default").count();
+    assert_eq!(
+        default_attr_count, 1,
+        "exactly one serde(default...) attribute must survive on the field, got {default_attr_count}: {rendered}"
+    );
+    assert!(!rendered.contains("#[serde(default)]"), "{rendered}");
+}
+
 #[test]
 fn gen_struct_with_rename_delegates_for_field_with_serde_with_codec() {
     let mut field = f64_field("elapsed");


### PR DESCRIPTION
Two defects in the same 0.82.1 fallback (#305), both in `serde_default_field_attr` — shared codegen, not the php emitter.

**1. Duplicate `serde(default)`.** The fallback mirrored a core field's serde default unconditionally when whole-type Deserialize delegation didn't fire, including onto fields where the backend's own `extra_field_attrs` had already written a valued `#[serde(default = "path")]`. serde rejects two `serde(default...)` on one field, so every php binding field carrying a valued default failed to compile (`duplicate serde attribute 'default'`). The guard now takes the field's already-built attrs and declines when a `serde(default...)` is present, so the more specific valued form wins.

**2. A mirrored default fn that isn't callable across the crate boundary.** The same fallback copies `#[serde(default = "path")]` verbatim onto the mirror struct in a different crate. That reads fine on the core type where the derive sees the function in scope, but a private one is `E0425: cannot find function` on the mirror. crawlberg's `SsrfPolicy::scheme_allowlist` (`default_scheme_allowlist`, private to `net::ssrf`) hit exactly this: crawlberg-php still did not compile after fix 1. Now gated on `typed_default == PublicFunctionCall`, the classification `codegen::shared::format_default_value` already uses for constructor defaults; when it's a bare `FunctionCall` the field goes back to being required on the mirror (pre-#305 behaviour) rather than shipping a crate that does not compile.

Worth recording: **after fix 1 alone a duplicate-attribute pattern count reads zero and the crate still does not compile.** Fix 2 was found only because the acceptance test is a real `cargo check` on a regenerated binding crate rather than a grep over generated text. See #311.

## Verification

- `cargo test --lib` 11876 passed / 0 failed; clippy `-D warnings` clean; `fmt --check` clean.
- Both fixes neutralised separately: bug reintroduced, targeted tests watched to fail with the real symptom, restored, re-run green, restored file diffed byte-for-byte against `git show HEAD:src/codegen/generators/structs.rs`.
- Regenerated all four consumer repos into scratch copies with `generate --clean` and ran `cargo check` per php crate, with an explicit attempted count so a skipped repo cannot read as green.