### PR TITLE
fix(swift): give Package.swift somewhere safe to carry its marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A generated `test_apps/swift_e2e/Package.swift` destroyed the provenance marker that
+  authorised its own overwrite, and was then frozen out of every later regeneration.** SwiftPM
+  requires `// swift-tools-version:` to be the literal first line, and the header writer had no
+  case for it -- putting the header above that line produces a manifest SwiftPM refuses to parse.
+  With nowhere safe to put a marker, the file was emitted `generated_header: false`. Each
+  regeneration then proved ownership from a marker some earlier out-of-band edit had left on
+  disk, authorised the write, and replaced that marker with a rendering carrying none, so the
+  next run found an unmarked file and refused to touch it forever. `ensure_generated_header` now
+  positions the header on the line *after* `// swift-tools-version:`, the same way it already
+  handles a shebang, `<?php` and an XML declaration, and the manifest is emitted with
+  `generated_header: true`. Observed in `html-to-markdown`, where the marker survived a
+  version-sync rewrite (which only edits the `branch:` pin) and then vanished on the next full
+  render -- two lines deleted, nothing added.
+
 ## [0.82.2] - 2026-09-03
 
 Patch release. Two entries are regressions shipped in 0.82.1 -- both generated crates that do not

--- a/src/cli/pipeline/generate/scaffold.rs
+++ b/src/cli/pipeline/generate/scaffold.rs
@@ -981,3 +981,115 @@ mod merge_managed_toml_tests {
         toml::from_str::<toml::Value>(&on_disk).expect("repaired poly.toml must still parse");
     }
 }
+
+/// Regression coverage for the self-sustaining `test_apps/swift_e2e/Package.swift` defect: a
+/// `Package.swift` emitted through this write path, across repeated `overwrite = true` runs
+/// (the shape `e2e generate` / `test-apps generate` always use), must keep carrying its
+/// provenance marker instead of having each run's freshly rendered, unmarked body silently
+/// replace whatever marker a prior run (or an out-of-band edit) had left in place.
+///
+/// Reproduces the exact incident: html-to-markdown's `test_apps/swift_e2e/Package.swift` carried
+/// a hand-added `alef:hash:` + prose header (`89628650fa`) that survived one version-sync-driven
+/// rewrite (`c2cc6931e6`, which only ever touches the `branch:` pin and never re-derives the
+/// header), then vanished -- 2 lines deleted, nothing added -- the next time `alef test-apps
+/// generate` re-rendered the file from its templates (`e940ccb1e3`), because that render path
+/// authorised the overwrite on the strength of the marker already on disk and then wrote content
+/// that never carried one. Once gone, `alef verify` reports the path as a create-once seed the
+/// write guard refuses forever -- see [`super::write::ensure_generated_header`]'s doc for the
+/// `swift-tools-version` positional case this closes. ~keep
+#[cfg(test)]
+mod swift_package_manifest_marker_tests {
+    use super::*;
+
+    const RENDERED_BODY: &str = "// swift-tools-version: 6.0\nimport PackageDescription\n\nlet package = Package(\n  \
+                                  name: \"E2eSwift\"\n)\n";
+
+    fn rendered_package_swift() -> GeneratedFile {
+        GeneratedFile {
+            path: "test_apps/swift_e2e/Package.swift".into(),
+            content: RENDERED_BODY.to_owned(),
+            generated_header: true,
+        }
+    }
+
+    /// A `Package.swift` already on disk with an out-of-band marker (the shape a hand-authored
+    /// `sync.text_replacements`-based workaround, or an earlier `alef adopt`, leaves behind)
+    /// converges to alef's own header on the first overwrite, and -- the actual regression --
+    /// keeps carrying a marker across every subsequent overwrite instead of losing it on the
+    /// first render that never itself added one.
+    #[test]
+    fn overwriting_a_marked_swift_package_manifest_preserves_its_marker_across_repeated_runs() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let base = temporary.path();
+        let relative = std::path::Path::new("test_apps/swift_e2e/Package.swift");
+        std::fs::create_dir_all(base.join("test_apps/swift_e2e")).expect("test_apps/swift_e2e directory");
+        std::fs::write(
+            base.join(relative),
+            "// swift-tools-version: 6.0\n\
+             // The first-party dependency pin below is managed by alef (sync.text_replacements); do not edit it \
+             by hand.\n\
+             // alef:hash:0000000000000000000000000000000000000000000000000000000000000000\n\
+             import PackageDescription\n\n\
+             let package = Package(\n  name: \"E2eSwift\"\n)\n",
+        )
+        .expect("seed a Package.swift carrying an out-of-band marker");
+
+        for run in 1..=3 {
+            let report =
+                write_scaffold_files_report(&[rendered_package_swift()], base, true).expect("overwrite must succeed");
+            assert_eq!(
+                report.refused_paths.len(),
+                0,
+                "run {run}: an already-marked Package.swift must never be refused, {:?}",
+                report.refused_paths
+            );
+            let on_disk = std::fs::read_to_string(base.join(relative)).expect("read Package.swift");
+            assert!(
+                on_disk.starts_with("// swift-tools-version: 6.0\n"),
+                "run {run}: swift-tools-version must stay the literal first line, got:\n{on_disk}"
+            );
+            assert!(
+                crate::core::hash::content_has_alef_marker(&on_disk),
+                "run {run}: THE REGRESSION -- Package.swift lost its provenance marker on an \
+                 authorised overwrite, which is exactly what re-freezes it out of every later \
+                 `alef generate`:\n{on_disk}"
+            );
+        }
+    }
+
+    /// The counterpart proving the assertion above is not vacuous: with `generated_header: false`
+    /// (this repository's state before the fix), the identical sequence loses the marker on the
+    /// very first overwrite -- the write guard still authorises the write (the pre-existing file
+    /// carries a marker), but nothing re-adds one to the content it writes.
+    #[test]
+    fn the_pre_fix_generated_header_false_shape_reproduces_the_marker_loss() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let base = temporary.path();
+        let relative = std::path::Path::new("test_apps/swift_e2e/Package.swift");
+        std::fs::create_dir_all(base.join("test_apps/swift_e2e")).expect("test_apps/swift_e2e directory");
+        std::fs::write(
+            base.join(relative),
+            "// swift-tools-version: 6.0\n\
+             // The first-party dependency pin below is managed by alef (sync.text_replacements); do not edit it \
+             by hand.\n\
+             // alef:hash:0000000000000000000000000000000000000000000000000000000000000000\n\
+             import PackageDescription\n\n\
+             let package = Package(\n  name: \"E2eSwift\"\n)\n",
+        )
+        .expect("seed a Package.swift carrying an out-of-band marker");
+
+        let unmarked_rendering = GeneratedFile {
+            generated_header: false,
+            ..rendered_package_swift()
+        };
+        write_scaffold_files_report(&[unmarked_rendering], base, true).expect("overwrite must succeed");
+
+        let on_disk = std::fs::read_to_string(base.join(relative)).expect("read Package.swift");
+        assert!(
+            !crate::core::hash::content_has_alef_marker(&on_disk),
+            "this test documents the historical defect and must start failing (proving it is \
+             fixed) only if `generated_header: false` itself stops losing the marker -- if it \
+             does, delete this test rather than the assertion:\n{on_disk}"
+        );
+    }
+}

--- a/src/cli/pipeline/generate/write.rs
+++ b/src/cli/pipeline/generate/write.rs
@@ -400,6 +400,18 @@ fn split_xml_declaration(content: &str) -> Option<(&str, &str)> {
     Some((declaration, body.strip_prefix('\n').unwrap_or(body)))
 }
 
+/// Prepend the standard alef header, positioned below any directive line a format requires
+/// to lead the file (a shebang, `<?php`, an XML declaration, or SwiftPM's
+/// `// swift-tools-version:` line).
+///
+/// The `swift-tools-version` case exists because SwiftPM requires that directive to be the
+/// literal first line of a `Package.swift` -- placing the header above it produces a manifest
+/// SwiftPM refuses to parse. Before this case existed, a `Package.swift` emitted with
+/// `generated_header: true` would never actually receive a header (any write that did would
+/// break the manifest), so the only paths that used this file's `//`-comment marker relied on a
+/// generator baking one into `content` by hand and set `generated_header: false` to avoid a
+/// second, misplaced one -- leaving the write guard's ownership check with nothing durable to
+/// find once that hand-baked header went stale or was regenerated away. ~keep
 pub(crate) fn ensure_generated_header(path: &Path, content: &str) -> String {
     if hash::content_has_alef_marker(content) {
         return content.to_owned();
@@ -420,6 +432,12 @@ pub(crate) fn ensure_generated_header(path: &Path, content: &str) -> String {
     }
     if let Some((declaration, body)) = split_xml_declaration(content) {
         return format!("{declaration}\n{header}\n{body}");
+    }
+    if let Some((tools_version, body)) = content
+        .split_once('\n')
+        .filter(|(line, _)| line.starts_with("// swift-tools-version:"))
+    {
+        return format!("{tools_version}\n{header}\n{body}");
     }
     format!("{header}\n{content}")
 }

--- a/src/cli/pipeline/generate/write/marker_syntax_tests.rs
+++ b/src/cli/pipeline/generate/write/marker_syntax_tests.rs
@@ -109,6 +109,45 @@ fn should_stamp_xml_whose_declaration_has_no_trailing_newline() {
     assert_read_side_agrees(&stamped, &hashed);
 }
 
+/// `// swift-tools-version:` must stay the literal first line of a `Package.swift` for
+/// SwiftPM to parse it -- the header goes on the line after it, exactly like the shebang
+/// and `<?php` cases above, never before it.
+///
+/// THE DEFECT this closes: before this case existed, a `Package.swift` had nowhere safe to
+/// carry a marker via this path, so `test_apps/swift_e2e/Package.swift` was emitted with
+/// `generated_header: false` and no self-marked header instead. Every regeneration overwrote
+/// it with the unmarked rendering; the write guard proved ownership from a marker a PRIOR,
+/// out-of-band edit had left in place, authorised the write, and the write then replaced
+/// that marker with nothing -- destroying the very evidence it had just relied on. The next
+/// run found no marker at all and refused to touch the file forever. See
+/// `ensure_generated_header`'s doc for the full history. ~keep
+#[test]
+fn should_stamp_swift_package_manifest_after_the_tools_version_line_never_before_it() {
+    let (stamped, hashed) = emit_and_stamp(
+        "test_apps/swift_e2e/Package.swift",
+        "// swift-tools-version: 6.0\nimport PackageDescription\n",
+    );
+    assert_eq!(
+        stamped,
+        format!("// swift-tools-version: 6.0\n{SLASH_HEADER}\nimport PackageDescription\n")
+    );
+    assert_read_side_agrees(&stamped, &hashed);
+}
+
+/// A previously-adopted `Package.swift` (this run's `content` has no marker, but the file on
+/// disk already carries one from an out-of-band edit or an earlier `alef adopt`) must not be
+/// re-stamped with a second header above the `swift-tools-version` line -- `ensure_generated_header`
+/// only ever sees the fresh `content`, so this exercises the read side `content_has_alef_marker`
+/// gates on instead.
+#[test]
+fn should_not_double_stamp_a_swift_package_manifest_that_already_carries_a_marker() {
+    let already = format!("// swift-tools-version: 6.0\n{SLASH_HEADER}\nimport PackageDescription\n");
+    assert_eq!(
+        ensure_generated_header(Path::new("test_apps/swift_e2e/Package.swift"), &already),
+        already
+    );
+}
+
 #[test]
 fn should_stamp_csproj_without_declaration_at_line_zero() {
     let (stamped, hashed) = emit_and_stamp(

--- a/src/e2e/codegen/swift.rs
+++ b/src/e2e/codegen/swift.rs
@@ -129,7 +129,16 @@ impl E2eCodegen for SwiftE2eCodegen {
                 has_http_fixtures,
                 package_swift_extras,
             ),
-            generated_header: false,
+            // `true`, unlike the root/package scaffold's `Package.swift` (which is a
+            // hand-grown, create-once seed): this manifest is fully re-rendered from
+            // config on every run, and `version_swift::sync_swift_package_versions`
+            // keeps its dependency pin current between full regenerations. Both need
+            // the write guard to recognise this file as alef-owned so it is neither
+            // frozen (no marker => refused forever) nor silently overwritten with an
+            // unmarked file that re-freezes itself on the next run -- see
+            // `write::ensure_generated_header`'s `swift-tools-version` case for how the
+            // header is kept off the mandatory first line.
+            generated_header: true,
         });
 
         // For registry mode, SwiftPM fetches the package directly from GitHub.


### PR DESCRIPTION
A file that destroys the evidence authorising its own overwrite, then locks itself out of every later run.

SwiftPM requires `// swift-tools-version:` to be the literal first line of a `Package.swift`; a header above it produces a manifest SwiftPM refuses to parse. `ensure_generated_header` had no case for that directive, so the e2e manifest was emitted with `generated_header: false` — no marker at all. The write guard then proved ownership from a marker some earlier out-of-band edit had left *on disk*, authorised the write, and wrote a rendering carrying none. The next run found an unmarked file and refused to touch it forever, reporting it as a create-once seed.

Observed in html-to-markdown: a hand-added header landed in `89628650fa`, survived `c2cc6931e6` (a version sync, which only rewrites the `branch:` pin and never re-derives the header), then vanished in `e940ccb1e3` — two lines deleted, nothing added — the first time `alef test-apps generate` re-rendered the file from its templates.

The header now goes on the line *after* the tools-version directive, exactly as it already does for a shebang, `<?php` and an XML declaration, and the manifest is emitted `generated_header: true`.

Four tests. Two on the header writer: correct positioning, and no double-stamp when the content already carries a marker. Two on the write path: a marked manifest survives three consecutive `overwrite = true` runs still carrying a marker, and — the control — the same sequence with `generated_header: false` loses it on the very first run. That second test documents the historical defect and is written to start failing if `generated_header: false` ever stops losing the marker, with an instruction to delete the test rather than weaken the assertion.

Expected consumer diff: `test_apps/swift_e2e/Package.swift` gains a header line on the next regeneration in every repo with a swift e2e target. That is additive and intended; it will be visible in the 0.82.3 adoption diffs.
