### PR TITLE
fix(csharp): propagate fallible void status errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve the native int32 status for C# bindings of fallible void functions and methods, and propagate failures
+  from synchronous, asynchronous, and trait-bridge wrappers without changing their public void or Task return types.
+
 ## [0.85.10] - 2026-09-09
 
 Combined release. Carries the enterprise consumer-correction work, the R/Ruby, adopted-marker and

--- a/src/backends/csharp/gen_bindings/methods.rs
+++ b/src/backends/csharp/gen_bindings/methods.rs
@@ -7,3 +7,6 @@ mod native_call;
 mod wrappers;
 
 pub(super) use class::gen_wrapper_class;
+
+#[cfg(test)]
+mod fallible_void_tests;

--- a/src/backends/csharp/gen_bindings/methods/bridge_fields.rs
+++ b/src/backends/csharp/gen_bindings/methods/bridge_fields.rs
@@ -141,7 +141,7 @@ pub(super) fn gen_bridge_field_wrapper_function(
         minijinja::context! { options_pascal, field_name_pascal, options_param_camel },
     ));
 
-    if func.return_type != TypeRef::Unit {
+    if func.return_type != TypeRef::Unit || func.error_type.is_some() {
         out.push_str("                    var nativeResult = ");
     } else {
         out.push_str("                    ");
@@ -175,6 +175,13 @@ pub(super) fn gen_bridge_field_wrapper_function(
     }
     out.push_str(");\n");
 
+    if func.return_type == TypeRef::Unit && func.error_type.is_some() {
+        out.push_str(&render(
+            "status_error_throw.jinja",
+            minijinja::context! { indent => "                    " },
+        ));
+    }
+
     if func.return_type != TypeRef::Unit {
         let zero = zero_sentinel(&func.return_type);
         out.push_str(&format!(
@@ -203,7 +210,7 @@ pub(super) fn gen_bridge_field_wrapper_function(
     out.push_str("            else\n");
     out.push_str("            {\n");
 
-    if func.return_type != TypeRef::Unit {
+    if func.return_type != TypeRef::Unit || func.error_type.is_some() {
         out.push_str("                var nativeResult = ");
     } else {
         out.push_str("                ");
@@ -223,6 +230,13 @@ pub(super) fn gen_bridge_field_wrapper_function(
         out.push_str(arg);
     }
     out.push_str(");\n");
+
+    if func.return_type == TypeRef::Unit && func.error_type.is_some() {
+        out.push_str(&render(
+            "status_error_throw.jinja",
+            minijinja::context! { indent => "                " },
+        ));
+    }
 
     if func.return_type != TypeRef::Unit {
         let zero = zero_sentinel(&func.return_type);

--- a/src/backends/csharp/gen_bindings/methods/fallible_void_tests.rs
+++ b/src/backends/csharp/gen_bindings/methods/fallible_void_tests.rs
@@ -1,0 +1,171 @@
+//! Fallible unit returns keep a public void API but carry an int32 native status.
+
+use super::wrappers::{gen_wrapper_function, gen_wrapper_method};
+use crate::backends::csharp::gen_bindings::pinvoke::{gen_pinvoke_for_func, gen_pinvoke_for_method};
+use crate::core::ir::{FunctionDef, MethodDef, ReceiverKind, TypeRef};
+use std::collections::{HashMap, HashSet};
+
+fn function(fallible: bool, asynchronous: bool) -> FunctionDef {
+    FunctionDef {
+        name: "validate".into(),
+        rust_path: "sample_core::validate".into(),
+        return_type: TypeRef::Unit,
+        error_type: fallible.then(|| "SampleError".into()),
+        is_async: asynchronous,
+        ..Default::default()
+    }
+}
+
+fn method(fallible: bool, asynchronous: bool, instance: bool) -> MethodDef {
+    MethodDef {
+        name: "validate".into(),
+        return_type: TypeRef::Unit,
+        error_type: fallible.then(|| "SampleError".into()),
+        is_async: asynchronous,
+        is_static: !instance,
+        receiver: instance.then_some(ReceiverKind::Ref),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn fallible_void_pinvoke_preserves_status_for_functions_and_methods() {
+    for fallible in [false, true] {
+        let expected = if fallible { "int" } else { "void" };
+        let declarations = [
+            gen_pinvoke_for_func(
+                "sample_validate",
+                &function(fallible, false),
+                &HashSet::new(),
+                &HashSet::new(),
+                &HashMap::new(),
+                &Default::default(),
+            ),
+            gen_pinvoke_for_method(
+                "sample_settings_validate",
+                "Validate",
+                &method(fallible, false, true),
+                &HashMap::new(),
+                &Default::default(),
+            ),
+            gen_pinvoke_for_method(
+                "sample_settings_validate",
+                "Validate",
+                &method(fallible, false, false),
+                &HashMap::new(),
+                &Default::default(),
+            ),
+        ];
+        for declaration in declarations {
+            assert!(
+                declaration.contains(&format!("extern {expected} Validate(")),
+                "{declaration}"
+            );
+        }
+    }
+}
+
+fn wrap_function(fallible: bool, asynchronous: bool) -> String {
+    let empty = HashSet::new();
+    gen_wrapper_function(
+        &function(fallible, asynchronous),
+        "SampleException",
+        "sample",
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        false,
+        &[],
+    )
+}
+
+fn wrap_method(fallible: bool, asynchronous: bool, instance: bool) -> String {
+    let empty = HashSet::new();
+    gen_wrapper_method(
+        &method(fallible, asynchronous, instance),
+        "SampleException",
+        "sample",
+        "Settings",
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        &empty,
+        &[],
+    )
+}
+
+#[test]
+fn fallible_void_wrappers_check_status_without_changing_public_return_type() {
+    for asynchronous in [false, true] {
+        for fallible in [false, true] {
+            for code in [
+                wrap_function(fallible, asynchronous),
+                wrap_method(fallible, asynchronous, true),
+                wrap_method(fallible, asynchronous, false),
+            ] {
+                let public_return = if asynchronous {
+                    "public static async Task "
+                } else {
+                    "public static void "
+                };
+                assert!(code.contains(public_return), "{code}");
+                assert_eq!(code.contains("var nativeResult = NativeMethods."), fallible, "{code}");
+                assert_eq!(code.contains("if (nativeResult != 0)"), fallible, "{code}");
+                assert_eq!(code.contains("throw GetLastError();"), fallible, "{code}");
+            }
+        }
+    }
+}
+
+fn wrap_bridge_function(fallible: bool) -> String {
+    use crate::codegen::generators::trait_bridge::BridgeFieldMatch;
+    use crate::core::config::TraitBridgeConfig;
+    use crate::core::ir::{FieldDef, ParamDef};
+    let bridge = TraitBridgeConfig {
+        trait_name: "Visitor".into(),
+        ..Default::default()
+    };
+    let field = FieldDef {
+        name: "visitor".into(),
+        ..Default::default()
+    };
+    let matched = BridgeFieldMatch {
+        param_index: 0,
+        param_name: "options".into(),
+        options_type: "Options".into(),
+        param_is_optional: false,
+        field_name: "visitor".into(),
+        field: &field,
+        bridge: &bridge,
+    };
+    let empty = HashSet::new();
+    let mut func = function(fallible, false);
+    func.params.push(ParamDef {
+        name: "options".into(),
+        ty: TypeRef::Named("Options".into()),
+        ..Default::default()
+    });
+    super::bridge_fields::gen_bridge_field_wrapper_function(&func, &matched, "SampleException", &empty, &empty, &empty)
+}
+
+#[test]
+fn fallible_void_bridge_wrappers_check_both_native_call_paths() {
+    for fallible in [false, true] {
+        let code = wrap_bridge_function(fallible);
+        assert_eq!(
+            code.matches("var nativeResult = NativeMethods.Validate(").count(),
+            if fallible { 2 } else { 0 },
+            "{code}"
+        );
+        assert_eq!(
+            code.matches("if (nativeResult != 0)").count(),
+            if fallible { 2 } else { 0 },
+            "{code}"
+        );
+    }
+}

--- a/src/backends/csharp/gen_bindings/methods/native_call.rs
+++ b/src/backends/csharp/gen_bindings/methods/native_call.rs
@@ -54,7 +54,7 @@ impl NativeCall<'_> {
         }
 
         out.push_str(self.call_indent);
-        if *self.return_type != TypeRef::Unit {
+        if *self.return_type != TypeRef::Unit || self.has_error_type {
             out.push_str("var nativeResult = ");
         }
         out.push_str(
@@ -105,6 +105,12 @@ impl NativeCall<'_> {
 
     fn emit_result_check(&self, out: &mut String) {
         if *self.return_type == TypeRef::Unit {
+            if self.has_error_type {
+                out.push_str(&render(
+                    "status_error_throw.jinja",
+                    minijinja::context! { indent => self.call_indent },
+                ));
+            }
             return;
         }
         if returns_ptr(self.return_type) {

--- a/src/backends/csharp/gen_bindings/pinvoke.rs
+++ b/src/backends/csharp/gen_bindings/pinvoke.rs
@@ -107,7 +107,7 @@ pub(super) fn gen_pinvoke_for_func(
 ) -> String {
     let cs_name = to_csharp_name(&func.name);
     let is_bytes_result = is_bytes_result_func(func);
-    let return_type = if is_bytes_result {
+    let return_type = if is_bytes_result || (func.return_type == TypeRef::Unit && func.error_type.is_some()) {
         "int"
     } else {
         pinvoke_return_type_with_capsules(&func.return_type, capsule_types, FfiEmitter::FreeFunction)
@@ -139,7 +139,7 @@ pub(super) fn gen_pinvoke_for_method(
     scalar_named_types: &ahash::AHashSet<String>,
 ) -> String {
     let is_bytes_result = is_bytes_result_method(method);
-    let return_type = if is_bytes_result {
+    let return_type = if is_bytes_result || (method.return_type == TypeRef::Unit && method.error_type.is_some()) {
         "int"
     } else {
         pinvoke_return_type_with_capsules(&method.return_type, capsule_types, FfiEmitter::Method)

--- a/src/backends/csharp/template_env.rs
+++ b/src/backends/csharp/template_env.rs
@@ -2,6 +2,10 @@ use minijinja::Environment;
 
 static TEMPLATES: &[(&str, &str)] = &[
     (
+        "status_error_throw.jinja",
+        include_str!("templates/status_error_throw.jinja"),
+    ),
+    (
         "async_task_return_type.jinja",
         include_str!("templates/async_task_return_type.jinja"),
     ),

--- a/src/backends/csharp/templates/status_error_throw.jinja
+++ b/src/backends/csharp/templates/status_error_throw.jinja
@@ -1,0 +1,4 @@
+{{ indent }}if (nativeResult != 0)
+{{ indent }}{
+{{ indent }}    throw GetLastError();
+{{ indent }}}


### PR DESCRIPTION
Preserve the native int32 status for C# bindings of `Result<()>` and propagate failures through function, method, async, and trait-bridge wrappers while preserving public `void`/`Task` signatures. Fixes #354.

Verified three red-to-green regressions, 168 C# unit tests, 48 integration tests, and real native-library probes in tree-sitter-language-pack and liter-llm; full Poly lint and formatting checks pass.
