### PR TITLE
fix(go/e2e): stop guarding scalar map values with a nil check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operator can only be used in a function that returns `Result` or `Option`"). Caught only by
   `cargo test --test backends_magnus_trait_bridge_test`, an integration test that `cargo test
   --lib` does not run — the regression shipped in 0.82.1 undetected.
+- **Go e2e generator emitted a `nil` comparison against a `map[string]string` value, failing
+  `go vet`/compilation.** A config-declared `fields_optional` entry for a map-key lookup (e.g.
+  `metadata.document.open_graph[title]`) is legitimately optional cross-language — the key may be
+  absent — but that optionality was pushed onto the Go accessor unchanged. Go's e2e `equals`
+  (and related) assertions then emitted `result.Metadata.Document.OpenGraph["title"] == nil`
+  against a plain `string`, a compile error (`invalid operation: mismatched types string and
+  untyped nil`) rather than a warning, breaking the generated e2e suite for every consumer with a
+  `map[string]<scalar>` field named in `fields_optional`. Shipped since 0.79.4
+  (`1cf185b68e`). The Go generator now consults the map's declared value type: a bracket-indexed
+  leaf only drops its nil guard when the IR can positively prove the value type is a plain,
+  never-nil Go kind (a resolved struct/enum or a bare scalar); a map whose value type is itself a
+  pointer, slice, another map, or an interface (sealed union) keeps its `nil` comparison exactly
+  as before.
 
 - **publish (Ruby platform gems):** precompiled platform gemspecs now load the generated source
   gemspec as their metadata authority, then replace only the version, platform, files, and native

--- a/src/e2e/codegen/go/assertion_field_shape.rs
+++ b/src/e2e/codegen/go/assertion_field_shape.rs
@@ -25,6 +25,27 @@ fn leaf_is_indexed_element(path: &str) -> bool {
         && path[open + 1..path.len() - 1].bytes().all(|b| b.is_ascii_digit())
 }
 
+/// Whether `path`'s FINAL segment is a map-key lookup (`open_graph[title]`) rather than a
+/// numeric array index -- the sibling shape [`leaf_is_indexed_element`] does not cover.
+///
+/// A map key lookup is bracket syntax exactly like an array index, but it can only ever be
+/// declared "optional" for the reason a map key genuinely can be: the key might be absent.
+/// That is a real cross-language fact (`fields_optional` on `open_graph[title]` is correct for
+/// Python's `.get()`/TypeScript's `undefined`), but it says nothing about whether the Go
+/// expression `m["key"]` can be `nil` -- a Go map read, even on a nil map or a missing key,
+/// always yields the value type's zero value. Whether that zero value can itself be `nil`
+/// depends only on the map's VALUE type, which `resolve_assertion_field_shape` checks
+/// separately via `FieldResolver::map_value_is_scalar` before trusting this leaf shape to
+/// suppress the container's declared optionality.
+fn leaf_is_map_key_element(path: &str) -> bool {
+    let Some(open) = path.rfind('[') else {
+        return false;
+    };
+    path.ends_with(']')
+        && open + 1 < path.len() - 1
+        && !path[open + 1..path.len() - 1].bytes().all(|b| b.is_ascii_digit())
+}
+
 pub(super) struct AssertionFieldShape {
     pub is_optional: bool,
     pub is_pointer: bool,
@@ -57,9 +78,19 @@ pub(super) fn resolve_assertion_field_shape(
         .unwrap_or(resolved);
     let uses_plain_local = optional_locals.contains_key(field);
     let leaf_is_indexed_element = leaf_is_indexed_element(check_path);
-    let is_optional = !leaf_is_indexed_element && field_resolver.is_optional(check_path) && !uses_plain_local;
-    let is_array_for_len = !leaf_is_indexed_element && field_resolver.is_array(check_path);
-    let is_slice = !leaf_is_indexed_element && field_resolver.is_array(resolved);
+    // A map-key leaf only overrides the container's declared optionality when the IR can
+    // positively prove the map's VALUE type is a plain, never-nil Go kind -- `unwrap_or(false)`
+    // here is deliberate and asymmetric with the numeric-index case above: an unresolved path
+    // must fall through to the existing `is_optional`/`is_pointer` computation unchanged, so a
+    // map of pointers or sealed interfaces (or a path the IR simply cannot anchor) keeps
+    // whatever nil guard it already had. See `leaf_is_map_key_element` and
+    // `FieldResolver::map_value_is_scalar`.
+    let leaf_is_scalar_map_value =
+        leaf_is_map_key_element(check_path) && field_resolver.map_value_is_scalar(check_path).unwrap_or(false);
+    let container_nullability_consumed = leaf_is_indexed_element || leaf_is_scalar_map_value;
+    let is_optional = !container_nullability_consumed && field_resolver.is_optional(check_path) && !uses_plain_local;
+    let is_array_for_len = !container_nullability_consumed && field_resolver.is_array(check_path);
+    let is_slice = !container_nullability_consumed && field_resolver.is_array(resolved);
     // ~keep `target_field_is_pointer` is the authoritative answer: it reads the same
     // `go_struct_field_type` the Go binding backend itself emits from (see
     // `ir_result_fields::pointer_at_path`). `None` means that walk could not resolve `check_path`
@@ -70,7 +101,7 @@ pub(super) fn resolve_assertion_field_shape(
     // Defaulting to `false` never adds a spurious `*`; the worst case is a missing deref the IR
     // could not prove was needed, which is a comparison against the wrong Go type and fails to
     // build immediately, rather than silently asserting nothing.
-    let is_pointer = !leaf_is_indexed_element
+    let is_pointer = !container_nullability_consumed
         && !uses_plain_local
         && field_resolver.target_field_is_pointer(check_path).unwrap_or(false);
 

--- a/src/e2e/codegen/go/field_shape_tests.rs
+++ b/src/e2e/codegen/go/field_shape_tests.rs
@@ -792,3 +792,91 @@ fn unresolved_optional_field_is_never_guessed_as_a_pointer() {
         "an unresolved field must never be GUESSED as a pointer"
     );
 }
+
+/// A root result type with a `Map<String, String>` field -- the exact shape
+/// `DocumentMetadata::open_graph` has in html-to-markdown -- and a `Map<String, Option<String>>`
+/// field standing in for a map whose VALUE type genuinely can be absent in Go (`map[string]
+/// *string`), both reached the same bracket-index way `alef.toml`'s `fields_optional` declares a
+/// map key lookup (`open_graph[title]`).
+fn map_key_fixture() -> Vec<TypeDef> {
+    vec![TypeDef {
+        name: "DocumentMetadata".into(),
+        fields: vec![
+            FieldDef {
+                name: "open_graph".into(),
+                ty: TypeRef::Map(Box::new(TypeRef::String), Box::new(TypeRef::String)),
+                ..Default::default()
+            },
+            FieldDef {
+                name: "pointer_labels".into(),
+                ty: TypeRef::Map(
+                    Box::new(TypeRef::String),
+                    Box::new(TypeRef::Optional(Box::new(TypeRef::String))),
+                ),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }]
+}
+
+fn map_key_resolver() -> FieldResolver {
+    let types = map_key_fixture();
+    let mut optional = HashSet::new();
+    optional.insert("open_graph".to_string());
+    optional.insert("open_graph[title]".to_string());
+    optional.insert("pointer_labels[title]".to_string());
+    FieldResolver::new(
+        &Default::default(),
+        &optional,
+        &Default::default(),
+        &Default::default(),
+        &Default::default(),
+    )
+    .with_ir_result_fields(
+        FieldResolver::go_ir_result_field_facts(&types, &[], &HashSet::new()),
+        Some("DocumentMetadata".into()),
+    )
+}
+
+/// THE H2M REGRESSION (shipped alef 0.79.4 through 0.82.2): `open_graph[title]` names a
+/// config-declared optional map-key lookup into `Map<String, String>` -- correct cross-language
+/// modeling of "the key might be absent" (Python's `.get()`, TypeScript's `undefined`), but Go's
+/// `m["key"]` on a `map[string]string` always yields a `string`, even for a missing key or a nil
+/// map. Before the fix this leaf inherited the container's declared optionality unchanged and the
+/// `equals` assertion family emitted `result.Metadata.Document.OpenGraph["title"] == nil` --
+/// `invalid operation: mismatched types string and untyped nil`, a Go compile failure in the
+/// generated e2e suite, not a warning.
+#[test]
+fn map_key_lookup_into_a_scalar_value_map_is_not_treated_as_nullable() {
+    let resolver = map_key_resolver();
+    let shape = shape_for(&resolver, "open_graph[title]");
+    assert!(
+        !shape.is_optional,
+        "a string value can never be nil, regardless of config"
+    );
+    assert!(!shape.is_pointer, "a map[string]string element is never a Go pointer");
+    assert!(!shape.is_nullable, "must not compile a `== nil` check against a string");
+
+    // Control: the bare map field (no key lookup) keeps its real declared optionality --
+    // proving the override fires only on the indexed leaf, not on `open_graph` in general.
+    let container_shape = shape_for(&resolver, "open_graph");
+    assert!(
+        container_shape.is_optional,
+        "control: the un-indexed field is still config-declared optional"
+    );
+}
+
+/// THE GUARDRAIL: a map whose VALUE type genuinely can be `nil` in Go (here `map[string]
+/// *string`) must keep its nil comparison. The fix must not blanket-strip the guard for every
+/// bracket-indexed leaf -- only for leaves the IR can positively prove are backed by a plain Go
+/// value type.
+#[test]
+fn map_key_lookup_into_a_pointer_value_map_keeps_its_nil_guard() {
+    let resolver = map_key_resolver();
+    let shape = shape_for(&resolver, "pointer_labels[title]");
+    assert!(
+        shape.is_nullable,
+        "a map[string]*string element can genuinely be nil and must keep its guard"
+    );
+}

--- a/src/e2e/field_access/ir_result_fields.rs
+++ b/src/e2e/field_access/ir_result_fields.rs
@@ -204,6 +204,14 @@ fn record_ir_result_field(
             .or_default()
             .insert(field.name.clone());
     }
+    if let Some(value_ty) = map_value_type(&field.ty)
+        && !map_value_is_go_nilable(value_ty, names)
+    {
+        map.map_scalar_value_fields
+            .entry(type_def.name.clone())
+            .or_default()
+            .insert(field.name.clone());
+    }
     if named_type(&field.ty).is_some_and(|name| names.data_enums.contains(name)) {
         map.data_interface_fields
             .entry(type_def.name.clone())
@@ -211,6 +219,37 @@ fn record_ir_result_field(
             .insert(field.name.clone());
     }
     record_ir_result_field_kind(map, type_def, field, names);
+}
+
+/// The `Map<K, V>` value type `ty` declares, peeling any wrapping `Option<..>` first so a
+/// `Map<K, V>` field and an `Option<Map<K, V>>` field answer identically — a nil Go map still
+/// safely returns `V`'s zero value on a missing-key read, so the field's own optionality never
+/// changes what an indexed read of it can produce. `None` for every other shape.
+fn map_value_type(ty: &TypeRef) -> Option<&TypeRef> {
+    match ty {
+        TypeRef::Map(_, value) => Some(value),
+        TypeRef::Optional(inner) => map_value_type(inner),
+        _ => None,
+    }
+}
+
+/// Whether a map's value type `value_ty` is a Go-nilable kind: a pointer (`Optional<T>`), a
+/// slice (`Vec<T>`, `Bytes`, `Json` — `json.RawMessage` is slice-backed), another map, or an
+/// `interface{}` (a sealed-interface/data-enum `Named` type, or any `Named` type the IR could
+/// not resolve to a struct/enum at all, which alef itself renders as `*json.RawMessage`).
+/// `false` for every plain Go value kind: bare scalars, `Duration`, `Path`, a resolved struct,
+/// or a resolved non-sealed enum — indexing a map of one of those can never produce `nil`.
+fn map_value_is_go_nilable(value_ty: &TypeRef, names: &GoFieldTypeNames<'_>) -> bool {
+    match value_ty {
+        TypeRef::Optional(_) | TypeRef::Vec(_) | TypeRef::Bytes | TypeRef::Json | TypeRef::Map(_, _) => true,
+        TypeRef::Named(name) => {
+            names.data_enums.contains(name.as_str())
+                || !(names.enums.contains(name.as_str())
+                    || names.passthrough_enums.contains(name.as_str())
+                    || names.structs.contains(name.as_str()))
+        }
+        _ => false,
+    }
 }
 
 fn record_ir_result_field_kind(
@@ -292,6 +331,21 @@ pub(super) fn pointer_at_path(map: &IrResultFieldMap, path: &str) -> Option<bool
     let (owner, leaf) = walk_to_owner_from(map, root, path)?;
     Some(
         map.pointer_fields
+            .get(owner)
+            .is_some_and(|fields| fields.contains(&leaf)),
+    )
+}
+
+/// Whether `path`'s leaf is a `Map<K, V>` field (see [`map_value_type`]) whose value type `V`
+/// is a plain, never-nil Go value kind, per [`map_value_is_go_nilable`]. `None` when the IR
+/// cannot resolve `path` at all — callers must not treat that as "no" (a plain string value)
+/// on an unresolved path, since that would wrongly strip a nil guard the IR never actually
+/// vouched for.
+pub(super) fn map_value_is_scalar_at_path(map: &IrResultFieldMap, path: &str) -> Option<bool> {
+    let root = map.root_type.as_deref()?;
+    let (owner, leaf) = walk_to_owner_from(map, root, path)?;
+    Some(
+        map.map_scalar_value_fields
             .get(owner)
             .is_some_and(|fields| fields.contains(&leaf)),
     )

--- a/src/e2e/field_access/resolver/classify.rs
+++ b/src/e2e/field_access/resolver/classify.rs
@@ -193,6 +193,15 @@ impl FieldResolver {
             .unwrap_or(false)
     }
 
+    /// Whether `field` resolves to a `Map<K, V>` field whose value type `V` is a plain,
+    /// never-nil Go value kind (see `ir_result_fields::map_value_is_scalar_at_path`). `None`
+    /// when the anchored IR cannot resolve the path — never `Some(false)` for "unknown", since
+    /// callers use this to positively override an otherwise-nilable classification and must
+    /// never do so on a guess.
+    pub fn map_value_is_scalar(&self, field: &str) -> Option<bool> {
+        super::super::ir_result_fields::map_value_is_scalar_at_path(&self.ir_result_field_map, self.resolve(field))
+    }
+
     /// Check whether `field`'s resolved leaf type is one alef cannot vouch for as implementing
     /// `Display` — a struct/enum from the crate's own IR, per
     /// [`ir_result_fields::leaf_is_named_type`](super::super::ir_result_fields::leaf_is_named_type).

--- a/src/e2e/field_access/types.rs
+++ b/src/e2e/field_access/types.rs
@@ -222,6 +222,17 @@ pub struct FieldResolver {
 ///   is a snippet that fails to compile.
 /// * `root_type` — the IR type name the call's declared return type resolves to, via
 ///   `codegen::call_ir::resolve_declared_result_type`. `None` disables every anchored answer.
+/// * `map_scalar_value_fields[type_name]` — fields of `type_name` whose declared type is a
+///   `Map<K, V>` (optionally wrapped in `Option<..>`) where `V` is a plain, never-nil Go value
+///   kind: a resolved struct, a resolved non-sealed enum, or a bare scalar (`string`,
+///   `bool`, a numeric primitive, `Duration`). Indexing such a map (`m["key"]`) always yields a
+///   concrete Go value, even when the map itself is absent or the key is missing — a nil Go map
+///   read is a safe zero-value read, never a panic — so a leaf reached through this field must
+///   never be treated as nilable, regardless of what `optional_fields`/`pointer_fields` say about
+///   the map field itself. Excludes `Optional<V>`, `Vec<V>`/`Bytes`/`Json` (slice-backed), a
+///   nested `Map<_, _>`, a sealed-interface (data enum) `V`, and any unresolved `Named` `V` —
+///   all of those render as a Go pointer, slice, map, or `interface{}`, which genuinely can be
+///   `nil` when read.
 #[derive(Debug, Clone, Default)]
 pub struct IrResultFieldMap {
     pub field_types: HashMap<String, HashMap<String, String>>,
@@ -231,6 +242,7 @@ pub struct IrResultFieldMap {
     pub declared_fields: HashMap<String, HashSet<String>>,
     pub unresolvable_named_fields: HashMap<String, HashSet<String>>,
     pub display_safe_fields: HashMap<String, HashSet<String>>,
+    pub map_scalar_value_fields: HashMap<String, HashSet<String>>,
     pub root_type: Option<String>,
 }
 


### PR DESCRIPTION
Generated Go compared a `map[string]string` lookup against `nil`, which is a compile error. Shipping since alef 0.79.4 (`1cf185b68e`).

```
metadata_test.go:482:52: invalid operation:
  result.Metadata.Document.OpenGraph["title"] == nil
  (mismatched types string and untyped nil)
```

A config-declared `fields_optional` entry on a map-key path is a legitimate cross-language fact ("the key may be absent"), but nothing distinguished it from Go-level nilability. The existing `leaf_is_indexed_element` guard covered numeric indices (`foo[0]`) and not map keys (`foo[title]`), and the only pointer fact available (`target_field_is_pointer`) describes the field itself, never a nested map value type — that type was genuinely unavailable rather than ignored.

The map value type is now threaded through the IR and a `leaf_is_map_key_element` classifier overrides the nil guard **only** when the IR can positively prove the value type is a plain Go value kind. A map whose value is a pointer, slice, map, or sealed interface keeps its guard, with a regression test pinning that.

## Verification

- Acceptance is `go vet ./...`, not a grep: it now passes on regenerated h2m `e2e/go`, having failed with the exact reported error before.
- Blast radius, A/B with two release binaries from the same base commit: **96 Go e2e files attempted across 5 repos, exactly 1 changed** (h2m `metadata_test.go`, 10 nil-guard removals), 95 byte-identical.
- Neutralised: reverting reproduces the identical error at the identical line and column; restoring fixes it. Asserted on `git show HEAD:<path>` for both a fix-unique and a defect-unique token.
- `cargo test --workspace --all-targets`, clippy `-D warnings`, `fmt --check` — the remaining integration failures reproduce on unmodified `origin/main`.

One pre-existing unrelated `go vet` failure was found in xberg (`smoke_test.go`, a `*uint32` compared against an untyped int) — identical with and without this fix, so not introduced here.