### PR TITLE
fix(e2e/python): import nested enum fields used in test bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never-nil Go kind (a resolved struct/enum or a bare scalar); a map whose value type is itself a
   pointer, slice, another map, or an interface (sealed union) keeps its `nil` comparison exactly
   as before.
+- **python e2e generator:** the import-line scanner and the constructor-call renderer for
+  `json_object` call args walked the fixture value independently, so an enum field nested inside
+  a nested config object (e.g. `PreprocessingOptions.preset: PreprocessingPreset` inside
+  `ConversionOptions`) was constructed correctly in the test body but never added to the
+  `from <module> import ...` line, failing every consumer whose fixtures exercise such a field
+  with `NameError`. The import scan now records enum usages through the same recursive traversal
+  that renders the constructor call, instead of a second pass that only checked the arg's
+  top-level keys.
 
 - **publish (Ruby platform gems):** precompiled platform gemspecs now load the generated source
   gemspec as their metadata authority, then replace only the version, platform, files, and native

--- a/src/e2e/codegen/python/import_lines.rs
+++ b/src/e2e/codegen/python/import_lines.rs
@@ -10,27 +10,37 @@ use crate::e2e::config::ArgMapping;
 use crate::e2e::fixture::Fixture;
 
 use super::super::helpers::is_skipped;
-use super::super::test_function::{KwargRenderContext, render_kwarg_field_value};
+use super::super::test_function::{KwargRenderContext, UsedTypeNames, render_kwarg_field_value};
 use super::references_identifier;
 
-/// Collect nested config/struct type names referenced by a `json_object` arg's value -- both the
-/// single-object shape (a field whose own type is a generated pyclass, e.g. `nested:
-/// NestedConfig` inside `ExtractionConfig`) and the "batch" array-of-typed-items shape
-/// (`element_type`, e.g. `BatchFileItem`).
+/// Collect nested config/struct AND enum type names referenced by a `json_object` arg's value --
+/// both the single-object shape (a field whose own type is a generated pyclass, e.g. `nested:
+/// NestedConfig` inside `ExtractionConfig`, or an enum-typed field at any nesting depth, e.g.
+/// `preset: PreprocessingPreset` inside `PreprocessingOptions` inside `ConversionConfig`) and the
+/// "batch" array-of-typed-items shape (`element_type`, e.g. `BatchFileItem`).
 ///
 /// Runs the identical traversal `render_kwarg_field_value` (typed_values.rs) uses to emit the
 /// actual constructor calls, discarding the rendered text and keeping only the type names it
-/// references -- so what gets constructed and what gets imported cannot silently disagree. ~keep
+/// references -- so what gets constructed and what gets imported cannot silently disagree.
+///
+/// Struct and enum names land in the caller's two separate sets (`used_config_types` /
+/// `used_enum_types`), mirroring the split `render_kwarg_field_value` already returns via
+/// `UsedTypeNames`. Merging both into one set here would fold every enum-typed field --
+/// including the top-level ones `collect_json_object_enum_types` already finds -- into the
+/// config-class import group, alphabetically interleaving two groups the import line otherwise
+/// keeps apart and reordering every generated file with more than one enum, not just the ones
+/// missing an import. ~keep
 pub(super) fn collect_nested_config_types(
     arg: &ArgMapping,
     value: &serde_json::Value,
     constructor_type: Option<&str>,
     context: KwargRenderContext<'_>,
     used_config_types: &mut BTreeSet<String>,
+    used_enum_types: &mut BTreeSet<String>,
 ) {
     if let Some(obj) = value.as_object() {
         for (key, field_value) in obj.iter() {
-            let mut nested = BTreeSet::new();
+            let mut nested = UsedTypeNames::default();
             let _ = render_kwarg_field_value(
                 key,
                 field_value,
@@ -39,7 +49,8 @@ pub(super) fn collect_nested_config_types(
                 context,
                 &mut nested,
             );
-            used_config_types.extend(nested);
+            used_config_types.extend(nested.structs);
+            used_enum_types.extend(nested.enums);
         }
     }
 
@@ -48,7 +59,7 @@ pub(super) fn collect_nested_config_types(
     {
         for item in arr.iter().filter_map(|v| v.as_object()) {
             for (key, field_value) in item.iter() {
-                let mut nested = BTreeSet::new();
+                let mut nested = UsedTypeNames::default();
                 let _ = render_kwarg_field_value(
                     key,
                     field_value,
@@ -57,7 +68,8 @@ pub(super) fn collect_nested_config_types(
                     context,
                     &mut nested,
                 );
-                used_config_types.extend(nested);
+                used_config_types.extend(nested.structs);
+                used_enum_types.extend(nested.enums);
             }
         }
     }
@@ -245,6 +257,7 @@ mod tests {
         let arg = config_arg();
         let value = serde_json::json!({"nested": {"value": "x"}});
         let mut used_config_types: BTreeSet<String> = BTreeSet::new();
+        let mut used_enum_types: BTreeSet<String> = BTreeSet::new();
         let context = KwargRenderContext {
             type_defs: &type_defs,
             enums: &[],
@@ -252,7 +265,14 @@ mod tests {
             docs_files: &[],
             leaf_source: LeafSource::Literal,
         };
-        collect_nested_config_types(&arg, &value, Some("ExtractionConfig"), context, &mut used_config_types);
+        collect_nested_config_types(
+            &arg,
+            &value,
+            Some("ExtractionConfig"),
+            context,
+            &mut used_config_types,
+            &mut used_enum_types,
+        );
 
         assert_eq!(
             used_config_types,
@@ -294,6 +314,7 @@ mod tests {
         let arg = config_arg();
         let value = serde_json::json!({"profiles": {"first": {"value": "x"}}});
         let mut used_config_types: BTreeSet<String> = BTreeSet::new();
+        let mut used_enum_types: BTreeSet<String> = BTreeSet::new();
         let context = KwargRenderContext {
             type_defs: &type_defs,
             enums: &[],
@@ -301,7 +322,14 @@ mod tests {
             docs_files: &[],
             leaf_source: LeafSource::Literal,
         };
-        collect_nested_config_types(&arg, &value, Some("ExtractionConfig"), context, &mut used_config_types);
+        collect_nested_config_types(
+            &arg,
+            &value,
+            Some("ExtractionConfig"),
+            context,
+            &mut used_config_types,
+            &mut used_enum_types,
+        );
 
         assert_eq!(
             used_config_types,
@@ -340,6 +368,7 @@ mod tests {
         arg.element_type = Some("BatchFileItem".to_string());
         let value = serde_json::json!([{"nested": {"value": "x"}}]);
         let mut used_config_types: BTreeSet<String> = BTreeSet::new();
+        let mut used_enum_types: BTreeSet<String> = BTreeSet::new();
         let context = KwargRenderContext {
             type_defs: &type_defs,
             enums: &[],
@@ -347,7 +376,14 @@ mod tests {
             docs_files: &[],
             leaf_source: LeafSource::Literal,
         };
-        collect_nested_config_types(&arg, &value, None, context, &mut used_config_types);
+        collect_nested_config_types(
+            &arg,
+            &value,
+            None,
+            context,
+            &mut used_config_types,
+            &mut used_enum_types,
+        );
 
         assert_eq!(
             used_config_types,
@@ -388,6 +424,7 @@ mod tests {
         let arg = config_arg();
         let value = serde_json::json!({"nested": {"value": "x"}});
         let mut used_config_types: BTreeSet<String> = BTreeSet::new();
+        let mut used_enum_types: BTreeSet<String> = BTreeSet::new();
         let context = KwargRenderContext {
             type_defs: &type_defs,
             enums: &[],
@@ -395,7 +432,14 @@ mod tests {
             docs_files: &[],
             leaf_source: LeafSource::Literal,
         };
-        collect_nested_config_types(&arg, &value, Some("ExtractionConfig"), context, &mut used_config_types);
+        collect_nested_config_types(
+            &arg,
+            &value,
+            Some("ExtractionConfig"),
+            context,
+            &mut used_config_types,
+            &mut used_enum_types,
+        );
         assert!(
             used_config_types.contains("GhostConfig"),
             "test setup: GhostConfig must be collected as a candidate for this to be a real test of pruning"
@@ -587,6 +631,75 @@ mod tests {
         assert!(
             out.contains("NestedConfig(inner=DeeperConfig(value="),
             "both levels must be constructed, got:\n{out}"
+        );
+    }
+
+    /// Regression test for the shipped defect: an enum-typed field nested inside a nested config
+    /// object (e.g. `PreprocessingOptions.preset: PreprocessingPreset` inside `ConversionOptions`,
+    /// html-to-markdown's `test_options.py`) is rendered correctly by `render_kwarg_field_value`
+    /// (which calls `PreprocessingPreset("Aggressive")`) but, before this fix, was never recorded
+    /// into `used_config_types` -- only the nested *struct* class (`PreprocessingOptions`) was.
+    /// The import line must carry both names the body actually references.
+    #[test]
+    fn render_test_file_imports_enum_type_nested_inside_a_nested_config_object() {
+        let outer = TypeDef {
+            name: "ConversionOptions".to_string(),
+            rust_path: "demo::ConversionOptions".to_string(),
+            fields: vec![FieldDef {
+                name: "preprocessing".to_string(),
+                ty: TypeRef::Named("PreprocessingOptions".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let inner = TypeDef {
+            name: "PreprocessingOptions".to_string(),
+            rust_path: "demo::PreprocessingOptions".to_string(),
+            fields: vec![FieldDef {
+                name: "preset".to_string(),
+                ty: TypeRef::Named("PreprocessingPreset".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let type_defs = vec![outer, inner];
+        let enums = vec![crate::core::ir::EnumDef {
+            name: "PreprocessingPreset".to_string(),
+            rust_path: "demo::PreprocessingPreset".to_string(),
+            ..Default::default()
+        }];
+
+        let e2e_config = e2e_config_with_options_type("ConversionOptions");
+        let config = crate::core::config::ResolvedCrateConfig::default();
+        let fixture = fixture_with_input(
+            "preprocessing_aggressive",
+            serde_json::json!({"config": {"preprocessing": {"preset": "Aggressive"}}}),
+        );
+        let fixtures: Vec<&Fixture> = vec![&fixture];
+
+        let out = super::super::render_test_file(
+            "smoke",
+            &fixtures,
+            &e2e_config,
+            &config,
+            &type_defs,
+            &enums,
+            &[],
+            &[],
+            false,
+        );
+
+        let import_line = out
+            .lines()
+            .find(|line| line.starts_with("from sample_pkg import"))
+            .unwrap_or_else(|| panic!("no `from sample_pkg import ...` line in output, got:\n{out}"));
+        assert!(
+            import_line.contains("PreprocessingPreset"),
+            "the nested enum type must be imported alongside its containing class, got: {import_line:?}"
+        );
+        assert!(
+            out.contains("PreprocessingPreset(\"Aggressive\")"),
+            "the nested enum field must be constructed, got:\n{out}"
         );
     }
 

--- a/src/e2e/codegen/python/test_file.rs
+++ b/src/e2e/codegen/python/test_file.rs
@@ -314,6 +314,7 @@ pub(super) fn render_test_file(
                     constructor_type,
                     context,
                     &mut used_config_types,
+                    &mut used_enum_types,
                 );
             }
 

--- a/src/e2e/codegen/python/test_function.rs
+++ b/src/e2e/codegen/python/test_function.rs
@@ -24,7 +24,9 @@ use super::visitors::{
 use args::build_args_and_setup;
 use error_assertions::emit_error_assertion;
 use result_assertions::emit_result_and_assertions;
-pub(super) use typed_values::{KwargRenderContext, LeafSource, render_kwarg_field_value, resolve_field_enum_type};
+pub(super) use typed_values::{
+    KwargRenderContext, LeafSource, UsedTypeNames, render_kwarg_field_value, resolve_field_enum_type,
+};
 
 /// Read-only inputs to [`render_test_function`], bundled because every field is invariant
 /// borrowed/`Copy` state describing the fixture category being rendered -- `out`, the string

--- a/src/e2e/codegen/python/test_function/typed_values.rs
+++ b/src/e2e/codegen/python/test_function/typed_values.rs
@@ -25,11 +25,11 @@ use super::super::json::json_to_python_literal;
 /// for the whole recursion, so it belongs here rather than as a parallel argument threaded
 /// through every function in the call tree.
 ///
-/// `used_struct_types` is deliberately NOT a field here: it is a per-call *output* accumulator
-/// that every level mutates, not read-only shared state, so it stays its own `&mut` argument at
-/// each call site. Folding a mutable accumulator into an otherwise `Copy`, read-only bundle
-/// would force every function to take `&mut KwargRenderContext` and forfeit the very simplicity
-/// -- cheap, ordinary reborrows -- this struct exists to buy. ~keep
+/// `used_types` is deliberately NOT a field here: it is a per-call *output* accumulator that
+/// every level mutates, not read-only shared state, so it stays its own `&mut` argument at each
+/// call site. Folding a mutable accumulator into an otherwise `Copy`, read-only bundle would
+/// force every function to take `&mut KwargRenderContext` and forfeit the very simplicity --
+/// cheap, ordinary reborrows -- this struct exists to buy. ~keep
 #[derive(Clone, Copy)]
 pub(in crate::e2e::codegen::python) struct KwargRenderContext<'a> {
     pub type_defs: &'a [crate::core::ir::TypeDef],
@@ -37,6 +37,18 @@ pub(in crate::e2e::codegen::python) struct KwargRenderContext<'a> {
     pub enum_fields: &'a HashMap<String, String>,
     pub docs_files: &'a [FixtureDocsFileInput],
     pub leaf_source: LeafSource<'a>,
+}
+
+/// Output accumulator for one `render_kwarg_field_value` traversal: every nested config/struct
+/// class and every enum class it actually constructs, kept in two separate sets so a caller
+/// merging them into an import list can keep the existing grouped ordering (config classes,
+/// then enum classes) instead of collapsing both kinds into one alphabetically-interleaved list
+/// -- a class-only rename here would otherwise reorder the import line of every generated file
+/// that references more than one enum, not just the ones that were missing an import. ~keep
+#[derive(Default)]
+pub(in crate::e2e::codegen::python) struct UsedTypeNames {
+    pub structs: BTreeSet<String>,
+    pub enums: BTreeSet<String>,
 }
 
 /// Where a leaf field value's Python expression comes from -- see the `leaf_source` doc on
@@ -118,27 +130,26 @@ pub(in crate::e2e::codegen::python) fn resolve_field_enum_type(
 /// Render one field's JSON value as a Python expression for a `kwargs`-mode constructor call,
 /// recursing into nested config/struct fields so a field whose type is itself a generated
 /// pyclass (e.g. `nested: NestedConfig` inside `ExtractionConfig`) is constructed with
-/// that class instead of a raw dict literal. `used_struct_types` records every nested
-/// constructor name this rendering references, so a caller collecting imports can run the
-/// identical traversal instead of a second copy that could disagree with what actually gets
-/// emitted (the same technique `handle_values::collect_used_nested_types` uses). ~keep
+/// that class instead of a raw dict literal. `used_types` records every nested constructor name
+/// this rendering references -- struct classes in `used_types.structs`, enum classes in
+/// `used_types.enums` -- so a caller collecting imports can run the identical traversal instead
+/// of a second copy that could disagree with what actually gets emitted (the same technique
+/// `handle_values::collect_used_nested_types` uses). ~keep
 pub(in crate::e2e::codegen::python) fn render_kwarg_field_value(
     field_name: &str,
     value: &serde_json::Value,
     containing_type: Option<&str>,
     pointer: &str,
     context: KwargRenderContext<'_>,
-    used_struct_types: &mut BTreeSet<String>,
+    used_types: &mut UsedTypeNames,
 ) -> String {
-    if let Some(rendered) = render_enum_field_value(field_name, value, containing_type, context) {
+    if let Some(rendered) = render_enum_field_value(field_name, value, containing_type, context, used_types) {
         return rendered;
     }
     if let Some(rendered) = render_docs_file_field_value(pointer, context.docs_files) {
         return rendered;
     }
-    if let Some(rendered) =
-        render_typed_field_value(field_name, value, containing_type, pointer, context, used_struct_types)
-    {
+    if let Some(rendered) = render_typed_field_value(field_name, value, containing_type, pointer, context, used_types) {
         return rendered;
     }
 
@@ -195,12 +206,12 @@ fn render_typed_field_value(
     containing_type: Option<&str>,
     pointer: &str,
     context: KwargRenderContext<'_>,
-    used_struct_types: &mut BTreeSet<String>,
+    used_types: &mut UsedTypeNames,
 ) -> Option<String> {
     let opts_type = containing_type?;
     let type_def = context.type_defs.iter().find(|t| t.name == opts_type)?;
     let field = type_def.fields.iter().find(|f| f.name == field_name)?;
-    render_value_for_type_ref(&field.ty, value, pointer, context, used_struct_types)
+    render_value_for_type_ref(&field.ty, value, pointer, context, used_types)
 }
 
 /// Uniform recursive core replacing the former shape-by-shape dispatch (one arm each for a
@@ -223,7 +234,7 @@ fn render_value_for_type_ref(
     value: &serde_json::Value,
     pointer: &str,
     context: KwargRenderContext<'_>,
-    used_struct_types: &mut BTreeSet<String>,
+    used_types: &mut UsedTypeNames,
 ) -> Option<String> {
     use crate::core::ir::TypeRef;
 
@@ -231,16 +242,10 @@ fn render_value_for_type_ref(
         TypeRef::Named(name) => {
             let type_def = context.type_defs.iter().find(|t| &t.name == name)?;
             let obj = value.as_object()?;
-            Some(render_struct_constructor(
-                type_def,
-                obj,
-                pointer,
-                context,
-                used_struct_types,
-            ))
+            Some(render_struct_constructor(type_def, obj, pointer, context, used_types))
         }
         TypeRef::Optional(_) if value.is_null() => Some("None".to_string()),
-        TypeRef::Optional(inner) => render_value_for_type_ref(inner, value, pointer, context, used_struct_types),
+        TypeRef::Optional(inner) => render_value_for_type_ref(inner, value, pointer, context, used_types),
         TypeRef::Vec(inner) => {
             let items = value
                 .as_array()?
@@ -248,7 +253,7 @@ fn render_value_for_type_ref(
                 .enumerate()
                 .map(|(index, item)| {
                     let item_pointer = array_item_pointer(pointer, index, context.leaf_source);
-                    render_value_for_type_ref(inner, item, &item_pointer, context, used_struct_types)
+                    render_value_for_type_ref(inner, item, &item_pointer, context, used_types)
                 })
                 .collect::<Option<Vec<String>>>()?;
             Some(format!("[{}]", items.join(", ")))
@@ -259,8 +264,7 @@ fn render_value_for_type_ref(
                 .iter()
                 .map(|(key, entry)| {
                     let entry_pointer = format!("{pointer}/{}", escape_json_pointer(key));
-                    let rendered =
-                        render_value_for_type_ref(value_ty, entry, &entry_pointer, context, used_struct_types)?;
+                    let rendered = render_value_for_type_ref(value_ty, entry, &entry_pointer, context, used_types)?;
                     Some(format!("\"{}\": {rendered}", escape_python(key)))
                 })
                 .collect::<Option<Vec<String>>>()?;
@@ -274,20 +278,35 @@ fn render_value_for_type_ref(
 /// an auto-detected enum field type, renders as `EnumType("variant")`. Mirrors the original
 /// inline logic exactly -- an `enum_fields` hit with a non-string value falls through to the
 /// remaining branches rather than trying auto-detection.
+///
+/// Records the resolved enum type name into `used_types.enums` -- the enum half of the same
+/// [`UsedTypeNames`] accumulator [`render_struct_constructor`] records nested config classes
+/// into (`used_types.structs`) -- so a caller collecting import candidates by running this
+/// traversal sees every type it constructs, enum or struct, through one shared output instead of
+/// a second hand-maintained scan that could disagree with it. Before this, an enum field nested
+/// inside a nested config object (e.g. `PreprocessingOptions.preset: PreprocessingPreset` inside
+/// `ConversionOptions`) was rendered correctly here but never recorded anywhere, so the import
+/// list omitted it even though the emitted body referenced it. Kept in its own set rather than
+/// merged into `used_types.structs` so a caller can still emit config classes and enum classes
+/// as two separately-ordered groups, matching the import line's existing shape instead of
+/// re-sorting every name in the file together. ~keep
 fn render_enum_field_value(
     field_name: &str,
     value: &serde_json::Value,
     containing_type: Option<&str>,
     context: KwargRenderContext<'_>,
+    used_types: &mut UsedTypeNames,
 ) -> Option<String> {
     if let Some(enum_type) = context.enum_fields.get(field_name) {
         if let Some(s) = value.as_str() {
+            used_types.enums.insert(enum_type.clone());
             return Some(format!("{enum_type}(\"{s}\")"));
         }
     } else if let Some(auto_enum_type) =
         resolve_field_enum_type(field_name, containing_type, context.type_defs, context.enums)
         && let Some(s) = value.as_str()
     {
+        used_types.enums.insert(auto_enum_type.clone());
         return Some(format!("{auto_enum_type}(\"{s}\")"));
     }
     None
@@ -324,9 +343,9 @@ fn render_struct_constructor(
     obj: &serde_json::Map<String, serde_json::Value>,
     pointer: &str,
     context: KwargRenderContext<'_>,
-    used_struct_types: &mut BTreeSet<String>,
+    used_types: &mut UsedTypeNames,
 ) -> String {
-    used_struct_types.insert(type_def.name.clone());
+    used_types.structs.insert(type_def.name.clone());
     let kwargs: Vec<String> = obj
         .iter()
         .map(|(field_name, field_value)| {
@@ -338,7 +357,7 @@ fn render_struct_constructor(
                 Some(type_def.name.as_str()),
                 &field_pointer,
                 context,
-                used_struct_types,
+                used_types,
             );
             format!("{snake_key}={rendered}")
         })
@@ -491,14 +510,13 @@ fn build_typed_kwargs_constructor(
     context: KwargRenderContext<'_>,
 ) -> Option<String> {
     let obj = value.as_object()?;
-    let mut used_struct_types = BTreeSet::new();
+    let mut used_types = UsedTypeNames::default();
     let kwargs: Vec<String> = obj
         .iter()
         .map(|(k, v)| {
             let snake_key = k.to_snake_case();
             let field_pointer = format!("/{}", escape_json_pointer(k));
-            let py_val =
-                render_kwarg_field_value(k, v, Some(opts_type), &field_pointer, context, &mut used_struct_types);
+            let py_val = render_kwarg_field_value(k, v, Some(opts_type), &field_pointer, context, &mut used_types);
             format!("{snake_key}={py_val}")
         })
         .collect();
@@ -686,14 +704,13 @@ fn emit_python_typed_instance(
     pointer: &str,
     context: KwargRenderContext<'_>,
 ) -> String {
-    let mut used_struct_types = BTreeSet::new();
+    let mut used_types = UsedTypeNames::default();
     let kwargs: Vec<String> = obj
         .iter()
         .map(|(k, v)| {
             let snake_key = k.to_snake_case();
             let field_pointer = format!("{pointer}/{}", escape_json_pointer(k));
-            let rendered =
-                render_kwarg_field_value(k, v, Some(elem_type), &field_pointer, context, &mut used_struct_types);
+            let rendered = render_kwarg_field_value(k, v, Some(elem_type), &field_pointer, context, &mut used_types);
             format!("{snake_key}={rendered}")
         })
         .collect();

--- a/src/e2e/codegen/python/test_function/typed_values_tests.rs
+++ b/src/e2e/codegen/python/test_function/typed_values_tests.rs
@@ -375,9 +375,9 @@ fn render_value_for_type_ref_returns_none_for_non_struct_map_value() {
     };
     let type_ref = TypeRef::Map(Box::new(TypeRef::String), Box::new(TypeRef::String));
     let value = serde_json::json!({"a": "b"});
-    let mut used_struct_types = BTreeSet::new();
+    let mut used_types = UsedTypeNames::default();
 
-    let result = render_value_for_type_ref(&type_ref, &value, "", context, &mut used_struct_types);
+    let result = render_value_for_type_ref(&type_ref, &value, "", context, &mut used_types);
     assert!(result.is_none(), "got: {result:?}");
 }
 
@@ -412,9 +412,9 @@ fn render_value_for_type_ref_unwraps_optional_map_of_structs() {
         Box::new(TypeRef::Named("NestedConfig".to_string())),
     )));
     let value = serde_json::json!({"first": {"model": "standard"}});
-    let mut used_struct_types = BTreeSet::new();
+    let mut used_types = UsedTypeNames::default();
 
-    let result = render_value_for_type_ref(&type_ref, &value, "", context, &mut used_struct_types);
+    let result = render_value_for_type_ref(&type_ref, &value, "", context, &mut used_types);
     assert_eq!(result.as_deref(), Some(r#"{"first": NestedConfig(model="standard")}"#));
 }
 


### PR DESCRIPTION
Generated Python e2e tests referenced an enum the generated import list omitted:

```
E   NameError: name 'PreprocessingPreset' is not defined
FAILED tests/test_options.py::test_options_preprocessing_aggressive
FAILED tests/test_options.py::test_options_preprocessing_minimal
```

This failed h2m's `Test: Python` job on all 9 matrix cells.

## The second derivation, which is the real defect

Two mechanisms scanned the call arg for enum-typed fields: `collect_json_object_enum_types` checked only **top-level** keys, while `render_kwarg_field_value`'s recursive traversal — the one that renders the actual constructor calls — walked nested config objects at any depth. The traversal already detected and correctly *rendered* nested enum fields; `render_enum_field_value` simply had no output parameter, so nothing recorded that a nested enum was used. Any enum nested inside a nested config object was invisible to import collection at any depth.

The render traversal now has a proper output (`UsedTypeNames { structs, enums }`), so the import builder gets both from one traversal instead of a second hand-maintained scan.

Worth recording: the first attempt flowed both into one set, which re-sorted the whole import line alphabetically for any file with more than one enum. That would have failed the empty-diff bar, and it was caught by running against a real repo rather than by inspecting the emitted text. The accumulator is split so the two ordered groups are preserved and only the missing name is inserted.

## Verification

- Acceptance is pytest, not a grep: before-fix regeneration reproduces `2 failed, 281 passed` with the identical `NameError` on the identical two tests; after-fix, `283 passed`.
- Blast radius, isolated before-binary versus after-binary on fresh archives: **102 Python e2e files attempted across 5 repos, exactly 1 changed**, 0 elsewhere.
- Neutralised in the committed file: the missing import returns; restored, 226/226 pass and the diff against `git show HEAD` is empty.
- Full `cargo test` across all targets, clippy `-D warnings`, `fmt --check` clean.

Same family as the napi enum, the C#/Dart variant hop, the pyo3 TypedDict and the node `bm_25` enum: a symbol referenced in the emitted body that the emitter's own import path never checks against.