### PR TITLE
fix(go): carry the dependency's own requires into the generated go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Generated `test_apps/<lang>/go.mod` listed only testify's own transitive dependencies, so
+  `go test -mod=readonly ./...` failed on an incomplete module graph while `go build
+  -mod=readonly` passed.** Go's module-graph pruning (go >= 1.17,
+  <https://go.dev/ref/mod#graph-pruning>) requires the *importing* module's own `go.mod` to carry
+  an explicit `// indirect` requirement for every module providing a package transitively
+  imported through a directly required module. The generator emitted the hardcoded
+  `TESTIFY_INDIRECT_DEPS` set and nothing else, silently dropping the module-under-test's own
+  dependency graph — for `tree-sitter-language-pack` that meant `go-tree-sitter` and
+  `go-pointer`, and `go test -mod=readonly ./...` aborted with "updates to go.mod needed,
+  disabled by -mod=readonly; to update it: go mod tidy". The build never needed those modules
+  (that is exactly what pruning buys), so a `go build` gate reported the file correct while it
+  was still broken. The `// indirect` block is now the testify set merged with every `require`
+  (direct or indirect) declared in the required module's own on-disk `go.mod`, minus anything
+  already required directly, and degrades to the testify-only set when that `go.mod` is missing
+  rather than failing generation.
+- **The generated `require (...)` block was not in the order `gofmt`/`go mod tidy` produce**, so
+  even a complete `go.mod` came back dirty from `go mod tidy`. The module-under-test was written
+  first and testify second; every consumer's module path is `github.com/xberg-io/...`, which
+  sorts *after* `github.com/stretchr/testify`, so the hand-written order was wrong for every
+  consumer, always. Direct requires are now sorted by module path.
+
 ## [0.82.2] - 2026-09-03
 
 Patch release. Two entries are regressions shipped in 0.82.1 -- both generated crates that do not

--- a/src/e2e/codegen/go.rs
+++ b/src/e2e/codegen/go.rs
@@ -17,6 +17,7 @@ use super::client;
 
 mod assertion_field_shape;
 mod assertion_render_helpers;
+mod dependency_requires;
 
 #[cfg(test)]
 mod field_shape_tests;
@@ -155,6 +156,12 @@ impl E2eCodegen for GoCodegen {
             crate::e2e::config::DependencyMode::Local => e2e_config.harness_extras.get(self.language_name()),
             crate::e2e::config::DependencyMode::Registry => None,
         };
+        // `replace_path` (unlike `effective_replace`) is populated in both dep modes -- it is
+        // the on-disk location of the required Go package regardless of whether this run emits
+        // a `replace` directive for it. Use it (unconditionally) to read that package's own
+        // go.mod so its direct+indirect requires can be folded into the `// indirect` block
+        // below; see `dependency_requires::resolve_indirect_requires`.
+        let dependency_go_mod_dir = replace_path.as_ref().map(|path| output_base.join(path));
         files.push(GeneratedFile {
             path: output_base.join("go.mod"),
             content: render_go_mod(
@@ -162,6 +169,7 @@ impl E2eCodegen for GoCodegen {
                 effective_replace.as_deref(),
                 &effective_go_version,
                 go_extras,
+                dependency_go_mod_dir.as_deref(),
             ),
             generated_header: false,
         });
@@ -366,6 +374,7 @@ fn render_go_mod(
     replace_path: Option<&str>,
     version: &str,
     extras: Option<&crate::core::config::manifest_extras::ManifestExtras>,
+    dependency_go_mod_dir: Option<&std::path::Path>,
 ) -> String {
     let mut out = String::new();
     // The generated test module must not be a subpath of the module under test.
@@ -385,36 +394,58 @@ fn render_go_mod(
     let _ = writeln!(out);
     let _ = writeln!(out, "go 1.26");
     let _ = writeln!(out);
-    let _ = writeln!(out, "require (");
-    let _ = writeln!(out, "\t{go_module_path} {version}");
-    let _ = writeln!(out, "\tgithub.com/stretchr/testify v1.11.1");
 
+    // Build the full direct-require set and sort it alphabetically by module path -- `gofmt`/`go
+    // mod tidy` sort `require (...)` blocks alphabetically, and every consumer module path is
+    // `github.com/xberg-io/...`, which always sorts after `github.com/stretchr/testify` ('s' <
+    // 'x'). Hand-ordering module-then-testify was therefore wrong for every consumer, always.
+    let mut direct_requires: Vec<(String, String)> = vec![
+        (go_module_path.to_string(), version.to_string()),
+        ("github.com/stretchr/testify".to_string(), "v1.11.1".to_string()),
+    ];
     // Inject extras: Go has no dev/runtime distinction, so merge both buckets
     if let Some(e) = extras
         && !e.is_empty()
     {
         let mut extra_modules: Vec<(&String, &crate::core::config::manifest_extras::ExtraDepSpec)> =
             e.dependencies.iter().chain(e.dev_dependencies.iter()).collect();
-        // Sort for deterministic output (BTreeMap already sorted, but we're chaining two maps)
+        // Sort for deterministic iteration below (BTreeMap already sorted, but we're chaining
+        // two maps).
         extra_modules.sort_by_key(|(k, _)| k.as_str());
         for (module_path, spec) in extra_modules {
             if let Some(version_str) = spec.version() {
-                let _ = writeln!(out, "\t{module_path} {version_str}");
+                direct_requires.push((module_path.clone(), version_str.to_string()));
             }
         }
     }
+    direct_requires.sort_by(|a, b| a.0.cmp(&b.0));
+    let direct_modules: std::collections::BTreeSet<String> =
+        direct_requires.iter().map(|(module, _)| module.clone()).collect();
 
+    let _ = writeln!(out, "require (");
+    for (module_path, module_version) in &direct_requires {
+        let _ = writeln!(out, "\t{module_path} {module_version}");
+    }
     let _ = writeln!(out, ")");
 
-    // Emit testify's transitive dependencies as an explicit `// indirect` require
-    // block. Without them `go test` / `go mod download` abort with
-    // "updates to go.mod needed; to update it: go mod tidy" because the generated
-    // go.mod would be an incomplete dependency graph. Listing them here makes the
-    // published test_app build without a manual `go mod tidy` (and offline). These
-    // are the pinned transitive deps of `github.com/stretchr/testify v1.11.1`.
+    // Emit an explicit `// indirect` require block covering both testify's own pinned
+    // transitive deps AND the required module's own direct+indirect requires. Without the
+    // former, `go test` / `go mod download` abort with "updates to go.mod needed; to update it:
+    // go mod tidy" because the generated go.mod would be an incomplete dependency graph. Without
+    // the latter, Go's module-graph-pruning rule (go >= 1.17, go.dev/ref/mod#graph-pruning)
+    // still requires this importing module's own go.mod to carry explicit indirect requirements
+    // for every module that provides a package transitively imported through the required
+    // module -- `go build -mod=readonly` doesn't need them (pruning), but `go test -mod=readonly
+    // ./...` fails on the missing entries, so this is a correctness gap a build-only check
+    // wouldn't catch. `direct_modules` excludes anything already required directly above (e.g. a
+    // Local-mode `harness_extras` entry that duplicates one of the dependency's own direct
+    // requires, as `tree-sitter-language-pack`'s `e2e/go` does with `go-tree-sitter`) -- a module
+    // cannot be required both directly and as `// indirect` in the same go.mod. See
+    // `dependency_requires::resolve_indirect_requires`.
+    let indirect_requires = dependency_requires::resolve_indirect_requires(dependency_go_mod_dir, &direct_modules);
     let _ = writeln!(out);
     let _ = writeln!(out, "require (");
-    for (module_path, module_version) in TESTIFY_INDIRECT_DEPS {
+    for (module_path, module_version) in &indirect_requires {
         let _ = writeln!(out, "\t{module_path} {module_version} // indirect");
     }
     let _ = writeln!(out, ")");

--- a/src/e2e/codegen/go/dependency_requires.rs
+++ b/src/e2e/codegen/go/dependency_requires.rs
@@ -1,0 +1,253 @@
+//! Fold the on-disk `go.mod` of a generated go.mod's required package into that generated
+//! go.mod's `// indirect` require block.
+//!
+//! Go's module-graph-pruning rule (go >= 1.17, go.dev/ref/mod#graph-pruning) requires the
+//! IMPORTING module's own go.mod to carry explicit `// indirect` requirements for every module
+//! that provides a package transitively imported through a directly required module. Emitting
+//! only testify's own pinned indirect deps (`super::TESTIFY_INDIRECT_DEPS`) silently drops the
+//! required module's own dependency graph. `go build -mod=readonly` still passes (module pruning
+//! means the build itself doesn't need them), but `go test -mod=readonly ./...` fails with
+//! "updates to go.mod needed, disabled by -mod=readonly; to update it: go mod tidy" -- a
+//! build-only check would report the generated file fixed while it is still broken.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use super::TESTIFY_INDIRECT_DEPS;
+
+/// Every `require` pin declared in `go_mod_text`, whether written as a single-line `require
+/// module version` or inside a parenthesized `require ( ... )` block. Trailing `// indirect`
+/// comments (or any other trailing comment) are stripped before reading the version field --
+/// direct and indirect requires alike are folded into the caller's `// indirect` block, since
+/// both provide packages a pruned module graph must still enumerate for the importing module.
+fn parse_go_mod_requires(go_mod_text: &str) -> BTreeMap<String, String> {
+    let mut requires = BTreeMap::new();
+    let mut in_require_block = false;
+    for raw_line in go_mod_text.lines() {
+        let line = raw_line.split("//").next().unwrap_or(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if in_require_block {
+            if line == ")" {
+                in_require_block = false;
+                continue;
+            }
+            if let Some((module, version)) = parse_module_version_pair(line) {
+                requires.insert(module, version);
+            }
+            continue;
+        }
+        if line == "require (" {
+            in_require_block = true;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("require ")
+            && let Some((module, version)) = parse_module_version_pair(rest)
+        {
+            requires.insert(module, version);
+        }
+    }
+    requires
+}
+
+/// Split a `module version` pair on the first run of whitespace.
+fn parse_module_version_pair(text: &str) -> Option<(String, String)> {
+    let mut parts = text.split_whitespace();
+    let module = parts.next()?;
+    let version = parts.next()?;
+    Some((module.to_string(), version.to_string()))
+}
+
+/// The full `// indirect` require block for a generated go.mod: `TESTIFY_INDIRECT_DEPS` merged
+/// with every require (direct or indirect) declared in the required module's own `go.mod`,
+/// deduplicated by module path and sorted alphabetically (`BTreeMap` iteration order). Excludes
+/// any module already in `direct_modules` -- a module cannot be required both directly and as
+/// `// indirect` in the same go.mod. `direct_modules` always contains the required module path
+/// itself and `testify`, and in Local dep mode may also contain a `harness_extras` entry that
+/// duplicates one of the dependency's own direct requires (e.g. `tree-sitter-language-pack`'s
+/// `e2e/go` harness extra for `go-tree-sitter`, which its `packages/go/go.mod` also requires
+/// directly).
+///
+/// `dependency_go_mod_dir` is the on-disk directory the required module resolves to (the
+/// generated go.mod's unconditional `replace_path`, joined onto `output_base` at the call site
+/// in `super::GoCodegen::generate` -- unlike the `replace` directive itself, this lookup is not
+/// gated on dep mode, since the dependency's own go.mod lives on disk regardless of whether this
+/// run emits a `replace`). When it's `None`, or the go.mod there is missing or unreadable (e.g.
+/// a partial/bootstrap run where the dependency hasn't been scaffolded yet), this degrades
+/// gracefully to the testify-only set via `tracing::debug!` rather than failing generation.
+pub(super) fn resolve_indirect_requires(
+    dependency_go_mod_dir: Option<&Path>,
+    direct_modules: &BTreeSet<String>,
+) -> Vec<(String, String)> {
+    let mut merged: BTreeMap<String, String> = TESTIFY_INDIRECT_DEPS
+        .iter()
+        .map(|(module, version)| ((*module).to_string(), (*version).to_string()))
+        .collect();
+
+    if let Some(dir) = dependency_go_mod_dir {
+        let go_mod_path = dir.join("go.mod");
+        match std::fs::read_to_string(&go_mod_path) {
+            Ok(text) => {
+                for (module, version) in parse_go_mod_requires(&text) {
+                    merged.insert(module, version);
+                }
+            }
+            Err(error) => {
+                tracing::debug!(
+                    path = %go_mod_path.display(),
+                    %error,
+                    "could not read dependency go.mod for indirect requires; falling back to testify-only set"
+                );
+            }
+        }
+    }
+
+    merged.retain(|module, _| !direct_modules.contains(module));
+    merged.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_go_mod_requires_reads_single_line_and_block_forms() {
+        let text = "module example.com/foo\n\ngo 1.26\n\nrequire github.com/tree-sitter/go-tree-sitter v0.25.0\n\nrequire (\n\tgithub.com/mattn/go-pointer v0.0.1 // indirect\n)\n";
+        let requires = parse_go_mod_requires(text);
+        assert_eq!(
+            requires
+                .get("github.com/tree-sitter/go-tree-sitter")
+                .map(String::as_str),
+            Some("v0.25.0")
+        );
+        assert_eq!(
+            requires.get("github.com/mattn/go-pointer").map(String::as_str),
+            Some("v0.0.1")
+        );
+        assert_eq!(requires.len(), 2, "unexpected requires: {requires:?}");
+    }
+
+    #[test]
+    fn parse_go_mod_requires_returns_empty_for_bare_module() {
+        let text = "module example.com/bare\n\ngo 1.26\n";
+        assert!(parse_go_mod_requires(text).is_empty());
+    }
+
+    fn direct_modules(paths: &[&str]) -> BTreeSet<String> {
+        paths.iter().map(|p| (*p).to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_indirect_requires_falls_back_to_testify_only_when_dir_is_none() {
+        let resolved = resolve_indirect_requires(None, &direct_modules(&["github.com/example/mylib"]));
+        let expected: Vec<(String, String)> = TESTIFY_INDIRECT_DEPS
+            .iter()
+            .map(|(m, v)| ((*m).to_string(), (*v).to_string()))
+            .collect();
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_indirect_requires_falls_back_to_testify_only_when_go_mod_missing() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        // No go.mod written into `dir`.
+        let resolved = resolve_indirect_requires(Some(dir.path()), &direct_modules(&["github.com/example/mylib"]));
+        let expected: Vec<(String, String)> = TESTIFY_INDIRECT_DEPS
+            .iter()
+            .map(|(m, v)| ((*m).to_string(), (*v).to_string()))
+            .collect();
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_indirect_requires_merges_dependency_go_mod_requires() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module github.com/xberg-io/tree-sitter-language-pack/packages/go\n\n\
+             go 1.26\n\n\
+             require github.com/tree-sitter/go-tree-sitter v0.25.0\n\n\
+             require github.com/mattn/go-pointer v0.0.1 // indirect\n",
+        )
+        .expect("write fixture go.mod");
+
+        let resolved = resolve_indirect_requires(
+            Some(dir.path()),
+            &direct_modules(&[
+                "github.com/xberg-io/tree-sitter-language-pack/packages/go",
+                "github.com/stretchr/testify",
+            ]),
+        );
+
+        assert_eq!(
+            resolved,
+            vec![
+                ("github.com/davecgh/go-spew".to_string(), "v1.1.1".to_string()),
+                ("github.com/mattn/go-pointer".to_string(), "v0.0.1".to_string()),
+                ("github.com/pmezard/go-difflib".to_string(), "v1.0.0".to_string()),
+                (
+                    "github.com/tree-sitter/go-tree-sitter".to_string(),
+                    "v0.25.0".to_string()
+                ),
+                ("gopkg.in/yaml.v3".to_string(), "v3.0.1".to_string()),
+            ],
+            "expected testify indirects merged alphabetically with the dependency's own requires"
+        );
+    }
+
+    #[test]
+    fn resolve_indirect_requires_excludes_self_reference() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module github.com/example/mylib\n\ngo 1.26\n\nrequire github.com/example/mylib v1.0.0\n",
+        )
+        .expect("write fixture go.mod");
+
+        let resolved = resolve_indirect_requires(Some(dir.path()), &direct_modules(&["github.com/example/mylib"]));
+        assert!(
+            !resolved.iter().any(|(module, _)| module == "github.com/example/mylib"),
+            "a module must not appear as its own indirect require, got: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_indirect_requires_excludes_modules_already_required_directly() {
+        // Models `tree-sitter-language-pack`'s `e2e/go`: `harness_extras` already lists
+        // `go-tree-sitter` as a DIRECT require, and `packages/go/go.mod` also requires it
+        // directly. It must not additionally appear in the `// indirect` block -- a module
+        // cannot be required both directly and as `// indirect` in the same go.mod.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::write(
+            dir.path().join("go.mod"),
+            "module github.com/xberg-io/tree-sitter-language-pack/packages/go\n\n\
+             go 1.26\n\n\
+             require github.com/tree-sitter/go-tree-sitter v0.25.0\n\n\
+             require github.com/mattn/go-pointer v0.0.1 // indirect\n",
+        )
+        .expect("write fixture go.mod");
+
+        let resolved = resolve_indirect_requires(
+            Some(dir.path()),
+            &direct_modules(&[
+                "github.com/xberg-io/tree-sitter-language-pack/packages/go",
+                "github.com/stretchr/testify",
+                "github.com/tree-sitter/go-tree-sitter",
+            ]),
+        );
+
+        assert!(
+            !resolved
+                .iter()
+                .any(|(module, _)| module == "github.com/tree-sitter/go-tree-sitter"),
+            "a module already required directly must not also appear as `// indirect`, got: {resolved:?}"
+        );
+        assert!(
+            resolved
+                .iter()
+                .any(|(module, _)| module == "github.com/mattn/go-pointer"),
+            "go-pointer (only indirect) should still be included, got: {resolved:?}"
+        );
+    }
+}

--- a/src/e2e/codegen/go/tests/go_mod_tests.rs
+++ b/src/e2e/codegen/go/tests/go_mod_tests.rs
@@ -1,5 +1,9 @@
 //! Coverage for `render_go_mod`: registry vs local mode, testify indirect deps, and extras
-//! (dependencies/dev-dependencies) merging, sorting, and idempotency.
+//! (dependencies/dev-dependencies) merging, sorting, and idempotency. Also covers the direct
+//! require block's canonical alphabetical ordering and the merge of a required module's own
+//! on-disk go.mod requires into the generated `// indirect` block (the
+//! `dependency_go_mod_dir` parameter) -- see `dependency_requires` for the lower-level parser
+//! and merge/sort unit tests.
 //!
 //! Split out of `tests.rs`, which is over the 1000-line cap and may not grow.
 
@@ -7,7 +11,7 @@ use super::render_go_mod;
 
 #[test]
 fn render_go_mod_without_extras() {
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None);
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None, None);
     assert!(
         out.contains("github.com/example/mylib v1.0.0"),
         "should contain main module require"
@@ -28,7 +32,7 @@ fn render_go_mod_includes_testify_indirect_deps() {
     // abort with "updates to go.mod needed; ... go mod tidy". The generated
     // test_app must carry a complete dependency graph so it builds without a
     // manual tidy (and offline).
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None);
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None, None);
     for indirect in [
         "github.com/davecgh/go-spew v1.1.1 // indirect",
         "github.com/pmezard/go-difflib v1.0.0 // indirect",
@@ -46,7 +50,7 @@ fn render_go_mod_registry_mode_uses_sibling_module_path() {
     // Registry mode (no replace): the main module must NOT be a subpath of the
     // module under test, or Go ignores the `require` directive and resolves a
     // stray upstream tag instead of the pinned version.
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None);
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", None, None);
     assert!(
         out.contains("module github.com/example/mylib-e2e"),
         "registry-mode main module must be a sibling path, got: {out}"
@@ -61,7 +65,13 @@ fn render_go_mod_registry_mode_uses_sibling_module_path() {
 fn render_go_mod_local_mode_uses_nested_module_path() {
     // Local mode (replace present): a nested `/e2e` main module resolves via the
     // replace directive, so keep the historical nested path.
-    let out = render_go_mod("github.com/example/mylib", Some("../../packages/go"), "v0.0.0", None);
+    let out = render_go_mod(
+        "github.com/example/mylib",
+        Some("../../packages/go"),
+        "v0.0.0",
+        None,
+        None,
+    );
     assert!(
         out.contains("module github.com/example/mylib/e2e"),
         "local-mode main module should stay nested, got: {out}"
@@ -76,7 +86,7 @@ fn render_go_mod_with_extras_includes_requires() {
         "github.com/tree-sitter/go-tree-sitter".to_string(),
         ExtraDepSpec::Simple("v0.24.0".to_string()),
     );
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     assert!(
         out.contains("github.com/tree-sitter/go-tree-sitter v0.24.0"),
         "should include tree-sitter extra, got: {out}"
@@ -100,6 +110,7 @@ fn render_go_mod_extras_with_replace_directive() {
         Some("../../packages/go"),
         "v0.0.0",
         Some(&extras),
+        None,
     );
     assert!(
         out.contains("github.com/upstream/lib v0.5.0"),
@@ -115,8 +126,8 @@ fn render_go_mod_extras_with_replace_directive() {
 fn render_go_mod_empty_extras_matches_no_extras() {
     use crate::core::config::manifest_extras::ManifestExtras;
     let extras = ManifestExtras::default();
-    let without_empty = render_go_mod("github.com/example/mylib", None, "v1.0.0", None);
-    let with_empty = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let without_empty = render_go_mod("github.com/example/mylib", None, "v1.0.0", None, None);
+    let with_empty = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     assert_eq!(without_empty, with_empty, "empty extras should be equivalent to None");
 }
 
@@ -136,7 +147,7 @@ fn render_go_mod_extras_are_sorted_deterministically() {
         "github.com/m-middle/lib".to_string(),
         ExtraDepSpec::Simple("v3.0.0".to_string()),
     );
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     let first_idx = out.find("github.com/a-first/lib").expect("should find a-first");
     let middle_idx = out.find("github.com/m-middle/lib").expect("should find m-middle");
     let last_idx = out.find("github.com/z-last/lib").expect("should find z-last");
@@ -157,7 +168,7 @@ fn render_go_mod_extras_handles_detailed_form_with_version() {
         "github.com/example/with-features".to_string(),
         ExtraDepSpec::Detailed(table),
     );
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     assert!(
         out.contains("github.com/example/with-features v0.25.0"),
         "should extract version from detailed form, got: {out}"
@@ -177,7 +188,7 @@ fn render_go_mod_extras_skips_entries_without_version() {
         "github.com/example/no-version".to_string(),
         ExtraDepSpec::Detailed(table),
     );
-    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let out = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     assert!(
         !out.contains("github.com/example/no-version"),
         "should skip extras without version field, got: {out}"
@@ -192,7 +203,179 @@ fn render_go_mod_extras_idempotent() {
         "github.com/tree-sitter/go-tree-sitter".to_string(),
         ExtraDepSpec::Simple("v0.24.0".to_string()),
     );
-    let first = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
-    let second = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras));
+    let first = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
+    let second = render_go_mod("github.com/example/mylib", None, "v1.0.0", Some(&extras), None);
     assert_eq!(first, second, "re-rendering with same extras should be stable");
+}
+
+#[test]
+fn render_go_mod_direct_require_block_is_alphabetical() {
+    // Every consumer module path is `github.com/xberg-io/...`, which always sorts after
+    // `github.com/stretchr/testify` ('s' < 'x') -- so testify must come first in the generated
+    // block, not the required module.
+    let out = render_go_mod(
+        "github.com/xberg-io/tree-sitter-language-pack/packages/go",
+        None,
+        "v1.16.2",
+        None,
+        None,
+    );
+    let testify_idx = out
+        .find("github.com/stretchr/testify")
+        .expect("should contain testify require");
+    let module_idx = out
+        .find("github.com/xberg-io/tree-sitter-language-pack/packages/go v1.16.2")
+        .expect("should contain module require");
+    assert!(
+        testify_idx < module_idx,
+        "testify must sort before the xberg module in the direct require block, got:\n{out}"
+    );
+}
+
+#[test]
+fn render_go_mod_merges_dependency_go_mod_indirect_requires() {
+    // Models `tree-sitter-language-pack`'s real `packages/go/go.mod`: a direct require of
+    // `go-tree-sitter` and an indirect require of `go-pointer`. Both must appear in the
+    // generated go.mod's `// indirect` block, merged alphabetically with the testify indirects
+    // -- dropping them makes `go build -mod=readonly` still pass (module pruning) but `go test
+    // -mod=readonly ./...` fail with "updates to go.mod needed".
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("go.mod"),
+        "module github.com/xberg-io/tree-sitter-language-pack/packages/go\n\n\
+         go 1.26\n\n\
+         require github.com/tree-sitter/go-tree-sitter v0.25.0\n\n\
+         require github.com/mattn/go-pointer v0.0.1 // indirect\n",
+    )
+    .expect("write fixture go.mod");
+
+    let out = render_go_mod(
+        "github.com/xberg-io/tree-sitter-language-pack/packages/go",
+        Some("../../packages/go"),
+        "v1.16.2",
+        None,
+        Some(dir.path()),
+    );
+
+    // (a) direct require block is alphabetical: testify before the xberg module.
+    let testify_idx = out
+        .find("github.com/stretchr/testify")
+        .expect("should contain testify require");
+    let module_idx = out
+        .find("github.com/xberg-io/tree-sitter-language-pack/packages/go v1.16.2")
+        .expect("should contain module require");
+    assert!(
+        testify_idx < module_idx,
+        "testify must sort before the xberg module, got:\n{out}"
+    );
+
+    // (b) indirect block merges testify's pinned indirects with the dependency's own requires,
+    // alphabetically.
+    let expected_indirect_order = [
+        "github.com/davecgh/go-spew v1.1.1 // indirect",
+        "github.com/mattn/go-pointer v0.0.1 // indirect",
+        "github.com/pmezard/go-difflib v1.0.0 // indirect",
+        "github.com/tree-sitter/go-tree-sitter v0.25.0 // indirect",
+        "gopkg.in/yaml.v3 v3.0.1 // indirect",
+    ];
+    let mut last_idx = None;
+    for indirect in expected_indirect_order {
+        let idx = out
+            .find(indirect)
+            .unwrap_or_else(|| panic!("go.mod must contain indirect dep `{indirect}`, got:\n{out}"));
+        if let Some(last) = last_idx {
+            assert!(last < idx, "indirect block out of alphabetical order, got:\n{out}");
+        }
+        last_idx = Some(idx);
+    }
+}
+
+#[test]
+fn render_go_mod_excludes_extra_that_duplicates_dependency_direct_require() {
+    // Models `tree-sitter-language-pack`'s real `e2e/go/go.mod`: `harness_extras` lists
+    // `go-tree-sitter` as a direct require (Local dep mode injects the harness's own native
+    // dep), and `packages/go/go.mod` ALSO requires it directly. It must appear exactly once, in
+    // the direct block -- never additionally in the `// indirect` block, which would make it a
+    // duplicate requirement for the same module.
+    use crate::core::config::manifest_extras::{ExtraDepSpec, ManifestExtras};
+
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("go.mod"),
+        "module github.com/xberg-io/tree-sitter-language-pack/packages/go\n\n\
+         go 1.26\n\n\
+         require github.com/tree-sitter/go-tree-sitter v0.25.0\n\n\
+         require github.com/mattn/go-pointer v0.0.1 // indirect\n",
+    )
+    .expect("write fixture go.mod");
+
+    let mut extras = ManifestExtras::default();
+    extras.dev_dependencies.insert(
+        "github.com/tree-sitter/go-tree-sitter".to_string(),
+        ExtraDepSpec::Simple("v0.25.0".to_string()),
+    );
+
+    let out = render_go_mod(
+        "github.com/xberg-io/tree-sitter-language-pack/packages/go",
+        Some("../../packages/go"),
+        "v0.0.0",
+        Some(&extras),
+        Some(dir.path()),
+    );
+
+    let occurrences = out.matches("github.com/tree-sitter/go-tree-sitter").count();
+    assert_eq!(
+        occurrences, 1,
+        "go-tree-sitter must appear exactly once (direct, not also indirect), got:\n{out}"
+    );
+    assert!(
+        !out.contains("github.com/tree-sitter/go-tree-sitter v0.25.0 // indirect"),
+        "go-tree-sitter is already a direct require and must not also be `// indirect`, got:\n{out}"
+    );
+    assert!(
+        out.contains("github.com/mattn/go-pointer v0.0.1 // indirect"),
+        "go-pointer (only indirect) should still be included, got:\n{out}"
+    );
+}
+
+#[test]
+fn render_go_mod_dependency_with_no_extra_requires_matches_testify_only() {
+    // Models `crawlberg`/`xberg`/`liter-llm`/`html-to-markdown`'s actual shape today: a bare
+    // `module .../go.mod` `go 1.26` with zero requires. Output must be unchanged from the
+    // testify-only indirect set (just reordered alphabetically in the direct block).
+    let dir = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(
+        dir.path().join("go.mod"),
+        "module github.com/xberg-io/example/packages/go\n\ngo 1.26\n",
+    )
+    .expect("write fixture go.mod");
+
+    let with_dependency_dir = render_go_mod(
+        "github.com/xberg-io/example/packages/go",
+        Some("../../packages/go"),
+        "v1.0.0",
+        None,
+        Some(dir.path()),
+    );
+    let without_dependency_dir = render_go_mod(
+        "github.com/xberg-io/example/packages/go",
+        Some("../../packages/go"),
+        "v1.0.0",
+        None,
+        None,
+    );
+    assert_eq!(
+        with_dependency_dir, without_dependency_dir,
+        "a dependency go.mod with no requires must not change the testify-only indirect output"
+    );
+    for indirect in [
+        "github.com/davecgh/go-spew v1.1.1 // indirect",
+        "github.com/pmezard/go-difflib v1.0.0 // indirect",
+        "gopkg.in/yaml.v3 v3.0.1 // indirect",
+    ] {
+        assert!(
+            with_dependency_dir.contains(indirect),
+            "should still contain testify indirect `{indirect}`, got:\n{with_dependency_dir}"
+        );
+    }
 }


### PR DESCRIPTION
0.82.2 regressed `test_apps/go/go.mod` for any consumer whose Go package has its own dependencies: the `// indirect` block was the hardcoded testify set and nothing else, so Go's module-graph pruning rule left the generated module with an incomplete graph.

The reason this was not caught is the important part. `go build -mod=readonly ./...` **passes** on the broken file — pruning means the build genuinely does not need those modules — so a build-only gate reports it fixed while `go test -mod=readonly ./...` still fails with "updates to go.mod needed".

Measured against `tree-sitter-language-pack` (the only consumer whose `packages/go/go.mod` declares requires), with the module pin held at the published v1.16.1 so publication state is not a confound:

| | `go build -mod=readonly` | `go test -mod=readonly` | `go mod tidy` diff |
|---|---|---|---|
| 0.82.2 output | exit 0 | `updates to go.mod needed` | adds `go-tree-sitter`, `go-pointer`; reorders directs |
| this branch | exit 0 | `ok` | **empty** |

Blast radius across all five consumers: tslp gets the indirect merge and the reorder; crawlberg, html-to-markdown and xberg get the reorder only (their `packages/go/go.mod` declares no requires, so the merge degrades to the testify-only set); liter-llm is unchanged.

The second change is the direct-`require` sort. It was written module-then-testify, but every consumer module path is `github.com/xberg-io/...`, which sorts after `github.com/stretchr/testify` — so the hand-written order was wrong for every consumer, always, and `go mod tidy` kept undoing it.

35 unit tests, including cases for the fallback when the dependency's `go.mod` is missing, self-reference exclusion, and a module that is both a `harness_extras` direct require and one of the dependency's own direct requires.
