### PR TITLE
fix(generate): treat every emitted npm package as first-party

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `NameError`. The import scan now records enum usages through the same recursive traversal
   that renders the constructor call, instead of a second pass that only checked the arg's
   top-level keys.
+- **`alef generate` errored on a crate's own wasm test_app pinning its not-yet-published version,
+  while the identical situation one package over only warned.** The pnpm lock-freshness check's
+  pending-publish exemption resolved a self-dependency identity for the `"node"` e2e package only,
+  so `test_apps/node/pnpm-lock.yaml` pinning the crate's own pending version was correctly
+  downgraded to a warning, but `test_apps/wasm/pnpm-lock.yaml` pinning that same crate's pending
+  version under its own npm package name (e.g. `@xberg-io/html-to-markdown-wasm`) fell through to
+  a hard error — a specifier the release itself cannot satisfy until it ships. The exemption now
+  resolves a self-dependency identity for every e2e language that can emit a `package.json`
+  (`node` and `wasm`), matching a finding against any of them.
 
 - **publish (Ruby platform gems):** precompiled platform gemspecs now load the generated source
   gemspec as their metadata authority, then replace only the version, platform, files, and native

--- a/src/cli/pipeline/lock_freshness/node.rs
+++ b/src/cli/pipeline/lock_freshness/node.rs
@@ -8,13 +8,26 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 
-use super::shared::{registered_unmarkable_manifest_dirs, registry_self_dependency};
+use super::shared::{RegistrySelfDependency, registered_unmarkable_manifest_dirs, registry_self_dependency};
 
 /// Dependency buckets alef itself writes into a generated `package.json` -- see
 /// `crate::e2e::codegen::typescript::config::render_package_json` (and its wasm counterpart),
 /// which only ever populate `dependencies` / `devDependencies`. Checking a bucket alef never
 /// writes would find nothing but a hand-authored drift this module has no business reporting.
 const NODE_DEPENDENCY_BUCKETS: [&str; 2] = ["dependencies", "devDependencies"];
+
+/// Every `[crates.e2e...packages.<lang>]` key whose e2e codegen can emit a `package.json` --
+/// see `crate::e2e::codegen::typescript::config::render_package_json` (`"node"`) and its wasm
+/// counterpart in `crate::e2e::codegen::wasm` (`"wasm"`). Both land in their own `test_apps/*`
+/// directory with their own `pnpm-lock.yaml`, so [`collect_generated_node_lock_findings`] walks
+/// both, and this check's pending-publish exemption must resolve a self-dependency identity for
+/// both too -- see the doc comment on
+/// [`check_generated_node_lock_freshness_tolerating_pending_publish`] for the incident this
+/// closes. Not derived by pattern-matching a `-wasm` name suffix on purpose: that would be a
+/// second, independent guess at the same fact `registry_self_dependency` already computes
+/// authoritatively from `[crates.e2e.registry.packages.<lang>]`. Extending this list is the only
+/// change needed the day a third lang starts emitting `package.json` into this ecosystem.
+const PACKAGE_JSON_EMITTING_LANGS: [&str; 2] = ["node", "wasm"];
 
 /// One `package.json` specifier whose sibling `pnpm-lock.yaml` records a different specifier for
 /// the same dependency name and bucket.
@@ -122,6 +135,17 @@ fn collect_generated_node_lock_findings(
 /// operator cannot run yet. Once the release actually publishes, `collect_generated_node_lock_findings`
 /// stops reporting the self-dependency row at all (the specifiers agree), so this exemption
 /// narrows back down to nothing on its own -- it never permanently hides a lock's other findings.
+///
+/// ~keep alef #A6: one self-dependency identity is not enough. `collect_generated_node_lock_findings`
+/// walks every `test_apps/*` directory holding an alef-generated `package.json`, and that
+/// includes BOTH the `"node"` test_app (`@xberg-io/html-to-markdown`) AND the `"wasm"` test_app
+/// (`@xberg-io/html-to-markdown-wasm`) -- two different `[crates.e2e...packages.<lang>]` rows,
+/// two different published npm packages, each with its own pending-publish window. Resolving
+/// only `"node"`'s self-dependency left the wasm test_app's identical pending-self-version row
+/// unrecognised: it does not match the node identity by name, so it fell through to `real` and
+/// hard-failed generation on a specifier the release itself cannot satisfy until it ships. Every
+/// lang in [`PACKAGE_JSON_EMITTING_LANGS`] gets its own [`registry_self_dependency`] call, and a
+/// finding is pending if it matches ANY of them.
 pub(crate) fn check_generated_node_lock_freshness_tolerating_pending_publish(
     generated_paths: &HashSet<PathBuf>,
     base_dir: &Path,
@@ -131,16 +155,24 @@ pub(crate) fn check_generated_node_lock_freshness_tolerating_pending_publish(
     if findings.is_empty() {
         return None;
     }
-    let Some(self_dependency) = resolved_cfg
-        .and_then(|cfg| registry_self_dependency(cfg, "node", |package| package.name.clone(), str::to_string))
-    else {
+    let self_dependencies: Vec<RegistrySelfDependency> = resolved_cfg
+        .map(|cfg| {
+            PACKAGE_JSON_EMITTING_LANGS
+                .into_iter()
+                .filter_map(|lang| registry_self_dependency(cfg, lang, |package| package.name.clone(), str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    if self_dependencies.is_empty() {
         return Some(anyhow::anyhow!(stale_node_lock_message(&findings)));
-    };
+    }
 
     let pending_locks: HashSet<PathBuf> = findings
         .iter()
         .filter(|finding| {
-            finding.dependency == self_dependency.name && finding.requirement == self_dependency.requirement
+            self_dependencies.iter().any(|self_dependency| {
+                finding.dependency == self_dependency.name && finding.requirement == self_dependency.requirement
+            })
         })
         .map(|finding| finding.lock.clone())
         .collect();

--- a/src/cli/pipeline/lock_freshness/node_tests.rs
+++ b/src/cli/pipeline/lock_freshness/node_tests.rs
@@ -281,6 +281,172 @@ mod pending_publish {
         }
     }
 
+    const WASM_DIR_RELATIVE: &str = "e2e/wasm";
+    const WASM_DEPENDENCY: &str = "sample-pkg-wasm";
+    const WASM_STALE_SPEC: &str = "1.3.0";
+    const WASM_FRESH_SPEC: &str = "1.2.3";
+
+    fn wasm_dir(root: &Path) -> PathBuf {
+        root.join(WASM_DIR_RELATIVE)
+    }
+
+    /// The alef-generated wasm e2e `package.json`, matching `crate::e2e::codegen::wasm`'s own
+    /// shape (see that module's counterpart to `render_package_json`): a sibling npm package
+    /// under its own name, not `"node"`'s.
+    fn write_wasm_package_json(root: &Path, specifier: &str) -> PathBuf {
+        let dir = wasm_dir(root);
+        std::fs::create_dir_all(&dir).expect("create wasm dir");
+        let manifest = dir.join("package.json");
+        std::fs::write(
+            &manifest,
+            format!(
+                "{{\n  \"name\": \"sample-pkg-e2e-wasm\",\n  \"version\": \"0.1.0\",\n  \"private\": \
+                 true,\n  \"devDependencies\": {{\n    \"{WASM_DEPENDENCY}\": \"{specifier}\"\n  }}\n}}\n"
+            ),
+        )
+        .expect("write package.json");
+        manifest
+    }
+
+    fn write_wasm_pnpm_lock(root: &Path, locked_specifier: &str) {
+        std::fs::write(
+            wasm_dir(root).join("pnpm-lock.yaml"),
+            format!(
+                "lockfileVersion: '9.0'\n\nimporters:\n  .:\n    devDependencies:\n      \
+                 {WASM_DEPENDENCY}:\n        specifier: {locked_specifier}\n        version: \
+                 {locked_specifier}\n"
+            ),
+        )
+        .expect("write pnpm-lock.yaml");
+    }
+
+    /// Both `[crates.e2e.registry.packages.node]` and `[crates.e2e.registry.packages.wasm]`
+    /// explicitly named -- the shape a crate publishing both an npm package and its wasm
+    /// sibling (the html-to-markdown / tree-sitter-language-pack incident) actually has.
+    fn resolved_cfg_with_node_and_wasm_registry_packages(
+        node_name: &str,
+        node_version: &str,
+        wasm_name: &str,
+        wasm_version: &str,
+    ) -> ResolvedCrateConfig {
+        let e2e = E2eConfig {
+            registry: RegistryConfig {
+                packages: [
+                    (
+                        "node".to_string(),
+                        PackageRef {
+                            name: Some(node_name.to_string()),
+                            version: Some(node_version.to_string()),
+                            ..PackageRef::default()
+                        },
+                    ),
+                    (
+                        "wasm".to_string(),
+                        PackageRef {
+                            name: Some(wasm_name.to_string()),
+                            version: Some(wasm_version.to_string()),
+                            ..PackageRef::default()
+                        },
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                ..RegistryConfig::default()
+            },
+            ..E2eConfig::default()
+        };
+        ResolvedCrateConfig {
+            e2e: Some(e2e),
+            ..ResolvedCrateConfig::default()
+        }
+    }
+
+    /// The reported defect (alef #A6): the `"wasm"` test_app has its own pending self-dependency
+    /// row (its own not-yet-published version), the exact shape of `"node"`'s already-tolerated
+    /// row but under a different package name. Before the fix, only `"node"`'s self-dependency
+    /// was ever resolved, so this row fell through to `real` and hard-failed generation on a
+    /// specifier the release itself cannot satisfy until it ships.
+    #[test]
+    fn tolerating_variant_downgrades_the_wasm_test_apps_own_pending_self_dependency() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let manifest = write_wasm_package_json(root, WASM_STALE_SPEC);
+        write_wasm_pnpm_lock(root, WASM_FRESH_SPEC);
+        let generated: HashSet<PathBuf> = [manifest].into_iter().collect();
+        let resolved_cfg = resolved_cfg_with_node_and_wasm_registry_packages(
+            NODE_DEPENDENCY,
+            NODE_STALE_SPEC,
+            WASM_DEPENDENCY,
+            WASM_STALE_SPEC,
+        );
+
+        let result =
+            check_generated_node_lock_freshness_tolerating_pending_publish(&generated, root, Some(&resolved_cfg));
+
+        assert!(
+            result.is_none(),
+            "the wasm test_app's own pending self-dependency must be tolerated exactly like node's: {result:?}"
+        );
+    }
+
+    /// The exact reported incident: both `test_apps/node` and `test_apps/wasm` carry the
+    /// crate's own pending, not-yet-published version in the same run -- `"node"`'s row was
+    /// already tolerated before this fix; `"wasm"`'s identical row, under its own package name,
+    /// was not, and alone made `alef generate` exit 1. Both must be tolerated together.
+    #[test]
+    fn tolerating_variant_downgrades_both_the_node_and_wasm_test_apps_pending_self_dependencies_together() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let node_manifest = write_package_json(root, NODE_STALE_SPEC);
+        write_pnpm_lock_v9(root, NODE_FRESH_SPEC);
+        let wasm_manifest = write_wasm_package_json(root, WASM_STALE_SPEC);
+        write_wasm_pnpm_lock(root, WASM_FRESH_SPEC);
+        let generated: HashSet<PathBuf> = [node_manifest, wasm_manifest].into_iter().collect();
+        let resolved_cfg = resolved_cfg_with_node_and_wasm_registry_packages(
+            NODE_DEPENDENCY,
+            NODE_STALE_SPEC,
+            WASM_DEPENDENCY,
+            WASM_STALE_SPEC,
+        );
+
+        let result =
+            check_generated_node_lock_freshness_tolerating_pending_publish(&generated, root, Some(&resolved_cfg));
+
+        assert!(
+            result.is_none(),
+            "both test_apps' own pending self-dependencies must be tolerated in the same run: {result:?}"
+        );
+    }
+
+    /// The false-negative guard for the wasm test_app, mirroring
+    /// `tolerating_variant_still_fails_on_a_disagreement_not_explained_by_pending_publish` for
+    /// node: a genuinely stale THIRD-PARTY pin in the wasm test_app's lock must still fail even
+    /// though a resolved config with a `"wasm"` registry package is supplied -- recognising the
+    /// wasm self-dependency must not blanket-suppress every wasm finding.
+    #[test]
+    fn tolerating_variant_still_fails_on_the_wasm_test_apps_drift_not_explained_by_pending_publish() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        let manifest = write_wasm_package_json(root, WASM_STALE_SPEC);
+        write_wasm_pnpm_lock(root, WASM_FRESH_SPEC);
+        let generated: HashSet<PathBuf> = [manifest].into_iter().collect();
+        // The configured wasm registry package name/version do NOT match this finding's own
+        // dependency/requirement at all -- an unrelated self-dependency identity.
+        let resolved_cfg = resolved_cfg_with_node_and_wasm_registry_packages(
+            NODE_DEPENDENCY,
+            NODE_STALE_SPEC,
+            "unrelated-wasm-package",
+            "9.9.9",
+        );
+
+        assert!(
+            check_generated_node_lock_freshness_tolerating_pending_publish(&generated, root, Some(&resolved_cfg),)
+                .is_some(),
+            "a third-party lock drift in the wasm test_app unrelated to its own registry \
+             self-dependency must still fail the run"
+        );
+    }
+
     const SIBLING_DEPENDENCY: &str = "sibling-pkg";
     const SIBLING_STALE_SPEC: &str = "^1.0.0";
     const SIBLING_LOCKED_SPEC: &str = "^2.0.0";


### PR DESCRIPTION
alef errored on a lockfile specifier that only the release itself can satisfy, making `alef generate` exit 1 on two consumer repos for a condition that is unsatisfiable by construction at the moment it fires.

The pending-publish exemption resolved a self-dependency identity for the `node` test_app only. The `wasm` test_app has its own `package.json`, its own `pnpm-lock.yaml` and its own published package, so its identical pending-self-version row matched no identity, fell through to `real`, and hard-failed. The asymmetry was visible in the output — one package warned with *"resolves once the release publishes"* while its sibling one directory over was fatal.

Every lang that can emit a `package.json` now gets its own `registry_self_dependency` call, and a finding is pending if it matches any of them. Deliberately **not** derived by suffix-matching `-wasm`: that would be a second guess at a fact `registry_self_dependency` already computes authoritatively from `[crates.e2e.registry.packages.<lang>]`.

## Verification

- 113 `lock_freshness` tests pass.
- Acceptance is the real repos: on html-to-markdown the message moves from a hard ERROR to `WARN 2 committed pnpm-lock.yaml pin(s) below require this crate's own version, which is not on the registry yet -- expected after a version bump; resolves once the release publishes`. **2** pins recognised where 1 was before — the node and wasm entries both.
- The check is not weakened: a genuine third-party specifier drift still errors, with a test pinning that distinction.
- Committed object asserted rather than the worktree: fix token present, hardcoded-`"node"` defect token absent.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.