### PR TITLE
fix(magnus): keep bridge wrappers Result-shaped for a fallible ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Magnus (Ruby) trait-bridge functions with no declared error type and no fallible parameter
+  emitted a Rust `?` inside a bare (non-`Result`) return type, which does not compile.** PR #292
+  (0.82.1) made every generated bridge constructor call fallible —
+  `RbFooBridge::new(value, name)?`, unconditionally, to validate the Ruby object's required
+  methods and build the runtime dispatcher — but the wrapper function's return-type computation
+  was never taught about it: it stayed `func.error_type.is_some() || <param needs fallible
+  deserialization>`, neither of which is true for a plain bridge-only function. Any consumer
+  configuring a `[[crates.trait_bridges]]` entry bound to a function with no core error type and
+  no other fallible parameter got a generated Ruby binding that fails `rustc` with E0277 ("the `?`
+  operator can only be used in a function that returns `Result` or `Option`"). Caught only by
+  `cargo test --test backends_magnus_trait_bridge_test`, an integration test that `cargo test
+  --lib` does not run — the regression shipped in 0.82.1 undetected.
+
 - **publish (Ruby platform gems):** precompiled platform gemspecs now load the generated source
   gemspec as their metadata authority, then replace only the version, platform, files, and native
   extension build hook. The previous synthesized gemspec dropped required fields such as

--- a/src/backends/magnus/trait_bridge/bridge_functions.rs
+++ b/src/backends/magnus/trait_bridge/bridge_functions.rs
@@ -106,11 +106,6 @@ pub fn gen_bridge_function(
         .copied()
         .any(|(_, p)| !default_types.contains(named_type_name(&p.ty).unwrap_or_default()));
 
-    let has_error = func.error_type.is_some() || params_need_fallible_deser;
-    let ret = mapper.wrap_return(&return_type, has_error);
-
-    let err_conv = ".map_err(|e| magnus::Error::new(unsafe { magnus::Ruby::get_unchecked() }.exception_runtime_error(), e.to_string()))";
-
     let bridge_wrap = if is_optional {
         format!(
             "let {param_name}: Option<{bridge_handle_type}> = match {param_name} {{\n        \
@@ -129,6 +124,19 @@ pub fn gen_bridge_function(
              }};"
         )
     };
+
+    // `has_error` must reflect every fallible operation this function's body actually emits.
+    // `bridge_wrap` above always constructs the bridge via `{struct_name}::new(...)?` (the
+    // constructor validates required methods and builds the runtime dispatcher, both fallible
+    // since #292 made trait-bridge constructors return `Result`) — read that fact from the
+    // generated code itself rather than asserting it as a separate constant, so a future change
+    // to `bridge_wrap` that removes or conditions the `?` is picked up here automatically instead
+    // of needing a second, independent edit that can drift out of sync. ~keep
+    let bridge_construction_is_fallible = bridge_wrap.contains('?');
+    let has_error = func.error_type.is_some() || params_need_fallible_deser || bridge_construction_is_fallible;
+    let ret = mapper.wrap_return(&return_type, has_error);
+
+    let err_conv = ".map_err(|e| magnus::Error::new(unsafe { magnus::Ruby::get_unchecked() }.exception_runtime_error(), e.to_string()))";
 
     let serde_bindings: String = deser_params
         .into_iter()
@@ -223,18 +231,17 @@ pub fn gen_bridge_function(
         } else {
             format!("{bridge_wrap}\n    {serde_bindings}{core_call}.map(|val| {return_wrap}){err_conv}")
         }
-    } else if has_error {
-        // The core call returns a bare value, but `serde_bindings` above used `?` on at least one
-        // param (`params_need_fallible_deser`), which forced the signature to be `Result`-shaped.
-        // The tail expression must match that: wrap the plain call in `Ok(..)` instead of handing
-        // back the bare value the `Result<T, Error>` signature above no longer fits. ~keep
+    } else {
+        // The core call returns a bare value, but `bridge_construction_is_fallible` above is
+        // always true for this generator (`bridge_wrap`'s constructor call is unconditionally
+        // fallible; `serde_bindings` may add its own `?`s on top), so `has_error` is always true
+        // here too and the signature above is `Result`-shaped. The tail expression must match
+        // that: wrap the plain call in `Ok(..)` instead of handing back a bare value. ~keep
         if return_wrap == "val" {
             format!("{bridge_wrap}\n    {serde_bindings}Ok({core_call})")
         } else {
             format!("{bridge_wrap}\n    {serde_bindings}let val = {core_call};\n    Ok({return_wrap})")
         }
-    } else {
-        format!("{bridge_wrap}\n    {serde_bindings}{core_call}")
     };
 
     let func_name = &func.name;

--- a/tests/backends_magnus_trait_bridge_test.rs
+++ b/tests/backends_magnus_trait_bridge_test.rs
@@ -8,6 +8,14 @@
 //! - `gen_bridge_function` emits `serde_json::from_str(..)?` / `.transpose()?` for any non-opaque
 //!   `Named`/`Optional<Named>` parameter that isn't a configured "default type" — gated on
 //!   parameter shape, never on `func.error_type`.
+//!
+//! 0.82.1 regression (shipped, fixed here): PR #292 changed `gen_bridge_function`'s bridge
+//! construction from an infallible `{struct_name}::new({param})` to a fallible
+//! `{struct_name}::new({param}, {name})?`, unconditionally on every call — but nothing taught
+//! `has_error` about it, so a function with neither a declared error type nor a fallible param
+//! kept a bare-`T` signature wrapped around that same unconditional `?`. Every generated Magnus
+//! trait-bridge free function is Result-shaped now: the bridge constructor's own fallibility is
+//! never conditional.
 
 use alef::backends::magnus::trait_bridge::{gen_bridge_function, gen_options_field_bridge_function};
 use alef::codegen::type_mapper::IdentityMapper;
@@ -90,10 +98,13 @@ fn bridge_function_without_error_type_stays_result_shaped_when_a_param_needs_fal
 }
 
 /// The same function, but `options` becomes an opaque type (skips deser entirely) and there's no
-/// other fallible source — the signature must stay bare (not our concern, but pins the "should
-/// still special-case the no-fallibility path" behavior so a future change doesn't regress it).
+/// other fallible source among the params or `error_type` — the signature must still be
+/// `Result`-shaped, because the bridge parameter itself (`visitor`) is always constructed via a
+/// fallible `RbVisitorBridge::new(..)?` (the constructor validates required methods and builds
+/// the runtime dispatcher). A bare-`T` return here would wrap that same unconditional `?` in a
+/// body rustc rejects with E0277 — the 0.82.1 regression this test pins.
 #[test]
-fn bridge_function_without_error_type_and_without_fallible_params_stays_bare() {
+fn bridge_function_without_error_type_and_without_fallible_params_stays_result_shaped_for_fallible_constructor() {
     let mut func = render_document_function();
     func.params[1].ty = TypeRef::Primitive(alef::core::ir::PrimitiveType::U32);
     func.params[1].name = "count".to_string();
@@ -110,13 +121,109 @@ fn bridge_function_without_error_type_and_without_fallible_params_stays_bare() {
     );
 
     assert!(
-        !code.contains("-> Result<"),
-        "no error type and no fallible param must keep a bare return, got: {code}"
+        code.contains("-> Result<"),
+        "the bridge constructor's own `?` is unconditional, so the signature must stay \
+         Result-shaped even with no declared error type and no fallible param, got: {code}"
     );
     assert!(
-        !code.contains('?'),
-        "a bare-return body must not contain a `?`, got: {code}"
+        code.contains("RbVisitorBridge::new(") && code.contains('?'),
+        "the bridge construction must stay fallible, got: {code}"
     );
+    assert!(
+        code.contains("Ok("),
+        "the tail expression must be Ok(..)-wrapped to fit the Result-shaped signature, got: {code}"
+    );
+}
+
+/// Structural invariant `gen_bridge_function` must satisfy for every function shape: the
+/// generated body contains a `?` if and only if the signature it is wrapped in is
+/// `Result`-shaped. Unlike the two regression-pin tests above (which fix one input and assert
+/// one direction), this checks both directions across several shapes at once, so neither side
+/// can be satisfied by a constant — a hardcoded `-> Result<` or a hardcoded bare return would
+/// fail whichever shape disagrees with it.
+#[test]
+fn bridge_function_body_contains_question_mark_iff_signature_is_result_shaped() {
+    let opaque_types = ahash::AHashSet::new();
+    let mut default_types = std::collections::HashSet::new();
+
+    let mut declared_error_no_fallible_param = render_document_function();
+    declared_error_no_fallible_param.error_type = Some("sample_core::Error".to_string());
+    declared_error_no_fallible_param.params[1].ty = TypeRef::Primitive(alef::core::ir::PrimitiveType::U32);
+    declared_error_no_fallible_param.params[1].name = "count".to_string();
+
+    let no_declared_error_fallible_deser_param = render_document_function();
+
+    let mut no_declared_error_no_fallible_param = render_document_function();
+    no_declared_error_no_fallible_param.params[1].ty = TypeRef::Primitive(alef::core::ir::PrimitiveType::U32);
+    no_declared_error_no_fallible_param.params[1].name = "count".to_string();
+
+    // Same shape as above, but `RenderOptions` is a configured "default type": `serde_bindings`
+    // takes the `.into()` arm instead of the fallible `serde_json::from_str(..)?` arm, so the
+    // *only* remaining source of fallibility in the body is `bridge_wrap`'s constructor call.
+    let no_declared_error_default_type_param = render_document_function();
+    default_types.insert("RenderOptions");
+
+    let mut declared_error_and_fallible_deser_param = render_document_function();
+    declared_error_and_fallible_deser_param.error_type = Some("sample_core::Error".to_string());
+
+    let mut optional_bridge_no_declared_error_no_fallible_param = render_document_function();
+    optional_bridge_no_declared_error_no_fallible_param.params[0].optional = true;
+    optional_bridge_no_declared_error_no_fallible_param.params[1].ty =
+        TypeRef::Primitive(alef::core::ir::PrimitiveType::U32);
+    optional_bridge_no_declared_error_no_fallible_param.params[1].name = "count".to_string();
+
+    let shapes: Vec<(&str, FunctionDef, std::collections::HashSet<&str>)> = vec![
+        (
+            "declared error type, no fallible param",
+            declared_error_no_fallible_param,
+            std::collections::HashSet::new(),
+        ),
+        (
+            "no declared error type, fallible deser param",
+            no_declared_error_fallible_deser_param,
+            std::collections::HashSet::new(),
+        ),
+        (
+            "no declared error type, no fallible param",
+            no_declared_error_no_fallible_param,
+            std::collections::HashSet::new(),
+        ),
+        (
+            "no declared error type, default-type param",
+            no_declared_error_default_type_param,
+            default_types.clone(),
+        ),
+        (
+            "declared error type and fallible deser param",
+            declared_error_and_fallible_deser_param,
+            std::collections::HashSet::new(),
+        ),
+        (
+            "optional bridge param, no declared error type, no fallible param",
+            optional_bridge_no_declared_error_no_fallible_param,
+            std::collections::HashSet::new(),
+        ),
+    ];
+
+    for (label, func, default_types) in shapes {
+        let code = gen_bridge_function(
+            &ApiSurface::default(),
+            &func,
+            0,
+            &function_param_bridge_config(),
+            &IdentityMapper,
+            &opaque_types,
+            &default_types,
+            "sample_core",
+        );
+
+        let is_result_shaped = code.contains("-> Result<");
+        let body_is_fallible = code.contains('?');
+        assert_eq!(
+            is_result_shaped, body_is_fallible,
+            "[{label}] a Result-shaped signature must correspond exactly to a body containing              `?`, and vice versa — got is_result_shaped={is_result_shaped},              body_is_fallible={body_is_fallible}, code: {code}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
A regression shipped in 0.82.1: generated Magnus bridge wrappers can contain a `?` inside a bare, non-`Result` return type, which does not compile.

PR #292 made every trait-bridge constructor call fallible — `RbFooBridge::new(value, name)?`, unconditionally, to validate the Ruby object's required methods and build the runtime dispatcher. The wrapper's return-type computation was never taught about it and stayed `func.error_type.is_some() || <a param needs fallible deserialization>`. A bridge-only function with neither source therefore emitted:

```rust
pub fn render_document(visitor: magnus::Value, count: u32) -> String {
    let visitor = {
        let bridge = RbVisitorBridge::new(visitor, String::new())?;   // E0277
        ...
```

`has_error` now reads the fact off the generated `bridge_wrap` itself rather than asserting it as a separate constant, so a future change that removes or conditions that `?` is picked up automatically instead of requiring a second, independent edit that can drift.

## Why it shipped

The test that catches this already existed and already asserted the right thing. It is an **integration** test, and `cargo test --lib` does not run it — which is what every local verification during 0.82.1 used, all 11876 of them green. alef's own `Test (ubuntu-latest)` leg does catch it: on #315 that leg reports 11865 lib tests passing and this one integration test failing, which is the whole of its failure.

The `Test (macos-latest)` and `Test (windows-latest)` legs are separately and chronically red because Go is not installed on those runners and the Go fixtures panic rather than reporting themselves unrun. That is being fixed on its own branch.

## Verification

- `cargo test --test backends_magnus_trait_bridge_test` — 4 passed, 0 failed.
- Neutralised: reverting `has_error` to the two-operand form fails 2 tests, including the new invariant; restoring passes 4. Asserted on `git show HEAD:<path>` rather than the working tree — fix token present, defect token absent.
- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.

The original test asserted the opposite — that this shape stays bare. That assertion encoded a pre-#292 invariant which stopped being true when the constructor became fallible, so it is inverted here and joined by a stronger one: over several function shapes, the body contains a `?` **if and only if** the signature is `Result`-shaped. That invariant cannot be satisfied by hardcoding either side.