### PR TITLE
ci: install go on every leg and count toolchain fixture skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,18 @@ jobs:
           # JDK is also `javac`, the oracle `ALEF_REQUIRE_JAVAC` below requires.
           java-version: "25"
       - uses: xberg-io/actions/setup-maven@v1
+      # Go is NOT preinstalled on every GitHub-hosted image. The arm64 macOS images carry none,
+      # which is why `Test (macos-latest)` failed nine generated-Go fixtures on every run from
+      # 2026-08-31 (the commit that added them) onward while `ALEF_REQUIRE_GO` below turned the
+      # skip into a panic. Installing it explicitly on all three legs is far cheaper than
+      # weakening the fixtures, and it is what makes `--require go` in the census step below
+      # honest. Pinned to the minor line alef itself emits into generated `go.mod` files
+      # (`go 1.26`, see `e2e::codegen::go`), so the toolchain CI compiles the output with can
+      # never be older than the directive that output declares. ~keep
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
       - uses: xberg-io/actions/setup-zig@v1
       - uses: xberg-io/actions/setup-elixir@v1
         with:
@@ -111,6 +123,20 @@ jobs:
         uses: fwilhe2/setup-kotlin@ee9692514da313706b193d808526812102a344e4 # v2.0
         with:
           version: "2.4.10"
+      # Swift is the one toolchain here that genuinely cannot be installed on every leg: it ships
+      # with Xcode on macOS, while the Windows toolchain is a multi-gigabyte installer with no
+      # first-party setup action and Linux would need a separate swift.org tarball -- for a single
+      # fixture. So macOS is where the SwiftPM compile gate has to run, and the census step below
+      # is what proves it did rather than assuming it. ~keep
+      - name: Require the Swift toolchain on macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo "ALEF_REQUIRE_SWIFT=1" >> "$GITHUB_ENV"
+      # The cargo cache restores `target/`, so a previous run's tallies would otherwise be summed
+      # into this one and could report fixtures as executed that this run never reached.
+      - name: Clear the toolchain fixture census
+        shell: bash
+        run: rm -rf target/toolchain-census
       - name: Run tests
         env:
           ALEF_REQUIRE_ELIXIR: "1"
@@ -125,10 +151,11 @@ jobs:
           ALEF_REQUIRE_JAVAC: "1"
           ALEF_REQUIRE_DOTNET: "1"
           ALEF_REQUIRE_KOTLINC: "1"
-          # Go needs no dedicated setup step above (GitHub-hosted runner images preinstall a Go
-          # LTS toolchain), but the two `go test` compile canaries in
-          # `backends::go::gen_bindings::service_api::tests` silently skipped when `go` was
-          # missing just the same as the dotnet ones did -- see `required_go` there.
+          # Paired with the `Set up Go` step above, which is not optional: the claim this comment
+          # used to make -- that GitHub-hosted images all preinstall a Go LTS toolchain, so this
+          # variable needed no `uses:` step -- is false for the arm64 macOS images, and setting
+          # the variable without installing Go only converted a silent skip into a permanently red
+          # leg. `ci_requires_go_for_runtime_regressions` now asserts both halves are present.
           ALEF_REQUIRE_GO: "1"
         run: cargo test --workspace
       # Every Elixir escaping oracle is #[ignore]d, so the step above runs none of them and
@@ -138,6 +165,25 @@ jobs:
       # not this comment, which contains both needles) and fails if either goes missing.
       - name: Run the Elixir escaping oracles
         run: cargo test --lib elixir_oracle -- --ignored --nocapture
+      # Counts what the two steps above actually executed, per toolchain, and fails when a
+      # toolchain this leg installed executed zero fixtures.
+      #
+      # A fixture that shells out to a real toolchain has three possible outcomes and only two of
+      # them are honest: it can pass, it can fail, or it can quietly verify nothing and be counted
+      # as a pass. `cargo test`'s own summary cannot tell the third apart from the first -- both
+      # print `test result: ok` -- so this step prints the ratio instead: "12 of 12 go fixtures
+      # executed" versus "0 of 12 executed". `if: ${{ !cancelled() }}` so the ratio is still
+      # reported when the suite failed, which is when it is most useful for telling an
+      # environmental failure from a real one. ~keep
+      - name: Toolchain fixture census
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            scripts/toolchain-census.sh --require go --require swift
+          else
+            scripts/toolchain-census.sh --require go
+          fi
 
   # Runs the consumer's own toolchain gate over a tree alef emits, in a scratch directory.
   # The `validate` job above lints alef; this one lints alef's *output*, which nothing

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,7 +40,17 @@ tasks:
   test:
     desc: "Run all tests"
     cmds:
+      - rm -rf target/toolchain-census
       - cargo test --workspace
+      - task: test:census
+
+  test:census:
+    desc: "Report how many toolchain-dependent fixtures the last test run actually executed"
+    cmds:
+      # No `--require` locally: a contributor without Go or Swift installed should see the ratio,
+      # not a failure. CI passes `--require` for the toolchains its runner installs, which is
+      # where a zero-execution run has to be fatal.
+      - ./scripts/toolchain-census.sh
 
   test:release:
     desc: "Run all tests in release mode (catches release-only optimizer/lifetime issues)"

--- a/scripts/toolchain-census.sh
+++ b/scripts/toolchain-census.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+#
+# Report how many toolchain-dependent fixtures actually executed, and fail when a toolchain this
+# platform installed executed none of them.
+#
+# `src/test_support/toolchain.rs` writes one TSV per test binary into
+# `<target-dir>/toolchain-census/`, each row `<toolchain>\t<attempted>\t<executed>\t<skipped>`.
+# This script sums them and prints the result. It exists because there is nowhere inside the test
+# run to print it from: `libtest` offers no end-of-run hook and captures the stdout and stderr of
+# passing tests, so a fixture that skipped itself has no way to say so in a run that is otherwise
+# green -- which is exactly the run where it matters.
+#
+# The check is deliberately about cardinality, not about the toolchain being on PATH. A fixture
+# family that was deleted, renamed out of its filter, or `#[ignore]`d reports zero attempts, and
+# that fails here just as loudly as a missing toolchain does: both are runs that examined nothing
+# while reporting success.
+#
+# Usage:
+#   scripts/toolchain-census.sh [--dir <census-dir>] [--require <toolchain>]...
+#
+# `--require` names a toolchain the caller guarantees is installed on this platform, so anything
+# other than "every attempt executed" is a failure. Toolchains not named are reported with their
+# counts and never fail the run.
+
+set -eu
+
+census_dir="target/toolchain-census"
+required=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir)
+      [ $# -ge 2 ] || { echo "toolchain-census: --dir needs a value" >&2; exit 2; }
+      census_dir="$2"
+      shift 2
+      ;;
+    --require)
+      [ $# -ge 2 ] || { echo "toolchain-census: --require needs a value" >&2; exit 2; }
+      required="$required $2"
+      shift 2
+      ;;
+    *)
+      echo "toolchain-census: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+echo "alef toolchain fixture census -- $census_dir"
+
+if [ -d "$census_dir" ]; then
+  # `find`, not a glob, so an empty directory produces no rows rather than a literal `*.tsv`.
+  find "$census_dir" -name '*.tsv' -type f -exec cat {} +
+fi | awk -v required="$required" '
+  BEGIN {
+    split(required, wanted, " ")
+    for (index_ in wanted) {
+      if (wanted[index_] != "") {
+        is_required[wanted[index_]] = 1
+        seen[wanted[index_]] = 1
+      }
+    }
+  }
+  NF == 4 {
+    attempted[$1] += $2
+    executed[$1] += $3
+    skipped[$1] += $4
+    seen[$1] = 1
+  }
+  END {
+    failures = 0
+    count = 0
+    for (name in seen) { count++ }
+    if (count == 0) {
+      print "  (no toolchain-gated fixture reported in; nothing was measured)"
+    }
+    for (name in seen) {
+      total = attempted[name] + 0
+      ran = executed[name] + 0
+      missed = skipped[name] + 0
+      status = is_required[name] ? "required" : "optional"
+      printf "  %-10s %2d of %2d fixtures executed (%d skipped) [%s]", name, ran, total, missed, status
+      if (is_required[name] && ran == 0) {
+        printf "  <-- FAILED: nothing ran\n"
+        failures++
+      } else if (is_required[name] && missed > 0) {
+        printf "  <-- FAILED: %d skipped on a platform that installs %s\n", missed, name
+        failures++
+      } else if (ran == 0) {
+        printf "  <-- NOT RUN: %s is absent, so these fixtures verified nothing\n", name
+      } else {
+        printf "  ok\n"
+      }
+    }
+    if (failures > 0) {
+      printf "\ntoolchain-census: %d required toolchain(s) executed fewer fixtures than this\n", failures
+      print "platform guarantees. A green test run that skipped these examined nothing; treat it"
+      print "as a red one. Install the toolchain, or stop declaring it required for this platform."
+      exit 1
+    }
+  }
+'

--- a/src/backends/go/gen_bindings/service_api/tests.rs
+++ b/src/backends/go/gen_bindings/service_api/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::core::ir::{
     EntrypointDef, EntrypointKind, HandlerContractDef, MethodDef, ParamDef, RegistrationDef, ServiceDef, TypeRef,
 };
+use crate::test_support::toolchain;
 
 fn make_fixture_surface() -> ApiSurface {
     let constructor = MethodDef {
@@ -171,45 +172,16 @@ fn test_gen_service_go_produces_valid_go() {
     assert!(go.contains("owner C.uint64_t"));
 }
 
-/// Panics instead of returning `None` when `required` is `true` and `go` is unavailable -- the
-/// failure mode this exists to close: a runner whose Go setup silently regressed, where the two
-/// real `go test` compile checks below would otherwise just as silently skip.
-///
-/// `required` is a plain parameter, and `go` an already-resolved lookup, rather than this
-/// function reading `ALEF_REQUIRE_GO` or calling `which::which` itself, so
-/// `required_go_mode_fails_when_toolchain_is_unavailable` below can prove the panic fires with a
-/// fabricated "unavailable" input instead of needing to actually hide `go` from `PATH`.
-fn require_go_available(go: Option<std::path::PathBuf>, required: bool) -> Option<std::path::PathBuf> {
-    assert!(
-        go.is_some() || !required,
-        "ALEF_REQUIRE_GO is set but go is unavailable"
-    );
-    go
-}
-
 /// A `go` that actually runs, or `None` when it is not installed.
 ///
-/// A version-manager shim (e.g. `g`, `asdf`) resolves on `PATH` and spawns fine even with no Go
-/// toolchain installed behind it, then exits non-zero -- so `which::which("go").ok()` alone
-/// would leave `require_go_available`'s panic-free skip unreachable and fail the two real `go
-/// test` compile checks below on every such machine. ~keep
+/// Delegates to the crate-wide [`toolchain::GO`] gate rather than calling `which::which` here, so
+/// the two real `go test` compile checks below are counted in the same attempted/executed census
+/// every other generated-Go fixture reports into -- a skip that nothing counts is the failure
+/// mode the gate exists to close, and this file used to have its own uncounted copy of it. The
+/// gate also panics rather than skipping when `ALEF_REQUIRE_GO` is set, which is what makes a
+/// runner whose Go setup silently regressed fail loudly. ~keep
 fn required_go() -> Option<std::path::PathBuf> {
-    let go = which::which("go").ok().filter(|_| go_is_runnable());
-    require_go_available(go, std::env::var_os("ALEF_REQUIRE_GO").is_some())
-}
-
-/// Whether `go` runs, not merely resolves. See [`required_go`]. ~keep
-fn go_is_runnable() -> bool {
-    static RUNNABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *RUNNABLE.get_or_init(|| {
-        std::process::Command::new("go")
-            .arg("version")
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
-    })
+    toolchain::GO.open()
 }
 
 #[test]
@@ -567,27 +539,28 @@ func use(config Config) error {{
     );
 }
 
-/// Proves required-toolchain mode cannot turn a missing `go` into a silently-passed compile
-/// check, mirroring `tests/identifier_grammar_compiler_oracle.rs`'s
-/// `required_javac_mode_fails_when_toolchain_is_unavailable` and siblings.
-#[test]
-fn required_go_mode_fails_when_toolchain_is_unavailable() {
-    let result = std::panic::catch_unwind(|| require_go_available(None, true));
-    let panic = result.expect_err("required mode must fail when go is unavailable");
-    let message = panic
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| panic.downcast_ref::<&str>().copied())
-        .unwrap_or("non-string panic");
-    assert!(message.contains("ALEF_REQUIRE_GO is set"), "got: {message}");
-}
-
-/// Keeps required mode wired to a job that actually has `go` on `PATH`. GitHub-hosted runner
-/// images preinstall a Go LTS toolchain (`actions/go-versions`), so unlike
+/// Keeps required mode wired to a job that actually has `go` on `PATH`.
+///
+/// The env var alone is not enough, and assuming it was is exactly how this went wrong: the
+/// previous version of this test asserted only `ALEF_REQUIRE_GO`, on the stated grounds that
+/// "GitHub-hosted runner images preinstall a Go LTS toolchain, so unlike
 /// `ALEF_REQUIRE_JAVAC`/`ALEF_REQUIRE_DOTNET`/`ALEF_REQUIRE_KOTLINC` this needs no dedicated
-/// `uses:` setup step -- only the env var.
+/// `uses:` setup step". That is false for the arm64 macOS images, which carry no Go at all, so
+/// setting the variable there only converted a silent skip into a permanent, ignored red on
+/// `Test (macos-latest)` from 2026-08-31 onward. Requiring the explicit setup step means the
+/// claim is now enforced rather than assumed. ~keep
 #[test]
 fn ci_requires_go_for_runtime_regressions() {
     let workflow = include_str!("../../../../../.github/workflows/ci.yml");
-    assert!(workflow.contains("ALEF_REQUIRE_GO: \"1\""));
+
+    assert!(
+        workflow.contains("ALEF_REQUIRE_GO: \"1\""),
+        "the test job must make a missing Go toolchain a hard failure"
+    );
+    assert!(
+        workflow.contains("uses: actions/setup-go@"),
+        "`ALEF_REQUIRE_GO` needs an explicit Go install on every leg of the matrix: the arm64 \
+         macOS runner image does not preinstall one, so without this step the variable only \
+         turns a skip into a permanently red leg"
+    );
 }

--- a/src/backends/go/gen_bindings/types/field_shape_tests.rs
+++ b/src/backends/go/gen_bindings/types/field_shape_tests.rs
@@ -1,11 +1,17 @@
 use std::collections::HashSet;
 
 use crate::core::ir::{EnumDef, EnumVariant, FieldDef, TypeDef, TypeRef};
+use crate::test_support::toolchain;
 
 use super::gen_struct_type;
 
-fn go_compile(generated: &str, declarations: &str) -> std::process::Output {
-    let go = which::which("go").expect("Go is required for generated-Go compile fixtures");
+/// Compile the generated struct with the real Go toolchain, or `None` when Go is not installed.
+///
+/// `None` is not a pass: every caller must return without asserting, and
+/// [`toolchain::ToolchainGate::open`] has already counted the skip so the run reports how many of
+/// these fixtures actually executed. ~keep
+fn go_compile(generated: &str, declarations: &str) -> Option<std::process::Output> {
+    let go = toolchain::GO.open()?;
     let directory = tempfile::tempdir().expect("create Go compile fixture");
     std::fs::write(directory.path().join("go.mod"), "module example.com/shape\n\ngo 1.24\n").expect("write Go module");
     std::fs::write(
@@ -13,16 +19,20 @@ fn go_compile(generated: &str, declarations: &str) -> std::process::Output {
         format!("package shape\n\nimport \"encoding/json\"\n\n{declarations}\n{generated}"),
     )
     .expect("write generated Go source");
-    std::process::Command::new(go)
-        .arg("test")
-        .arg("./...")
-        .current_dir(directory.path())
-        .output()
-        .expect("run Go compiler")
+    Some(
+        std::process::Command::new(go)
+            .arg("test")
+            .arg("./...")
+            .current_dir(directory.path())
+            .output()
+            .expect("run Go compiler"),
+    )
 }
 
 fn assert_go_compiles(generated: &str, declarations: &str) {
-    let output = go_compile(generated, declarations);
+    let Some(output) = go_compile(generated, declarations) else {
+        return;
+    };
     assert!(
         output.status.success(),
         "generated Go failed to compile:\n{}\n{generated}",
@@ -47,8 +57,8 @@ const RUNTIME_INVARIANT_TEST_COUNT: usize = 1;
 /// assuming success. Kept separate from `assert_go_runtime_invariant` so a negative control can
 /// drive a deliberately failing invariant through this same path and observe the real failure —
 /// see `generated_go_runtime_invariant_control_rejects_broken_invariant` below. ~keep
-fn run_go_runtime_invariant(generated: &str, assertions: &str) -> std::process::Output {
-    let go = which::which("go").expect("Go is required for generated-Go runtime fixtures");
+fn run_go_runtime_invariant(generated: &str, assertions: &str) -> Option<std::process::Output> {
+    let go = toolchain::GO.open()?;
     let directory = tempfile::tempdir().expect("create Go runtime fixture");
     std::fs::write(directory.path().join("go.mod"), "module example.com/shape\n\ngo 1.24\n").expect("write Go module");
     std::fs::write(
@@ -63,17 +73,21 @@ fn run_go_runtime_invariant(generated: &str, assertions: &str) -> std::process::
         ),
     )
     .expect("write generated Go runtime test");
-    std::process::Command::new(go)
-        .args(["test", "-v", "./..."])
-        .current_dir(directory.path())
-        .output()
-        .expect("run Go runtime fixture")
+    Some(
+        std::process::Command::new(go)
+            .args(["test", "-v", "./..."])
+            .current_dir(directory.path())
+            .output()
+            .expect("run Go runtime fixture"),
+    )
 }
 
 /// Compile the generated struct and evaluate `assertions` inside a real `Test*` function,
 /// asserting the invariant ran and passed.
 fn assert_go_runtime_invariant(generated: &str, assertions: &str) {
-    let output = run_go_runtime_invariant(generated, assertions);
+    let Some(output) = run_go_runtime_invariant(generated, assertions) else {
+        return;
+    };
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
@@ -116,10 +130,12 @@ fn generated_go_runtime_invariant_control_rejects_broken_invariant() {
     // through this exact harness by hand: it failed at `go build` with two "imported and not
     // used" errors and never reached `TestGeneratedStructRuntimeInvariant`, which is precisely
     // the false-negative shape this control must not have. ~keep
-    let output = run_go_runtime_invariant(
+    let Some(output) = run_go_runtime_invariant(
         "type Envelope struct {\n\tPayload *json.RawMessage `json:\"payload,omitempty\"`\n}\n",
         "\t_ = json.RawMessage{}\n\tt.Fatalf(\"deliberately broken invariant\")\n",
-    );
+    ) else {
+        return;
+    };
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !output.status.success(),
@@ -134,7 +150,9 @@ fn generated_go_runtime_invariant_control_rejects_broken_invariant() {
 
 #[test]
 fn generated_go_compile_check_rejects_broken_source() {
-    let output = go_compile("func broken() { missingSymbol() }", "");
+    let Some(output) = go_compile("func broken() { missingSymbol() }", "") else {
+        return;
+    };
     assert!(!output.status.success(), "compile control unexpectedly passed");
 }
 

--- a/src/backends/swift/tests/trait_box_swiftpm_compile.rs
+++ b/src/backends/swift/tests/trait_box_swiftpm_compile.rs
@@ -20,8 +20,6 @@
 //! 'Swift...Bridge' in scope" failure a generated doc snippet hit before the umbrella module
 //! re-exported the protocol.
 
-#![allow(clippy::print_stderr)]
-
 use crate::backends::swift::gen_bindings::boxes::emit_function_param_box_files;
 use crate::backends::swift::gen_bindings::trait_bridge::{
     gen_bridge_registration_overloads_file, gen_trait_bridge_files,
@@ -30,9 +28,10 @@ use crate::core::config::{BridgeBinding, ResolvedCrateConfig, TraitBridgeConfig}
 use crate::core::ir::{
     ApiSurface, EnumDef, EnumVariant, FieldDef, MethodDef, ParamDef, PrimitiveType, TypeDef, TypeRef,
 };
+use crate::test_support::spawn_from_stable_dir;
+use crate::test_support::toolchain;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 /// Minimal stand-in for the swift-bridge runtime types that ship inside the real `RustBridge`
 /// target (`SwiftBridgeCore.swift`). Only the surface the generated box glue actually touches is
@@ -443,53 +442,28 @@ fn materialize_package(root: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Locate a `swift` driver, or explain loudly why the compile gate is not running.
+/// Locate a `swift` driver, or report that the compile gate did not run.
 ///
-/// On macOS a missing `swift` is an environment fault, not a portability concern -- failing there
-/// is deliberate, because a silently skipped compile gate is how this defect shipped in the first
-/// place. Elsewhere the toolchain genuinely may be absent, so the skip is allowed but shouted.
+/// Routed through the crate-wide [`toolchain::SWIFT`] gate, which counts this fixture as
+/// attempted and then as executed or skipped. The previous version of this function announced its
+/// own skip with `eprintln!`, which reads as loud and is not: `libtest` captures the stderr of a
+/// *passing* test, so that banner was invisible in every run where the gate actually lapsed --
+/// the one situation it was written for. The census file the gate writes is read by
+/// `scripts/toolchain-census.sh` after the run instead, where nothing can capture it.
 ///
-/// Resolution alone is not enough: a version-manager shim spawns fine then exits non-zero, which
-/// would make `which::which("swift")` report a driver that cannot actually build anything --
-/// silently defeating the "loud skip, never a silent one" contract this function exists for. ~keep
+/// On macOS a missing `swift` stays a hard failure, because the toolchain ships with Xcode there
+/// and CI sets `ALEF_REQUIRE_SWIFT` on that leg; elsewhere the toolchain genuinely may be absent,
+/// so the skip is allowed -- and counted. ~keep
 fn swift_driver() -> Option<PathBuf> {
-    if let Ok(path) = which::which("swift")
-        && swift_is_runnable()
-    {
-        return Some(path);
-    }
-    if cfg!(target_os = "macos") {
-        panic!(
-            "`swift` is not on PATH but this is macOS, where the Swift toolchain ships with Xcode. \
-             The two-target SwiftPM compile gate for the trait-box generator cannot run, and it is \
-             the only test that proves the generated Swift compiles. Install the toolchain rather \
-             than letting this gate lapse."
-        );
-    }
-    eprintln!(
-        "\n\
-         ================================================================\n\
-         SKIPPED: generated_trait_box_package_compiles\n\
-         No `swift` driver on PATH, so the generated Swift was NOT compiled.\n\
-         String-level assertions alone cannot catch alef #258; this run\n\
-         provides NO evidence that the trait-box output builds.\n\
-         ================================================================\n"
+    let driver = toolchain::SWIFT.open();
+    assert!(
+        driver.is_some() || !cfg!(target_os = "macos"),
+        "`swift` is not on PATH but this is macOS, where the Swift toolchain ships with Xcode. \
+         The two-target SwiftPM compile gate for the trait-box generator cannot run, and it is \
+         the only test that proves the generated Swift compiles. Install the toolchain rather \
+         than letting this gate lapse."
     );
-    None
-}
-
-/// Whether `swift` runs, not merely resolves. See [`swift_driver`]. ~keep
-fn swift_is_runnable() -> bool {
-    static RUNNABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *RUNNABLE.get_or_init(|| {
-        std::process::Command::new("swift")
-            .arg("--version")
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
-    })
+    driver
 }
 
 /// The gate: alef's generated trait-box output must build in the two-target layout it is
@@ -528,7 +502,12 @@ fn generated_trait_box_package_compiles() {
     let root = keep.as_deref().unwrap_or_else(|| tmp.path());
     materialize_package(root).expect("write fixture SwiftPM package");
 
-    let output = Command::new(&swift)
+    // Every argument below is an absolute path, so this spawn does not care what directory it
+    // runs from -- but it does care that the directory still exists. Without the pin it inherits
+    // whatever process-wide cwd another test's `CwdGuard` last set, and `swift build` fails with
+    // "couldn't determine the current working directory" once that tempdir is gone, which is how
+    // this fixture failed on `Test (macos-latest)` with the Swift toolchain present. ~keep
+    let output = spawn_from_stable_dir(&swift.to_string_lossy())
         .arg("build")
         .arg("--package-path")
         .arg(root)

--- a/src/e2e/codegen/go/field_shape_tests.rs
+++ b/src/e2e/codegen/go/field_shape_tests.rs
@@ -415,7 +415,9 @@ fn rendered_assertion_shapes_compile_and_run_in_one_go_test() {
         module_path: SHAPE_BATCH_MODULE.to_owned(),
         extra_args: Vec::new(),
     };
-    let report = run_go_batch(&layout, &cases);
+    let Some(report) = run_go_batch(&layout, &cases) else {
+        return;
+    };
 
     report.assert_inventory(&inventory);
     for name in &passing {

--- a/src/e2e/codegen/go/go_batch.rs
+++ b/src/e2e/codegen/go/go_batch.rs
@@ -14,6 +14,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::test_support::toolchain;
+
 /// One case in a batch: a single Go package directory inside the shared batch module.
 pub(super) struct GoBatchCase {
     /// Directory name under the batch module root. Must be unique and a valid Go import
@@ -131,9 +133,14 @@ impl GoBatchReport {
 }
 
 /// Write every case into one throwaway Go module and run them all in a single `go test`.
-pub(super) fn run_go_batch(layout: &GoBatchLayout, cases: &[GoBatchCase]) -> GoBatchReport {
+///
+/// `None` means the Go toolchain is not installed, so nothing was compiled and the caller must
+/// return without asserting. The skip is already counted by [`toolchain::ToolchainGate::open`],
+/// which is what stops a batch that ran zero cases from reading as a batch that passed them
+/// all. ~keep
+pub(super) fn run_go_batch(layout: &GoBatchLayout, cases: &[GoBatchCase]) -> Option<GoBatchReport> {
     assert!(!cases.is_empty(), "a batched Go run must contain at least one case");
-    let go = which::which("go").expect("Go is required for generated-Go batch fixtures");
+    let go = toolchain::GO.open()?;
     let root = tempfile::tempdir().expect("create batched Go module root");
     for (path, content) in &layout.root_files {
         write_batch_file(&root.path().join(path), content);
@@ -159,11 +166,11 @@ pub(super) fn run_go_batch(layout: &GoBatchLayout, cases: &[GoBatchCase]) -> GoB
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     let parsed = parse_case_blocks(&stdout, &stderr, &layout.module_path);
-    GoBatchReport {
+    Some(GoBatchReport {
         cases: parsed,
         stderr,
         _root: root,
-    }
+    })
 }
 
 fn write_batch_file(path: &Path, content: &str) {

--- a/src/e2e/codegen/go/package_compile_tests.rs
+++ b/src/e2e/codegen/go/package_compile_tests.rs
@@ -239,7 +239,9 @@ fn generated_data_interface_packages_compile_and_run_in_one_go_test() {
         module_path: module_path_of(&manifest),
         extra_args: vec!["-mod=mod".to_owned()],
     };
-    let report = run_go_batch(&layout, &cases);
+    let Some(report) = run_go_batch(&layout, &cases) else {
+        return;
+    };
 
     report.assert_inventory(&inventory);
     for (assertion_type, _) in PASSING_ASSERTIONS {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -11,6 +11,8 @@
 //! modules could still run concurrently and race. [`CWD_LOCK`] is the one lock every cwd-mutating
 //! test in this crate now shares. ~keep
 
+pub(crate) mod toolchain;
+
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;

--- a/src/test_support/toolchain.rs
+++ b/src/test_support/toolchain.rs
@@ -1,0 +1,336 @@
+//! Availability gate and execution census for the fixtures that shell out to a real language
+//! toolchain.
+//!
+//! A fixture that compiles alef's generated Go with the real `go` command has exactly two honest
+//! outcomes when `go` is not installed: fail, or report that it did not run. What it must never
+//! do is report the third thing -- a pass -- because a pass that examined nothing is
+//! indistinguishable from a pass that examined everything, and CI reads only the counts.
+//!
+//! Both of the obvious designs are wrong on their own. A hard panic (what the Go fixtures did
+//! before this module existed) turns every runner without the toolchain permanently red, so
+//! nobody reads that leg and real regressions hide inside the expected failures. A silent skip
+//! turns it permanently green while testing less than it claims. [`ToolchainGate::open`] does
+//! the third thing: it skips, and it *counts*.
+//!
+//! Every call is tallied per toolchain as attempted, and then as either executed or skipped, and
+//! the running tally is flushed to `<target-dir>/toolchain-census/<test-binary>.tsv` after each
+//! call. Nothing in this process reads those files back. That is deliberate: `libtest` gives a
+//! test binary no end-of-run hook to report from, it captures the stdout *and* stderr of a
+//! passing test (so an `eprintln!` skip notice is invisible in precisely the run that needs it),
+//! and `cargo test` splits the suite across several binaries anyway. `scripts/toolchain-census.sh`
+//! reads the files after the run, prints the per-toolchain counts, and fails when a toolchain the
+//! caller declared required executed zero fixtures -- which is what keeps "12 of 12 go fixtures
+//! executed" and "0 of 12 executed, go absent" distinguishable in CI output without reading any
+//! code. ~keep
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use super::spawn_from_stable_dir;
+
+/// Directory, relative to the cargo target directory, holding one tally file per test binary.
+/// `scripts/toolchain-census.sh` reads this same name -- change both together. ~keep
+const CENSUS_DIR_NAME: &str = "toolchain-census";
+
+/// One external language toolchain a fixture cannot run without.
+///
+/// Constructed only as the `const`s below, so the census can never grow a toolchain whose name
+/// no `scripts/toolchain-census.sh` invocation knows about.
+pub(crate) struct ToolchainGate {
+    /// Census key, and the name a census failure reports.
+    name: &'static str,
+    /// Binary looked up on `PATH`.
+    binary: &'static str,
+    /// Argument that makes the binary prove it can actually run. See [`ToolchainGate::resolve`].
+    version_arg: &'static str,
+    /// Environment variable that upgrades "absent" from a counted skip to a hard failure. CI sets
+    /// it on every platform that installs the toolchain.
+    require_env: &'static str,
+}
+
+/// The Go toolchain, needed by every fixture that compiles or runs alef's generated Go.
+///
+/// GitHub's Linux and Windows runner images preinstall Go; the arm64 macOS images do not, which
+/// is how the `Test (macos-latest)` leg spent from 2026-08-31 onward permanently red on nine Go
+/// fixtures. CI installs Go explicitly on all three platforms now, so `ALEF_REQUIRE_GO` is set
+/// everywhere and this gate never skips there. ~keep
+pub(crate) const GO: ToolchainGate = ToolchainGate {
+    name: "go",
+    binary: "go",
+    version_arg: "version",
+    require_env: "ALEF_REQUIRE_GO",
+};
+
+/// The Swift toolchain, needed by the SwiftPM compile gate for the trait-box generator.
+///
+/// Unlike Go this genuinely cannot be installed on every platform: Swift ships with Xcode on
+/// macOS, and the Windows toolchain is a multi-gigabyte installer with no first-party setup
+/// action. So the Windows and Linux legs skip it and say so, and the census enforces that the
+/// macOS leg -- the one platform where the compile actually happens -- executed it.
+pub(crate) const SWIFT: ToolchainGate = ToolchainGate {
+    name: "swift",
+    binary: "swift",
+    version_arg: "--version",
+    require_env: "ALEF_REQUIRE_SWIFT",
+};
+
+/// Per-toolchain attempt/execution counts for this test binary.
+#[derive(Clone, Copy, Default)]
+struct Tally {
+    attempted: u32,
+    executed: u32,
+    skipped: u32,
+}
+
+/// The census, and the resolution cache, for this process.
+///
+/// One mutex covers both so a tally and the flush that publishes it cannot interleave with
+/// another test thread's -- the file on disk is rewritten whole on every update, never appended
+/// to, so a concurrent writer could otherwise publish a tally that skips a count.
+static CENSUS: Mutex<Census> = Mutex::new(Census {
+    tallies: BTreeMap::new(),
+    resolved: BTreeMap::new(),
+});
+
+struct Census {
+    tallies: BTreeMap<&'static str, Tally>,
+    resolved: BTreeMap<&'static str, Option<PathBuf>>,
+}
+
+impl ToolchainGate {
+    /// This gate's census name, for a fixture that wants to name the toolchain it skipped.
+    pub(crate) fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Resolve this gate's toolchain for one fixture invocation, recording the attempt.
+    ///
+    /// Returns `None` when the toolchain is absent and its `ALEF_REQUIRE_*` variable is unset:
+    /// the caller must then return without asserting anything, because it has verified nothing.
+    /// The skip is already counted by the time this returns, so a caller cannot forget to report
+    /// it. Panics instead when the variable *is* set, which is how a runner whose toolchain setup
+    /// silently regressed fails loudly rather than quietly testing less.
+    pub(crate) fn open(&self) -> Option<PathBuf> {
+        let resolved = self.resolve();
+        self.record(resolved.is_some());
+        self.require_available(resolved, std::env::var_os(self.require_env).is_some())
+    }
+
+    /// Turn an absent toolchain into a panic when `required`, and pass it through otherwise.
+    ///
+    /// `required` is a plain parameter, and `resolved` an already-performed lookup, rather than
+    /// this reading the environment or `PATH` itself, so
+    /// `required_mode_fails_when_the_toolchain_is_unavailable` below can prove the panic fires
+    /// against a fabricated "unavailable" input instead of having to hide a real binary from
+    /// `PATH` -- which no test in a shared process can do without racing every other test. ~keep
+    fn require_available(&self, resolved: Option<PathBuf>, required: bool) -> Option<PathBuf> {
+        assert!(
+            resolved.is_some() || !required,
+            "{} is set but `{}` is unavailable: this fixture compiles alef's generated output \
+             with the real {} toolchain and verifies nothing without it",
+            self.require_env,
+            self.binary,
+            self.name
+        );
+        resolved
+    }
+
+    /// Look the binary up on `PATH` *and* prove it runs, caching the answer for the process.
+    ///
+    /// Resolution alone is not enough: a version-manager shim (`asdf`, `g`, `rbenv`-style) sits
+    /// on `PATH` and spawns fine with no toolchain installed behind it, then exits non-zero. A
+    /// `which`-only check would count that as executed and then fail the fixture's real
+    /// assertions on every such machine. ~keep
+    fn resolve(&self) -> Option<PathBuf> {
+        let mut census = lock();
+        if let Some(cached) = census.resolved.get(self.name) {
+            return cached.clone();
+        }
+        let resolved = which::which(self.binary).ok().filter(|_| self.is_runnable());
+        census.resolved.insert(self.name, resolved.clone());
+        resolved
+    }
+
+    fn is_runnable(&self) -> bool {
+        spawn_from_stable_dir(self.binary)
+            .arg(self.version_arg)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    fn record(&self, executed: bool) {
+        let mut census = lock();
+        let tally = census.tallies.entry(self.name).or_default();
+        tally.attempted += 1;
+        if executed {
+            tally.executed += 1;
+        } else {
+            tally.skipped += 1;
+        }
+        let snapshot = census.tallies.clone();
+        drop(census);
+        flush(&snapshot);
+    }
+}
+
+/// A poisoned census is still usable: a fixture that panicked while holding this lock left only
+/// counters behind, and cascading that panic into every other toolchain fixture would replace one
+/// legible failure with dozens.
+fn lock() -> std::sync::MutexGuard<'static, Census> {
+    CENSUS.lock().unwrap_or_else(|error| error.into_inner())
+}
+
+/// Rewrite this test binary's tally file. Best-effort: a fixture must not fail because the census
+/// could not be written, and `scripts/toolchain-census.sh` reports a missing tally as zero
+/// executed anyway, which fails the run for the right reason.
+fn flush(tallies: &BTreeMap<&'static str, Tally>) {
+    let Some(path) = census_file() else { return };
+    let Some(parent) = path.parent() else { return };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let mut rendered = String::new();
+    for (name, tally) in tallies {
+        let _ = writeln!(
+            rendered,
+            "{name}\t{}\t{}\t{}",
+            tally.attempted, tally.executed, tally.skipped
+        );
+    }
+    let _ = std::fs::write(&path, rendered);
+}
+
+/// `<target-dir>/toolchain-census/<test-binary>.tsv`.
+///
+/// Derived from the running test binary rather than `CARGO_MANIFEST_DIR/target`, so a custom
+/// `CARGO_TARGET_DIR` or a `--release` run lands beside the binaries that produced it. Test
+/// executables live at `<target-dir>/<profile>/deps/<name>-<hash>`, so the target directory is
+/// three levels up.
+fn census_file() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let name = exe.file_stem()?.to_str()?.to_owned();
+    let target_dir = exe.parent()?.parent()?.parent()?;
+    Some(target_dir.join(CENSUS_DIR_NAME).join(format!("{name}.tsv")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The census file has to land inside the cargo target directory, next to the binaries whose
+    /// tallies it holds, or `scripts/toolchain-census.sh` reads an empty directory and reports a
+    /// clean run as "no fixtures attempted". ~keep
+    #[test]
+    fn census_file_lands_under_the_cargo_target_directory() {
+        let path = census_file().expect("census path resolves for a cargo-built test binary");
+        let parent = path.parent().expect("census file has a parent directory");
+
+        assert_eq!(
+            parent.file_name().and_then(|name| name.to_str()),
+            Some(CENSUS_DIR_NAME),
+            "census file must sit in the {CENSUS_DIR_NAME} directory, got {path:?}"
+        );
+        assert_eq!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("tsv"),
+            "census file must be a TSV the census script can sum, got {path:?}"
+        );
+    }
+
+    /// The whole point of the gate: a fixture invocation is counted before the caller can decide
+    /// what to do about it, so a skip can never go unreported.
+    #[test]
+    fn opening_a_gate_records_exactly_one_attempt() {
+        let before = tally_of(GO.name());
+
+        let resolved = GO.open();
+
+        let after = tally_of(GO.name());
+        assert_eq!(
+            after.attempted,
+            before.attempted + 1,
+            "opening the go gate must record exactly one attempt"
+        );
+        assert_eq!(
+            (after.executed - before.executed, after.skipped - before.skipped),
+            if resolved.is_some() { (1, 0) } else { (0, 1) },
+            "an attempt must land in exactly one of the executed/skipped columns"
+        );
+        assert_eq!(
+            after.attempted,
+            after.executed + after.skipped,
+            "attempted must always equal executed + skipped, or the census cannot be read as a ratio"
+        );
+    }
+
+    /// `scripts/toolchain-census.sh` fails a required toolchain on `executed == 0`, so the on-disk
+    /// row must carry the executed count, not just the attempt count. Reads the real file back
+    /// rather than the in-memory tally so a broken flush is caught here and not in CI. ~keep
+    #[test]
+    fn the_flushed_row_reports_attempted_executed_and_skipped() {
+        let _ = GO.open();
+        let path = census_file().expect("census path resolves");
+
+        let rendered = std::fs::read_to_string(&path).expect("census file was flushed to disk");
+
+        let row = rendered
+            .lines()
+            .find(|line| line.starts_with(&format!("{}\t", GO.name())))
+            .unwrap_or_else(|| panic!("no `{}` row in flushed census:\n{rendered}", GO.name()));
+        let columns: Vec<&str> = row.split('\t').collect();
+        assert_eq!(
+            columns.len(),
+            4,
+            "a census row is <toolchain>\\t<attempted>\\t<executed>\\t<skipped>, got {row:?}"
+        );
+        let attempted: u32 = columns[1].parse().expect("attempted column is a number");
+        let executed: u32 = columns[2].parse().expect("executed column is a number");
+        let skipped: u32 = columns[3].parse().expect("skipped column is a number");
+        assert!(
+            attempted > 0,
+            "the row must record the attempt that just happened: {row:?}"
+        );
+        assert_eq!(attempted, executed + skipped, "flushed row does not add up: {row:?}");
+    }
+
+    /// The hard half of the contract: on a platform CI installs the toolchain for, a missing
+    /// toolchain must fail the run rather than be counted as a skip. Without this the census
+    /// alone would let a regressed runner setup pass, since a skip is a legitimate outcome
+    /// everywhere else. ~keep
+    #[test]
+    fn required_mode_fails_when_the_toolchain_is_unavailable() {
+        let result = std::panic::catch_unwind(|| GO.require_available(None, true));
+
+        let panic = result.expect_err("required mode must fail when the toolchain is unavailable");
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or("non-string panic");
+        assert!(
+            message.contains("ALEF_REQUIRE_GO is set"),
+            "the panic must name the variable that made the toolchain required, got: {message}"
+        );
+    }
+
+    /// The other half: absent and *not* required is a skip, not a failure -- otherwise a
+    /// contributor without Go installed cannot run the suite at all, which is how the Go fixtures
+    /// came to be permanently red on two of the three CI legs. ~keep
+    #[test]
+    fn unrequired_mode_reports_an_absent_toolchain_as_a_skip() {
+        assert_eq!(
+            GO.require_available(None, false),
+            None,
+            "an absent, unrequired toolchain must be reported as not-run rather than panicking"
+        );
+    }
+
+    fn tally_of(name: &'static str) -> Tally {
+        lock().tallies.get(name).copied().unwrap_or_default()
+    }
+}


### PR DESCRIPTION
alef has had **no green CI run on `main` in the last 200 runs** — 121 failure, 78 cancelled, 1 startup_failure, spanning 2026-08-21 to 2026-09-02. Of the 25 most recent, 14 reached the `Test` matrix and all 14 were 3-for-3 red. A regression shipped in 0.82.1 partly because of this.

## Cause

The Go compile fixtures were added in `55fe70bd2` / `20ea0abc5` (2026-08-31) with a workflow comment asserting *"Go needs no dedicated setup step (GitHub-hosted runner images preinstall a Go LTS toolchain)"*. That is **false for the arm64 macOS images**, and `ALEF_REQUIRE_GO` converted the resulting skip into a permanent red.

Windows is a larger and different problem: Go is present there, and none of its 16 failures are Go. 7 are toolchains installed but unresolvable (`setup-beam` lands `elixir.bat` somewhere `which::which` misses), and 9 are genuine Windows portability defects — the most concrete being `packages/swift\rust\Cargo.toml` versus `packages/swift/rust/Cargo.toml` at `swift/gen_bindings/mod.rs:979`. Those 9 are reported, not fixed, so this leg stays red.

## Skip with cardinality, not silent skip

A fixture that cannot run reports itself as not-run and is counted. The load-bearing pair:

```
$ ./scripts/toolchain-census.sh --require go --require swift
  go         14 of 14 fixtures executed (0 skipped) [required]  ok
  swift       1 of  1 fixtures executed (0 skipped) [required]  ok

$ env -i PATH=/usr/bin:/bin <test-binary>          # go hidden
test result: ok. 35 passed; 0 failed
$ ./scripts/toolchain-census.sh --require go
  go          0 of 12 fixtures executed (12 skipped) [required]  <-- FAILED: nothing ran
exit=1
```

**libtest prints `ok` in both cases.** The census is what tells them apart. Zero *attempts* fails identically, which catches fixtures deleted, renamed out of a filter, or `#[ignore]`d — something no `ALEF_REQUIRE_*` can catch, because no code runs to check.

Two findings from the inventory (~250 tests across 26 external binaries) worth stating: `ALEF_REQUIRE_SWIFT` did not exist and CI installed no Swift, so the only test proving generated Swift compiles hard-panicked on macOS and skipped everywhere else; and the "loud skip" was not loud — it used `eprintln!`, which libtest captures for passing tests. Verified empirically: a write to raw fd 2 shows, `eprintln!` does not.

## Proving the signal is real

Injected an unused local into a Go template — invisible to every Rust string assertion, visible only to the Go compiler:

```
generated Go failed to compile:
./shape.go:18:2: declared and not used: unusedShadow
test result: FAILED. 18 passed; 3 failed
```

Reverted, 21 passed. The workflow assertion that used to be a comment is now enforced by a test that checks for `uses: actions/setup-go@` as well as the env var.

Go is pinned to 1.26, the minor line alef itself emits into generated `go.mod`, so CI can never compile output with a toolchain older than the directive that output declares.