### PR TITLE
fix(node): assert a nested tagged-enum literal's own union type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A node e2e/snippet object literal whose field is a tagged-data enum lost its discriminant's
+  literal type, so the value stopped matching the union the napi binding declares (`TS2345`).**
+  The generic object path had no typed renderer for a `Named` field resolving to an `EnumDef`
+  rather than a `TypeDef`, so it treated the discriminant like any other field and copied the
+  fixture's wire string verbatim. Nothing is wrong with that literal in isolation — `"basic"` is
+  a real member of `"basic" | "bearer"` — but the argument builder binds the enclosing literal to
+  an unannotated `const` before passing it on (it strips the outer `as <OptionsType>` assertion
+  to do so), and with no contextual type left the tag widens to plain `string` and matches
+  neither union member. A struct-shaped variant's literal now asserts its own enum type, so the
+  tag cannot widen however deeply the literal is nested or however its caller binds it. Seen as
+  16 `fixture_node_auth_*` failures in `crawlberg`.
+
 ## [0.82.2] - 2026-09-03
 
 Patch release. Two entries are regressions shipped in 0.82.1 -- both generated crates that do not

--- a/src/e2e/codegen/typescript/test_file/builders/mod.rs
+++ b/src/e2e/codegen/typescript/test_file/builders/mod.rs
@@ -145,6 +145,84 @@ fn build_node_tagged_enum_variant_literal(
     ))
 }
 
+/// For a node-lang tagged-data enum whose matched variant is struct-shaped (named fields
+/// flattened directly alongside the tag, e.g. `AuthConfig::Basic { username, password }` under
+/// `#[serde(tag = "type")]`), napi's `.d.ts` union member keeps that exact flattened shape
+/// (`{ type: "basic"; username: string; password: string }`) — see `gen_tagged_enum_as_object`.
+///
+/// `node_value_expression`'s generic object path (the caller here) has no typed renderer for a
+/// `Named` field whose type is an [`EnumDef`] rather than a [`TypeDef`], so it fell through to
+/// treating the tag key like any other field and copied the fixture's wire string verbatim. That
+/// string is a real value of the discriminant's declared type ("basic" IS a member of
+/// `"basic" | "bearer" | "header"`), so nothing here is wrong in isolation -- the literal only
+/// breaks once something ELSE binds it to an unannotated `const` or otherwise loses the calling
+/// context that would contextually type it, at which point the tag widens to plain `string` and
+/// no longer matches the union (`TS2345`). Casting the object literal itself `as <type_name>`
+/// gives the WHOLE expression that exact type before it can be assigned to anything, so the tag
+/// never gets a chance to widen -- regardless of how deeply nested this literal ends up, or
+/// whether its caller binds it to a `const` first. ~keep
+///
+/// Returns `None` for anything this does not confidently know how to render (no tag key present,
+/// no variant matching the tag's wire value, or a tuple-shaped variant -- that shape nests its
+/// payload under a synthesized field name instead of flattening, and is
+/// `build_node_tagged_enum_variant_literal`'s to handle, not this one) so the caller falls back
+/// to the ordinary flatten path unchanged.
+#[allow(clippy::too_many_arguments)]
+fn node_tagged_struct_variant_literal(
+    type_name: &str,
+    enum_def: &EnumDef,
+    obj: &serde_json::Map<String, serde_json::Value>,
+    enum_fields: &std::collections::HashMap<String, String>,
+    docs_files: &[crate::e2e::fixture::FixtureDocsFileInput],
+    pointer: &str,
+    type_defs: &[TypeDef],
+    enums: &[EnumDef],
+    referenced_enums: &mut std::collections::BTreeSet<String>,
+) -> Option<String> {
+    if !crate::backends::napi::is_tagged_data_enum(enum_def) {
+        return None;
+    }
+    let tag_field = crate::backends::napi::tagged_enum_discriminant_js_name(enum_def);
+    let tag_value = obj.get(tag_field)?.as_str()?;
+    let variant = enum_def.variants.iter().find(|v| {
+        crate::codegen::naming::wire_variant_value(
+            &v.name,
+            v.serde_rename.as_deref(),
+            enum_def.serde_rename_all.as_deref(),
+        ) == tag_value
+    })?;
+    if variant.is_tuple {
+        return None;
+    }
+    let fields = obj
+        .iter()
+        .map(|(key, val)| {
+            let js_key = node_field_public_key(None, key);
+            let expr = if key == tag_field {
+                serde_json::to_string(tag_value).expect("tag values serialize as JSON strings")
+            } else {
+                let nested_field_type = variant.fields.iter().find(|f| f.name == *key).map(|f| &f.ty);
+                node_value_expression(
+                    val,
+                    key,
+                    enum_fields,
+                    docs_files,
+                    &json_pointer_child(pointer, key),
+                    nested_field_type,
+                    type_defs,
+                    enums,
+                    None,
+                    referenced_enums,
+                )
+            };
+            format!("{js_key}: {expr}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    referenced_enums.insert(format!("type {type_name}"));
+    Some(format!("{{ {fields} }} as {type_name}"))
+}
+
 /// Pre-process a JSON value so that napi-rs (node) binding can deserialize it.
 ///
 /// The napi-rs backend exposes a tagged-data enum's discriminant under the
@@ -886,6 +964,23 @@ fn node_value_expression(
         }
         let member = declared_enum_member_for_prefixed(enum_type, enums, "", variant);
         return enum_member_reference(enum_type, &member, referenced_enums);
+    }
+    if let Some(crate::core::ir::TypeRef::Named(type_name)) = field_type
+        && let serde_json::Value::Object(object) = value
+        && let Some(enum_def) = enums.iter().find(|definition| definition.name == *type_name)
+        && let Some(literal) = node_tagged_struct_variant_literal(
+            type_name,
+            enum_def,
+            object,
+            enum_fields,
+            docs_files,
+            pointer,
+            type_defs,
+            enums,
+            referenced_enums,
+        )
+    {
+        return literal;
     }
     match value {
         serde_json::Value::Object(object) => {

--- a/src/e2e/codegen/typescript/test_file/builders/tests.rs
+++ b/src/e2e/codegen/typescript/test_file/builders/tests.rs
@@ -978,3 +978,135 @@ fn node_field_keyed_by_a_wire_name_that_diverges_from_its_js_name_resolves_the_j
 
     assert_eq!(expression, "{ toolType: \"function\" } as ExampleTool");
 }
+
+/// `AuthConfig` is crawlberg's real `#[serde(tag = "type", rename_all = "lowercase")]` enum with
+/// two STRUCT variants — named fields flattened alongside the tag, which is the shape
+/// `internal_tagged_union_dts_lines` renders as `{ type: 'basic'; username: string; password:
+/// string } | { type: 'bearer'; token: string }`.
+fn auth_config_enum_def() -> EnumDef {
+    let string_field = |name: &str| crate::core::ir::FieldDef {
+        name: name.into(),
+        ty: TypeRef::String,
+        ..Default::default()
+    };
+    EnumDef {
+        name: "AuthConfig".into(),
+        serde_tag: Some("type".into()),
+        serde_rename_all: Some("lowercase".into()),
+        variants: vec![
+            crate::core::ir::EnumVariant {
+                name: "Basic".into(),
+                fields: vec![string_field("username"), string_field("password")],
+                ..Default::default()
+            },
+            crate::core::ir::EnumVariant {
+                name: "Bearer".into(),
+                fields: vec![string_field("token")],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+fn engine_config_type_def() -> TypeDef {
+    TypeDef {
+        name: "EngineConfig".into(),
+        fields: vec![
+            crate::core::ir::FieldDef {
+                name: "auth".into(),
+                ty: TypeRef::Named("AuthConfig".into()),
+                ..Default::default()
+            },
+            crate::core::ir::FieldDef {
+                name: "respect_robots_txt".into(),
+                ty: TypeRef::Primitive(crate::core::ir::PrimitiveType::Bool),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+fn engine_config_expression() -> String {
+    ts_builder_expression(
+        serde_json::json!({
+            "auth": {"type": "basic", "username": "testuser", "password": "testpass"},
+            "respect_robots_txt": false,
+        })
+        .as_object()
+        .expect("object"),
+        "EngineConfig",
+        &Default::default(),
+        "node",
+        &Default::default(),
+        &Default::default(),
+        &[engine_config_type_def()],
+        &[auth_config_enum_def()],
+        "",
+        &[],
+        &mut Default::default(),
+    )
+}
+
+#[test]
+fn node_nested_tagged_struct_variant_literal_carries_its_own_type_assertion() {
+    let expression = engine_config_expression();
+    assert!(
+        expression.contains("} as AuthConfig"),
+        "the nested tagged-enum literal must assert its own union type so its discriminant \
+         cannot widen to `string`, got: {expression}"
+    );
+}
+
+/// The falsifiable half, and the shape the defect actually took in crawlberg's 16
+/// `fixture_node_auth_*` failures: `args.rs`'s `bind_typed_json_objects` path strips the outer
+/// ` as EngineConfig` and binds the literal to an unannotated `const` before passing it on, so
+/// the object literal is contextually typed by NOTHING. Without an assertion of its own, the
+/// nested `type: "basic"` widens from the literal type `"basic"` to plain `string`, which is not
+/// assignable to either member of the `AuthConfig` union — `TS2345`.
+///
+/// This typechecks the e2e generator's literal against the union the napi backend itself emits
+/// (`internal_tagged_union_dts_lines`), so the two generators cannot drift apart silently. Skips
+/// itself when `tsc` is not installed, like every other test in this file.
+#[test]
+fn node_nested_tagged_struct_variant_survives_binding_to_an_unannotated_const() {
+    let expression = engine_config_expression();
+    let literal = expression
+        .strip_suffix(" as EngineConfig")
+        .expect("node builder expressions end in an `as <type>` assertion");
+    let dts = crate::backends::napi::internal_tagged_union_dts_lines(&auth_config_enum_def(), "AuthConfig").join("\n");
+    let source = format!(
+        "{dts}\n\
+         interface EngineConfig {{ auth: AuthConfig; respectRobotsTxt: boolean }}\n\
+         declare function createEngine(config: EngineConfig): void;\n\
+         const engineConfig = {literal};\n\
+         createEngine(engineConfig);\n"
+    );
+    assert_strict_typescript_compiles(&source);
+}
+
+/// The neutralisation control: the same literal with the nested assertion removed is exactly
+/// what 0.82.2 emitted, and strict TypeScript must reject it. Without this, the test above
+/// cannot tell a real fix from a `tsc` that accepts anything.
+#[test]
+fn node_nested_tagged_struct_variant_without_its_assertion_is_rejected() {
+    let expression = engine_config_expression();
+    let literal = expression
+        .strip_suffix(" as EngineConfig")
+        .expect("node builder expressions end in an `as <type>` assertion")
+        .replace("} as AuthConfig", "}");
+    assert!(
+        !literal.contains("as AuthConfig"),
+        "neutralisation must remove the nested assertion, got: {literal}"
+    );
+    let dts = crate::backends::napi::internal_tagged_union_dts_lines(&auth_config_enum_def(), "AuthConfig").join("\n");
+    let source = format!(
+        "{dts}\n\
+         interface EngineConfig {{ auth: AuthConfig; respectRobotsTxt: boolean }}\n\
+         declare function createEngine(config: EngineConfig): void;\n\
+         const engineConfig = {literal};\n\
+         createEngine(engineConfig);\n"
+    );
+    assert_strict_typescript_rejects(&source);
+}


### PR DESCRIPTION
crawlberg's node e2e leg fails 16 `fixture_node_auth_*` tests with `TS2345`. The generated snippet is:

```typescript
const engineConfig = { auth: { password: "testpass", type: "basic", username: "testuser" }, respectRobotsTxt: false };
const engine = createEngine(engineConfig);
```

`AuthConfig` is `{ type: "basic"; … } | { type: "bearer"; … }`. The nested literal is not wrong on its own — `"basic"` is a real member of that discriminant's type — but the argument builder strips the enclosing literal's `as EngineConfig` assertion in order to bind it to a `const`, and an object literal with no contextual type widens `type: "basic"` to `type: string`, which matches neither union member.

The generic object path had no typed renderer for a `Named` field that resolves to an `EnumDef` rather than a `TypeDef`, so it fell through to treating the tag like any other field. A struct-shaped variant now renders `{ … } as AuthConfig`, which fixes the tag's type at the point the literal is built — independent of how deeply it is nested or what its caller does with it. Tuple-shaped variants return `None` and keep the existing nesting path.

Verification is a real `tsc --strict` run against the union the napi backend itself emits (`internal_tagged_union_dts_lines`), so the two generators cannot drift apart silently:

- `node_nested_tagged_struct_variant_literal_carries_its_own_type_assertion` — the assertion is emitted.
- `node_nested_tagged_struct_variant_survives_binding_to_an_unannotated_const` — reproduces the exact binding shape `args.rs` produces, and typechecks.
- `node_nested_tagged_struct_variant_without_its_assertion_is_rejected` — the neutralised control: the same literal with the assertion stripped is what 0.82.2 emitted, and `tsc` must reject it. Without this the positive test could not distinguish a fix from a permissive typechecker.
