### PR TITLE
fix(node): build the mock-url payload with the typed arg builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **alef#309 instance 1: node/wasm e2e payloads for a `$mock_url`-templated `json_object`
+  argument dropped a tagged-data enum's `type` discriminator.** The array and single-object
+  branches of the TypeScript e2e arg renderer (`build_args_and_setup` in
+  `src/e2e/codegen/typescript/test_file/args.rs`) that detect a `$mock_url` placeholder built
+  their `JSON.stringify(...).replaceAll(...)`/`JSON.parse(...)` literal from a plain
+  `json_to_js_camel` dump instead of the same `ts_builder_expression`/per-element typed builder
+  the non-templated sibling branches already use. A fixture field typed as a data-carrying enum
+  (e.g. `OutputFormat`, internally tagged under napi's default `"type"` key) rendered as its bare
+  wire string (`outputFormat: "markdown"`) whenever the same array element or object also needed
+  URL templating, instead of the tagged object the napi binding requires
+  (`{ type: "markdown" }`) -- failing with `Missing field 'type' on
+  JsFileExtractionConfig.outputFormat on JsExtractInput.config`. Both branches now build the
+  typed literal first and reuse it whether or not a placeholder is present, so the templated and
+  non-templated paths can no longer disagree about an enum's wire shape.
+
 ## [0.82.2] - 2026-09-03
 
 Patch release. Two entries are regressions shipped in 0.82.1 -- both generated crates that do not

--- a/src/e2e/codegen/typescript/test_file.rs
+++ b/src/e2e/codegen/typescript/test_file.rs
@@ -31,6 +31,8 @@ mod json_object_field_agreement_tests;
 #[cfg(test)]
 mod loop_binding_tests;
 #[cfg(test)]
+mod mock_url_tagged_enum_tests;
+#[cfg(test)]
 mod node_enum_import_tests;
 #[cfg(test)]
 mod optional_segment_len_tests;

--- a/src/e2e/codegen/typescript/test_file/args.rs
+++ b/src/e2e/codegen/typescript/test_file/args.rs
@@ -398,31 +398,6 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                     }
                 } else if arg.arg_type == "json_object" {
                     if v.is_array() {
-                        // Array args use fixture-shaped object literals; element_type is
-                        // still used by typed bindings/imports, not product-specific constructors.
-                        if crate::e2e::codegen::value_contains_mock_url_placeholder(v) {
-                            let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
-                            let var_prefix = sanitize_ident(&arg.name);
-                            setup_lines.push(format!(
-                                "const {var_prefix}MockBaseUrl = process.env.{env_key} ?? `${{process.env.MOCK_SERVER_URL}}/fixtures/{fixture_id}`;"
-                            ));
-                            let json_literal = json_to_js_camel(v);
-                            setup_lines.push(format!(
-                                "const {var_prefix}Json = JSON.stringify({json_literal}).replaceAll(\"{}\", {var_prefix}MockBaseUrl);",
-                                crate::e2e::codegen::MOCK_URL_PLACEHOLDER
-                            ));
-                            let array_type = arg
-                                .element_type
-                                .as_deref()
-                                .map(|raw| format!("{}[]", canonical_ts_type_name(lang, raw, config)))
-                                .unwrap_or_else(|| "unknown[]".to_string());
-                            setup_lines.push(format!(
-                                "const {name} = JSON.parse({var_prefix}Json) as {array_type};",
-                                name = arg.name
-                            ));
-                            parts.push(arg.name.clone());
-                            continue;
-                        }
                         // A raw `json_to_js_camel` dump only camelCases keys — it does not know
                         // that a node/napi element type can be a tagged-data enum whose payload
                         // napi nests under a synthesized per-variant field (see
@@ -440,7 +415,18 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                         // (`TS2739: missing properties`). The single-object branch below already
                         // prefixes wasm element types via `wasm_prefixed_wrapped_type`; array
                         // elements must do the same rather than falling through to
-                        // `json_to_js_camel`'s plain literal. ~keep
+                        // `json_to_js_camel`'s plain literal.
+                        //
+                        // This typed literal is built BEFORE the mock-url check below, and reused
+                        // for both outcomes: a `$mock_url` placeholder changes how the literal
+                        // reaches the runtime value (JSON.stringify/replaceAll/JSON.parse, so a
+                        // template string can be substituted into it) but must never change what
+                        // that value IS -- an enum field's wire shape is a fact this literal
+                        // builder resolves through the same IR the napi binding was generated
+                        // from, and letting the mock-url path fall back to `json_to_js_camel`
+                        // once already dropped a tagged-data enum's `type` discriminator
+                        // entirely, because plain `json_to_js_camel` does not know that the
+                        // binding's `#[napi(object)]` type expects one. ~keep
                         let element_type = arg
                             .element_type
                             .as_deref()
@@ -448,7 +434,7 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                         let is_known_element_type = element_type.as_deref().is_some_and(|name| {
                             type_defs.iter().any(|t| t.name == name) || enums.iter().any(|e| e.name == name)
                         });
-                        if (lang == "node" || lang == "wasm")
+                        let array_literal = if (lang == "node" || lang == "wasm")
                             && let Some(element_type) = element_type.filter(|_| is_known_element_type)
                         {
                             let builder_type_name = if lang == "wasm" {
@@ -488,9 +474,32 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                                     None => json_to_js(item),
                                 })
                                 .collect();
-                            parts.push(format!("[{}]", items.join(", ")));
+                            format!("[{}]", items.join(", "))
                         } else {
-                            parts.push(json_to_js_camel(v));
+                            json_to_js_camel(v)
+                        };
+                        if crate::e2e::codegen::value_contains_mock_url_placeholder(v) {
+                            let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
+                            let var_prefix = sanitize_ident(&arg.name);
+                            setup_lines.push(format!(
+                                "const {var_prefix}MockBaseUrl = process.env.{env_key} ?? `${{process.env.MOCK_SERVER_URL}}/fixtures/{fixture_id}`;"
+                            ));
+                            setup_lines.push(format!(
+                                "const {var_prefix}Json = JSON.stringify({array_literal}).replaceAll(\"{}\", {var_prefix}MockBaseUrl);",
+                                crate::e2e::codegen::MOCK_URL_PLACEHOLDER
+                            ));
+                            let array_type = arg
+                                .element_type
+                                .as_deref()
+                                .map(|raw| format!("{}[]", canonical_ts_type_name(lang, raw, config)))
+                                .unwrap_or_else(|| "unknown[]".to_string());
+                            setup_lines.push(format!(
+                                "const {name} = JSON.parse({var_prefix}Json) as {array_type};",
+                                name = arg.name
+                            ));
+                            parts.push(arg.name.clone());
+                        } else {
+                            parts.push(array_literal);
                         }
                     } else if let Some(raw_type) =
                         crate::e2e::codegen::recipe::json_object_constructor_type(arg, options_type, v)
@@ -523,26 +532,16 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                                 parts.push("undefined".to_string());
                             }
                         } else if let Some(obj) = v.as_object() {
-                            if crate::e2e::codegen::value_contains_mock_url_placeholder(v) {
-                                let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
-                                let var_prefix = sanitize_ident(&arg.name);
-                                setup_lines.push(format!(
-                                    "const {var_prefix}MockBaseUrl = process.env.{env_key} ?? `${{process.env.MOCK_SERVER_URL}}/fixtures/{fixture_id}`;"
-                                ));
-                                let json_literal = json_to_js_camel(v);
-                                setup_lines.push(format!(
-                                    "const {var_prefix}Json = JSON.stringify({json_literal}).replaceAll(\"{}\", {var_prefix}MockBaseUrl);",
-                                    crate::e2e::codegen::MOCK_URL_PLACEHOLDER
-                                ));
-                                setup_lines.push(format!(
-                                    "const {name} = JSON.parse({var_prefix}Json) as {opts_type};",
-                                    name = arg.name
-                                ));
-                                parts.push(arg.name.clone());
-                                continue;
-                            }
                             // Build TypeScript code to construct the options object properly,
-                            // handling nested types via their static factory methods.
+                            // handling nested types via their static factory methods. Built
+                            // BEFORE the mock-url check below and reused for both outcomes: a
+                            // `$mock_url` placeholder only changes how the literal reaches the
+                            // runtime value (JSON.stringify/replaceAll/JSON.parse, so a template
+                            // string can be substituted into it), never what that value IS -- an
+                            // enum-typed field's wire shape is a fact this builder resolves
+                            // through the same IR the napi binding was generated from, and a raw
+                            // `json_to_js_camel` dump here (as before) does not know a tagged-data
+                            // enum needs a `type` discriminator at all. ~keep
                             let ts_code = ts_builder_expression(
                                 obj,
                                 &opts_type,
@@ -556,7 +555,22 @@ pub(in crate::e2e::codegen::typescript::test_file) fn build_args_and_setup(
                                 &fixture.docs_files_for_arg(&arg.field),
                                 &mut *referenced_enums,
                             );
-                            if bind_typed_json_objects {
+                            if crate::e2e::codegen::value_contains_mock_url_placeholder(v) {
+                                let env_key = crate::e2e::codegen::mock_url_env_key(fixture_id);
+                                let var_prefix = sanitize_ident(&arg.name);
+                                setup_lines.push(format!(
+                                    "const {var_prefix}MockBaseUrl = process.env.{env_key} ?? `${{process.env.MOCK_SERVER_URL}}/fixtures/{fixture_id}`;"
+                                ));
+                                setup_lines.push(format!(
+                                    "const {var_prefix}Json = JSON.stringify({ts_code}).replaceAll(\"{}\", {var_prefix}MockBaseUrl);",
+                                    crate::e2e::codegen::MOCK_URL_PLACEHOLDER
+                                ));
+                                setup_lines.push(format!(
+                                    "const {name} = JSON.parse({var_prefix}Json) as {opts_type};",
+                                    name = arg.name
+                                ));
+                                parts.push(arg.name.clone());
+                            } else if bind_typed_json_objects {
                                 let suffix = format!(" as {opts_type}");
                                 let expression = ts_code.strip_suffix(&suffix).unwrap_or(&ts_code);
                                 setup_lines.push(crate::e2e::template_env::render(

--- a/src/e2e/codegen/typescript/test_file/mock_url_tagged_enum_tests.rs
+++ b/src/e2e/codegen/typescript/test_file/mock_url_tagged_enum_tests.rs
@@ -1,0 +1,203 @@
+//! Regression for alef#309 instance 1 (the node e2e "Missing field `type`" defect): a
+//! `$mock_url`-templated array or single-object `json_object` argument routed the value through
+//! `json_to_js_camel`/blind key-casing instead of the same typed builder (`ts_builder_expression`
+//! and its per-element callers in `args.rs`) the non-templated path already uses. A fixture's bare
+//! `"markdown"` for a data-carrying enum field (`OutputFormat`, internally tagged under napi's
+//! default `"type"` key) must still render as `{ type: "markdown" }` once the same value also
+//! needs the JSON.stringify/replaceAll/JSON.parse dance for an unrelated `$mock_url` placeholder,
+//! exactly as it does when no placeholder is present.
+//!
+//! Split out of `args.rs` (approaching the 1,000-line split threshold) as its own concept,
+//! matching `call_arity_tests.rs` and `json_object_field_agreement_tests.rs` next door. ~keep
+
+use super::args::build_args_and_setup;
+use crate::core::ir::{EnumDef, EnumVariant, FieldDef, TypeDef, TypeRef};
+use crate::e2e::config::ArgMapping;
+use crate::e2e::fixture::Fixture;
+
+fn output_format_enum_def() -> EnumDef {
+    EnumDef {
+        name: "OutputFormat".into(),
+        serde_rename_all: Some("lowercase".into()),
+        variants: vec![
+            EnumVariant {
+                name: "Markdown".into(),
+                ..Default::default()
+            },
+            // A data-carrying variant with no explicit `#[serde(tag = ...)]` at the enum
+            // level, exactly like the real `OutputFormat::Custom(String)` -- this is what makes
+            // `is_tagged_data_enum` true (internally-tagged, default "type" key) even though
+            // `serde_tag` is `None`.
+            EnumVariant {
+                name: "Custom".into(),
+                is_tuple: true,
+                fields: vec![FieldDef {
+                    name: "_0".into(),
+                    ty: TypeRef::String,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+fn file_extraction_config_type_def() -> TypeDef {
+    TypeDef {
+        name: "FileExtractionConfig".into(),
+        fields: vec![FieldDef {
+            name: "output_format".into(),
+            ty: TypeRef::Named("OutputFormat".into()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn extract_input_with_config_type_def() -> TypeDef {
+    TypeDef {
+        name: "ExtractInput".into(),
+        fields: vec![
+            FieldDef {
+                name: "uri".into(),
+                ty: TypeRef::String,
+                ..Default::default()
+            },
+            FieldDef {
+                name: "config".into(),
+                ty: TypeRef::Named("FileExtractionConfig".into()),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+fn fixture() -> Fixture {
+    Fixture {
+        id: "api_extract_batch_uri_with_config".to_string(),
+        description: "Tests batch URI extraction with per-input config".to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn node_mock_url_array_element_still_tags_nested_enum_field() {
+    let enums = [output_format_enum_def()];
+    let type_defs = [file_extraction_config_type_def(), extract_input_with_config_type_def()];
+    let fixture = fixture();
+    let input = serde_json::json!({
+        "inputs": [{ "uri": "$mock_url/pdf/fake.pdf", "config": { "output_format": "markdown" } }]
+    });
+    let args = [ArgMapping {
+        name: "inputs".into(),
+        field: "input.inputs".into(),
+        arg_type: "json_object".into(),
+        optional: false,
+        owned: true,
+        element_type: Some("ExtractInput".into()),
+        go_type: None,
+        vec_inner_is_ref: false,
+        trait_name: None,
+    }];
+    let config = crate::core::config::ResolvedCrateConfig::default();
+
+    let (setup_lines, _call_args) = build_args_and_setup(
+        &input,
+        &args,
+        None,
+        &fixture,
+        &Default::default(),
+        "node",
+        &Default::default(),
+        &Default::default(),
+        None,
+        &type_defs,
+        &enums,
+        "",
+        &config,
+        true,
+        &mut Default::default(),
+        crate::e2e::codegen::call_ir::TargetParams::IrAbsent,
+        crate::e2e::codegen::call_ir::CallIr::default(),
+    );
+
+    let json_stringify_line = setup_lines
+        .iter()
+        .find(|line| line.contains("JSON.stringify"))
+        .expect("a $mock_url-templated array argument must build via JSON.stringify/replaceAll/JSON.parse");
+    assert!(
+        json_stringify_line.contains(r#"outputFormat: { type: "markdown" } as OutputFormat"#),
+        "tagged-data enum field lost its `type` discriminator in the mock_url-templated array \
+         path: {json_stringify_line}"
+    );
+    assert!(
+        !json_stringify_line.contains(r#"outputFormat: "markdown""#),
+        "regression: enum field rendered as a bare wire string instead of the tagged object \
+         the napi binding requires: {json_stringify_line}"
+    );
+}
+
+/// The single-object half of the same defect. `build_args_and_setup` has two `json_object`
+/// branches -- one for an array-valued argument, one for a single object -- and BOTH had their
+/// own copy of the `$mock_url` short-circuit that dumped the value through `json_to_js_camel`
+/// before the typed builder could run. Fixing only the array branch would leave every consumer
+/// whose templated argument is a plain options object still emitting a bare wire string for a
+/// tagged-data enum field, with no test able to tell.
+#[test]
+fn node_mock_url_single_object_still_tags_nested_enum_field() {
+    let enums = [output_format_enum_def()];
+    let type_defs = [file_extraction_config_type_def(), extract_input_with_config_type_def()];
+    let fixture = fixture();
+    let input = serde_json::json!({
+        "request": { "uri": "$mock_url/pdf/fake.pdf", "config": { "output_format": "markdown" } }
+    });
+    let args = [ArgMapping {
+        name: "request".into(),
+        field: "input.request".into(),
+        arg_type: "json_object".into(),
+        optional: false,
+        owned: true,
+        element_type: None,
+        go_type: None,
+        vec_inner_is_ref: false,
+        trait_name: None,
+    }];
+    let config = crate::core::config::ResolvedCrateConfig::default();
+
+    let (setup_lines, _call_args) = build_args_and_setup(
+        &input,
+        &args,
+        Some("ExtractInput"),
+        &fixture,
+        &Default::default(),
+        "node",
+        &Default::default(),
+        &Default::default(),
+        None,
+        &type_defs,
+        &enums,
+        "",
+        &config,
+        true,
+        &mut Default::default(),
+        crate::e2e::codegen::call_ir::TargetParams::IrAbsent,
+        crate::e2e::codegen::call_ir::CallIr::default(),
+    );
+
+    let json_stringify_line = setup_lines
+        .iter()
+        .find(|line| line.contains("JSON.stringify"))
+        .expect("a $mock_url-templated object argument must build via JSON.stringify/replaceAll/JSON.parse");
+    assert!(
+        json_stringify_line.contains(r#"outputFormat: { type: "markdown" } as OutputFormat"#),
+        "tagged-data enum field lost its `type` discriminator in the mock_url-templated \
+         single-object path: {json_stringify_line}"
+    );
+    assert!(
+        !json_stringify_line.contains(r#"outputFormat: "markdown""#),
+        "regression: enum field rendered as a bare wire string instead of the tagged object \
+         the napi binding requires: {json_stringify_line}"
+    );
+}


### PR DESCRIPTION
`build_args_and_setup` has two `json_object` branches — one for an array-valued argument, one for a single object — and each carried its own `$mock_url` short-circuit that dumped the value through `json_to_js_camel` before the typed builder could run. A data-carrying enum field then rendered as its bare wire string (`outputFormat: "markdown"`) instead of the tagged object the napi binding requires (`{ type: "markdown" }`), failing at runtime with `Missing field 'type' on JsFileExtractionConfig.outputFormat`.

A `$mock_url` placeholder changes *how* a value reaches the runtime — it has to survive a `JSON.stringify` / `replaceAll` / `JSON.parse` round trip so a template string can be substituted in — but it must never change *what* that value is. Both branches now build the typed literal first and reuse it for either outcome, so the templated and non-templated paths can no longer disagree about an enum's wire shape.

Two tests, one per branch. Fixing only the array branch would leave every consumer whose templated argument is a plain options object still broken, with nothing able to tell — so the single-object case is covered explicitly rather than assumed symmetric.

Neutralisation, run before committing: with `args.rs` reverted to its `HEAD` content both tests fail; with the fix both pass; the restored file's sha256 matches the pre-neutralisation hash (`0b51f5df5339…`).

Likely an instance of #309, though I have not confirmed the two share a root cause — this one is specifically the two mock-url short-circuits, not the general nested-vs-top-level renderer gap.
