### PR TITLE
fix(python): resolve from_json against the exported class, not the native one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The python e2e generator emitted `Type.from_json(...)` for types whose public name resolves
+  to `options.py`'s method-less dataclass, not the native `#[pyclass]`.** The eligibility check
+  asked pyo3's Rust-codegen gate whether the *native* class carries `from_json` -- a true answer
+  that says nothing about which class the package actually exports under that name. When a type
+  is options-wrapped, `__init__.py` imports it from `.options`, and `gen_options_py` never emits
+  a method on any dataclass it writes, so `from_json` is unreachable through the public name
+  however the native class underneath is generated. The check now consults the pyo3 backend's own
+  export decision (`options_dataclass_type_names` ∪ `options_return_dataclass_names`) before
+  trusting the native gate, rather than re-deriving a third, independently-drifting copy of it,
+  and falls back to the kwargs constructor every generated DTO exposes. `reexported_types`
+  remains the per-type escape hatch that keeps a type native.
+
 ## [0.82.2] - 2026-09-03
 
 Patch release. Two entries are regressions shipped in 0.82.1 -- both generated crates that do not

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -22,10 +22,15 @@ mod support_items;
 #[cfg(test)]
 mod tests;
 pub mod types;
-pub(in crate::backends::pyo3) use types::{options_dataclass_type_names, type_has_from_json};
-// pub(crate): e2e::codegen::python calls this to mirror the pyo3 backend's crate-level serde
-// detection when computing the shared from_json eligibility predicate. ~keep
-pub(crate) use types::{crate_has_serde, python_visible_field_name};
+pub(in crate::backends::pyo3) use types::type_has_from_json;
+// pub(crate): e2e::codegen::python calls `crate_has_serde` to mirror the pyo3 backend's
+// crate-level serde detection, and `options_dataclass_type_names`/`options_return_dataclass_names`
+// to know which type names `__init__.py` exports as the method-less `options.py` dataclass rather
+// than the native `#[pyclass]` -- required before trusting the from_json eligibility predicate,
+// which only knows what the native class carries, not which class the public name resolves to. ~keep
+pub(crate) use types::{
+    crate_has_serde, options_dataclass_type_names, options_return_dataclass_names, python_visible_field_name,
+};
 pub(in crate::backends::pyo3) mod wire_schema;
 
 use crate::backends::pyo3::type_map::Pyo3Mapper;

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -39,7 +39,13 @@ fn to_python_enum_variant(name: &str) -> String {
 /// re-exported as a native pyclass. This is the public *input* type family — the
 /// trait-callback marshalling and the Protocol stubs use the same set so the type
 /// a host is handed is the type the package exports under that name.
-pub(in crate::backends::pyo3) fn options_dataclass_type_names(
+///
+/// `pub(crate)`: `e2e::codegen::python` calls this (alongside [`options_return_dataclass_names`])
+/// to know when a type's public spelling is this method-less dataclass rather than the native
+/// `#[pyclass]`, before trusting [`crate::codegen::conversions::pyo3_from_json_eligible`]'s
+/// verdict that the native class carries `from_json` -- that verdict says nothing about which
+/// class the public name actually resolves to. ~keep
+pub(crate) fn options_dataclass_type_names(
     api: &ApiSurface,
     reexported_types: &[String],
 ) -> std::collections::HashSet<String> {
@@ -70,8 +76,11 @@ pub(in crate::backends::pyo3) fn options_dataclass_type_names(
 /// exactly the same types (this function's own logic is unchanged, and still honors
 /// `reexported_types` as the per-type escape hatch to keep a specific return type native even
 /// under that style -- xberg-io/alef#134), but every selected type now renders as `@dataclass`
-/// like every other type `options.py` defines. See [`gen_options_py`]'s doc for why. ~keep
-pub(in crate::backends::pyo3) fn options_return_dataclass_names(
+/// like every other type `options.py` defines. See [`gen_options_py`]'s doc for why.
+///
+/// `pub(crate)`: see [`options_dataclass_type_names`]'s visibility note -- the two together are
+/// the complete set of names `e2e::codegen::python` must treat as method-less. ~keep
+pub(crate) fn options_return_dataclass_names(
     api: &ApiSurface,
     dto: &DtoConfig,
     reexported_types: &[String],

--- a/src/e2e/codegen/python/enum_field_classification_tests.rs
+++ b/src/e2e/codegen/python/enum_field_classification_tests.rs
@@ -137,6 +137,7 @@ fn render(
     let handle_nested_types = std::collections::HashMap::new();
     let handle_dict_types = std::collections::HashSet::new();
     let convertible_types = ahash::AHashSet::new();
+    let options_wrapped_types = std::collections::HashSet::new();
     let context = RenderTestFunctionContext {
         e2e_config,
         config: &config,
@@ -152,6 +153,7 @@ fn render(
         force_bind_result: false,
         convertible_types: &convertible_types,
         crate_has_serde: false,
+        options_wrapped_types: &options_wrapped_types,
     };
     render_test_function(&mut out, fixture, context);
     out

--- a/src/e2e/codegen/python/helpers.rs
+++ b/src/e2e/codegen/python/helpers.rs
@@ -90,7 +90,10 @@ pub(super) fn core_to_binding_convertible_types(
 /// `093c42f31`, `type_has_from_json` is the single predicate shared by both the raw-text
 /// `#[pymethods]` injection and the `.pyi` stub generator, so passing this gate also means the
 /// shipped stub declares the method — verified against a consumer's `CreateImageRequest`, where
-/// `_internal_bindings.pyi` carries `def from_json`. ~keep
+/// `_internal_bindings.pyi` carries `def from_json`.
+///
+/// This says only what the *native* `#[pyclass]` carries. It says nothing about which class a
+/// type's public name actually resolves to — see [`options_wrapped_type_names`]. ~keep
 pub(super) fn pyo3_would_inject_from_json(
     name: &str,
     type_defs: &[crate::core::ir::TypeDef],
@@ -103,25 +106,73 @@ pub(super) fn pyo3_would_inject_from_json(
         .is_some_and(|t| crate::codegen::conversions::pyo3_from_json_eligible(t, crate_has_serde, convertible_types))
 }
 
-/// Downgrade `options_via` from `"from_json"` to `"kwargs"` unless the target type actually
-/// passes pyo3's Rust-codegen gate ([`pyo3_would_inject_from_json`]) — the gate that also
-/// controls whether the `.pyi` stub declares the method, so passing it guarantees the emitted
-/// call type-checks against the shipped stub. Every generated DTO still exposes a plain kwargs
-/// constructor, so falling back there keeps the emitted call valid for types that don't clear
-/// the gate. ~keep
+/// Names of the types whose public Python spelling is `options.py`'s `@dataclass` mirror rather
+/// than the native `#[pyclass]` — the exact union `__init__.py`/`api.py` import from `.options`
+/// (`options_dataclass_type_names` ∪ `options_return_dataclass_names`,
+/// `src/backends/pyo3/gen_bindings/types.rs`). `gen_options_py` never emits a method on any
+/// dataclass it writes (see that function's doc comment): a type in this set exposes `from_json`
+/// -- or any other native-only method -- through its public name only by accident of a caller
+/// never checking, regardless of whether pyo3 injected `from_json` on the native class
+/// underneath. Built from a synthetic `ApiSurface` over the same `type_defs`/`enums` slices
+/// already threaded through e2e codegen, mirroring [`core_to_binding_convertible_types`] above,
+/// so this reads the pyo3 backend's actual export decision instead of re-deriving a third,
+/// independently-drifting copy of it. ~keep
+pub(super) fn options_wrapped_type_names(
+    type_defs: &[crate::core::ir::TypeDef],
+    enums: &[crate::core::ir::EnumDef],
+    dto: &crate::core::config::DtoConfig,
+    reexported_types: &[String],
+) -> HashSet<String> {
+    let surface = crate::core::ir::ApiSurface {
+        types: type_defs.to_vec(),
+        enums: enums.to_vec(),
+        ..Default::default()
+    };
+    let mut names = crate::backends::pyo3::gen_bindings::options_dataclass_type_names(&surface, reexported_types);
+    names.extend(crate::backends::pyo3::gen_bindings::options_return_dataclass_names(
+        &surface,
+        dto,
+        reexported_types,
+    ));
+    names
+}
+
+/// Downgrade `options_via` from `"from_json"` to `"kwargs"` unless the target type's *public*
+/// name actually resolves to a class carrying `from_json`. Two independent conditions must both
+/// hold:
+///
+/// 1. The name is not in [`options_wrapped_type_names`] -- otherwise `__init__.py` exports it
+///    from `.options`, a plain dataclass with no methods at all, and `from_json` is unreachable
+///    through the public name no matter what the native class underneath carries.
+/// 2. Failing that (or when there's no wrapper for the type at all), the native class itself must
+///    pass pyo3's Rust-codegen gate ([`pyo3_would_inject_from_json`]) -- the gate that also
+///    controls whether the `.pyi` stub declares the method, so passing it guarantees the emitted
+///    call type-checks against the shipped stub.
+///
+/// Every generated DTO still exposes a plain kwargs constructor, so falling back there keeps the
+/// emitted call valid for types that clear neither condition. ~keep
 pub(super) fn effective_options_via_for_type<'a>(
     options_via: &'a str,
     options_type: Option<&str>,
     type_defs: &[crate::core::ir::TypeDef],
     convertible_types: &ahash::AHashSet<String>,
     crate_has_serde: bool,
+    options_wrapped_types: &HashSet<String>,
 ) -> &'a str {
     if options_via != "from_json" {
         return options_via;
     }
-    let is_declared = options_type
-        .is_some_and(|name| pyo3_would_inject_from_json(name, type_defs, convertible_types, crate_has_serde));
-    if is_declared { options_via } else { "kwargs" }
+    let Some(name) = options_type else {
+        return "kwargs";
+    };
+    if options_wrapped_types.contains(name) {
+        return "kwargs";
+    }
+    if pyo3_would_inject_from_json(name, type_defs, convertible_types, crate_has_serde) {
+        options_via
+    } else {
+        "kwargs"
+    }
 }
 
 /// Resolve enum field mappings from the Python override config.
@@ -435,7 +486,14 @@ mod tests {
         ));
 
         assert_eq!(
-            effective_options_via_for_type("from_json", Some("WidgetRequest"), &type_defs, &convertible, true),
+            effective_options_via_for_type(
+                "from_json",
+                Some("WidgetRequest"),
+                &type_defs,
+                &convertible,
+                true,
+                &HashSet::new()
+            ),
             "from_json"
         );
     }
@@ -450,7 +508,14 @@ mod tests {
         let convertible = core_to_binding_convertible_types(&type_defs, &[]);
 
         assert_eq!(
-            effective_options_via_for_type("from_json", Some("WidgetRequest"), &type_defs, &convertible, true),
+            effective_options_via_for_type(
+                "from_json",
+                Some("WidgetRequest"),
+                &type_defs,
+                &convertible,
+                true,
+                &HashSet::new()
+            ),
             "kwargs"
         );
     }
@@ -465,7 +530,14 @@ mod tests {
         let convertible = core_to_binding_convertible_types(&type_defs, &[]);
 
         assert_eq!(
-            effective_options_via_for_type("from_json", Some("WidgetRequest"), &type_defs, &convertible, false),
+            effective_options_via_for_type(
+                "from_json",
+                Some("WidgetRequest"),
+                &type_defs,
+                &convertible,
+                false,
+                &HashSet::new()
+            ),
             "kwargs"
         );
     }
@@ -474,7 +546,14 @@ mod tests {
     fn effective_options_via_for_type_downgrades_to_kwargs_when_type_is_unknown() {
         let convertible = core_to_binding_convertible_types(&[], &[]);
         assert_eq!(
-            effective_options_via_for_type("from_json", Some("WidgetRequest"), &[], &convertible, true),
+            effective_options_via_for_type(
+                "from_json",
+                Some("WidgetRequest"),
+                &[],
+                &convertible,
+                true,
+                &HashSet::new()
+            ),
             "kwargs"
         );
     }
@@ -483,12 +562,87 @@ mod tests {
     fn effective_options_via_for_type_leaves_non_from_json_values_untouched() {
         let convertible = core_to_binding_convertible_types(&[], &[]);
         assert_eq!(
-            effective_options_via_for_type("dict", None, &[], &convertible, true),
+            effective_options_via_for_type("dict", None, &[], &convertible, true, &HashSet::new()),
             "dict"
         );
         assert_eq!(
-            effective_options_via_for_type("kwargs", None, &[], &convertible, true),
+            effective_options_via_for_type("kwargs", None, &[], &convertible, true, &HashSet::new()),
             "kwargs"
+        );
+    }
+
+    /// The exact xberg `ExtractInput` defect: a type is both native-`from_json`-eligible (serde
+    /// derive, crate has serde, convertible) AND options-wrapped (`has_default`, not a return
+    /// type, not reexported) -- e.g. any config/input DTO with a hand-written constructor like
+    /// `from_bytes`/`from_uri` alongside pyo3's mechanically-injected `from_json`. `__init__.py`
+    /// exports the wrapped name from `.options`, a plain dataclass with zero methods, so
+    /// `from_json` must downgrade to `kwargs` even though the native gate alone says "keep it".
+    #[test]
+    fn effective_options_via_for_type_downgrades_to_kwargs_when_type_is_options_wrapped() {
+        let type_defs = vec![crate::core::ir::TypeDef {
+            name: "ExtractInput".to_string(),
+            has_serde: true,
+            has_default: true,
+            ..Default::default()
+        }];
+        let convertible = core_to_binding_convertible_types(&type_defs, &[]);
+        assert!(
+            pyo3_would_inject_from_json("ExtractInput", &type_defs, &convertible, true),
+            "test setup: the native class must still pass pyo3's own gate"
+        );
+
+        let dto = crate::core::config::DtoConfig::default();
+        let options_wrapped = options_wrapped_type_names(&type_defs, &[], &dto, &[]);
+        assert!(
+            options_wrapped.contains("ExtractInput"),
+            "test setup: a has_default, non-return, non-reexported type must be options-wrapped"
+        );
+
+        assert_eq!(
+            effective_options_via_for_type(
+                "from_json",
+                Some("ExtractInput"),
+                &type_defs,
+                &convertible,
+                true,
+                &options_wrapped
+            ),
+            "kwargs",
+            "the public name resolves to options.py's method-less dataclass, not the native class"
+        );
+    }
+
+    /// Symmetric case: `reexported_types` is the documented per-type escape hatch
+    /// (`xberg-io/alef#134`) that keeps a type native despite otherwise qualifying for the
+    /// `options.py` wrapper. A reexported type's public name IS the native class, so `from_json`
+    /// must be kept when the native gate says so.
+    #[test]
+    fn effective_options_via_for_type_keeps_from_json_when_type_is_reexported() {
+        let type_defs = vec![crate::core::ir::TypeDef {
+            name: "ExtractionResult".to_string(),
+            has_serde: true,
+            has_default: true,
+            ..Default::default()
+        }];
+        let convertible = core_to_binding_convertible_types(&type_defs, &[]);
+        let dto = crate::core::config::DtoConfig::default();
+        let reexported = vec!["ExtractionResult".to_string()];
+        let options_wrapped = options_wrapped_type_names(&type_defs, &[], &dto, &reexported);
+        assert!(
+            !options_wrapped.contains("ExtractionResult"),
+            "test setup: reexported_types must exclude the type from the options.py wrapper set"
+        );
+
+        assert_eq!(
+            effective_options_via_for_type(
+                "from_json",
+                Some("ExtractionResult"),
+                &type_defs,
+                &convertible,
+                true,
+                &options_wrapped
+            ),
+            "from_json"
         );
     }
 

--- a/src/e2e/codegen/python/test_file.rs
+++ b/src/e2e/codegen/python/test_file.rs
@@ -109,17 +109,25 @@ pub(super) fn render_test_file(
     };
     // Only honor "from_json" when the pyo3 backend actually injects a from_json() staticmethod
     // for this type (gated on per-type has_serde AND crate-level serde availability AND
-    // core→binding convertibility) — every DTO still has a plain kwargs constructor, so
+    // core→binding convertibility) AND the type's public name isn't shadowed by options.py's
+    // method-less dataclass mirror — every DTO still has a plain kwargs constructor, so
     // downgrading keeps the emitted call and its import valid. Computed once per file/snippet
     // render; `type_defs`/`enums`/`config` don't change across fixtures in the same category. ~keep
     let convertible_types = helpers::core_to_binding_convertible_types(type_defs, enums);
     let crate_has_serde = crate::backends::pyo3::gen_bindings::crate_has_serde(config);
+    let reexported_types = config
+        .python
+        .as_ref()
+        .map(|c| c.reexported_types.clone())
+        .unwrap_or_default();
+    let options_wrapped_types = helpers::options_wrapped_type_names(type_defs, enums, &config.dto, &reexported_types);
     let effective_options_via = helpers::effective_options_via_for_type(
         effective_options_via,
         effective_options_type.as_deref(),
         type_defs,
         &convertible_types,
         crate_has_serde,
+        &options_wrapped_types,
     );
 
     let enum_fields = resolve_enum_fields(e2e_config);
@@ -394,6 +402,7 @@ pub(super) fn render_test_file(
             type_defs,
             convertible_types: &convertible_types,
             crate_has_serde,
+            options_wrapped_types: &options_wrapped_types,
         };
         build_thirdparty_imports(thirdparty_import_context, &mut thirdparty_from);
     }
@@ -421,6 +430,7 @@ pub(super) fn render_test_file(
                 force_bind_result,
                 convertible_types: &convertible_types,
                 crate_has_serde,
+                options_wrapped_types: &options_wrapped_types,
             };
             render_test_function(&mut fixtures_body, fixture, render_test_function_context);
         }
@@ -545,6 +555,7 @@ struct ThirdpartyImportContext<'a> {
     type_defs: &'a [crate::core::ir::TypeDef],
     convertible_types: &'a ahash::AHashSet<String>,
     crate_has_serde: bool,
+    options_wrapped_types: &'a std::collections::HashSet<String>,
 }
 
 fn build_thirdparty_imports(context: ThirdpartyImportContext<'_>, thirdparty_from: &mut Vec<String>) {
@@ -567,6 +578,7 @@ fn build_thirdparty_imports(context: ThirdpartyImportContext<'_>, thirdparty_fro
         type_defs,
         convertible_types,
         crate_has_serde,
+        options_wrapped_types,
     } = context;
 
     let handle_constructors: Vec<String> = e2e_config
@@ -752,6 +764,7 @@ fn build_thirdparty_imports(context: ThirdpartyImportContext<'_>, thirdparty_fro
                 type_defs,
                 convertible_types,
                 crate_has_serde,
+                options_wrapped_types,
             ) == "from_json"
         {
             let native_module = python_override.from_json_module.as_deref().unwrap_or(module);
@@ -875,6 +888,7 @@ mod tests {
             type_defs: &[],
             convertible_types: &ahash::AHashSet::new(),
             crate_has_serde: false,
+            options_wrapped_types: &std::collections::HashSet::new(),
         };
         build_thirdparty_imports(thirdparty_import_context, &mut thirdparty_from);
 

--- a/src/e2e/codegen/python/test_function.rs
+++ b/src/e2e/codegen/python/test_function.rs
@@ -49,6 +49,7 @@ pub(super) struct RenderTestFunctionContext<'a> {
     pub force_bind_result: bool,
     pub convertible_types: &'a ahash::AHashSet<String>,
     pub crate_has_serde: bool,
+    pub options_wrapped_types: &'a HashSet<String>,
 }
 
 /// Render a pytest test function for a non-HTTP fixture.
@@ -68,6 +69,7 @@ pub(super) fn render_test_function(out: &mut String, fixture: &Fixture, context:
         force_bind_result,
         convertible_types,
         crate_has_serde,
+        options_wrapped_types,
     } = context;
 
     let fn_name = sanitize_ident(&fixture.id);
@@ -147,14 +149,16 @@ pub(super) fn render_test_function(out: &mut String, fixture: &Fixture, context:
         .unwrap_or(options_via);
     // Only honor "from_json" when the pyo3 backend actually injects a from_json()
     // staticmethod for this type (gated on per-type has_serde AND crate-level serde
-    // availability AND core→binding convertibility) — every DTO still has a plain kwargs
-    // constructor, so downgrading keeps the emitted call valid. ~keep
+    // availability AND core→binding convertibility) AND the type's public name isn't
+    // shadowed by options.py's method-less dataclass mirror — every DTO still has a plain
+    // kwargs constructor, so downgrading keeps the emitted call valid. ~keep
     let effective_options_via = helpers::effective_options_via_for_type(
         effective_options_via,
         effective_options_type,
         type_defs,
         convertible_types,
         crate_has_serde,
+        options_wrapped_types,
     );
 
     let desc_with_period = if description.ends_with('.') {
@@ -483,6 +487,7 @@ mod tests {
             force_bind_result: false,
             convertible_types: &ahash::AHashSet::new(),
             crate_has_serde: false,
+            options_wrapped_types: &HashSet::new(),
         };
         render_test_function(&mut out, &fixture, context);
         assert!(out.contains("pytest.mark.skip"), "got: {out}");


### PR DESCRIPTION
xberg's python e2e leg fails with `module 'xberg' has no attribute ...` / an unresolvable `ExtractInput.from_json(...)`. Three generated artifacts disagreed about whether that method exists.

The eligibility check asked pyo3's Rust-codegen gate whether the *native* `#[pyclass]` carries `from_json`. That answer is true and irrelevant: when a type is options-wrapped, `__init__.py` exports the name from `.options`, and `gen_options_py` never emits a method on any dataclass it writes. So the public name resolves to a class with no methods at all, however the native class underneath is generated. The gate was answering a different question than the one being asked — which is why every unit test on both sides passed.

The check now consults the pyo3 backend's own export decision (`options_dataclass_type_names` ∪ `options_return_dataclass_names`) before trusting the native gate, rather than re-deriving a third copy of that decision that would drift independently. `reexported_types` remains the documented per-type escape hatch that keeps a type native, and is covered by its own test. Types clearing neither condition fall back to the kwargs constructor every generated DTO exposes.

446 python codegen tests pass. Neutralisation, run before committing: removing the `options_wrapped_types` early return makes `effective_options_via_for_type_downgrades_to_kwargs_when_type_is_options_wrapped` fail; restoring it passes, and the restored file's sha256 matches the pre-neutralisation hash. The new test asserts its own setup first — that the native gate *does* say "keep it" for this type — so it cannot pass for the trivial reason that the type was never eligible.
