### PR TITLE
fix(csharp): preserve native codes in typed exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve native numeric error codes in C# typed exceptions and base-error fallbacks without changing existing
+  public constructors (#362).
 - Preserve the native int32 status for C# bindings of fallible void functions and methods, and propagate failures
   from synchronous, asynchronous, and trait-bridge wrappers without changing their public void or Task return types.
 

--- a/src/backends/csharp/gen_bindings/errors.rs
+++ b/src/backends/csharp/gen_bindings/errors.rs
@@ -63,7 +63,7 @@ pub(super) fn compute_variant_dispatch(errors: &[ErrorDef]) -> (bool, String, Ve
         .into_iter()
         .map(|(class, prefix)| {
             let escaped_prefix = prefix.replace('\\', "\\\\").replace('"', "\\\"");
-            format!("        if (message.StartsWith(\"{escaped_prefix}\")) return new {class}(message);")
+            format!("        if (message.StartsWith(\"{escaped_prefix}\")) return WithNativeCode(new {class}(message), code);")
         })
         .collect();
 
@@ -377,9 +377,9 @@ mod tests {
         assert_eq!(
             dispatch_lines,
             vec![
-                "        if (message.StartsWith(\"Authentication failed:\")) return new AuthenticationException(message);"
+                "        if (message.StartsWith(\"Authentication failed:\")) return WithNativeCode(new AuthenticationException(message), code);"
                     .to_string(),
-                "        if (message.StartsWith(\"Corrupt archive:\")) return new CorruptException(message);".to_string(),
+                "        if (message.StartsWith(\"Corrupt archive:\")) return WithNativeCode(new CorruptException(message), code);".to_string(),
             ]
         );
     }
@@ -398,7 +398,7 @@ mod tests {
         assert_eq!(
             dispatch_lines,
             vec![
-                "        if (message.StartsWith(\"Authentication failed:\")) return new AuthenticationException(message);"
+                "        if (message.StartsWith(\"Authentication failed:\")) return WithNativeCode(new AuthenticationException(message), code);"
                     .to_string(),
             ]
         );
@@ -437,7 +437,7 @@ mod tests {
             "",
             "public class SampleClientException : Exception",
             "{",
-            "    public int Code { get; }",
+            "    public int Code { get; private set; }",
             "",
             "    public SampleClientException(int code, string message) : base(message)",
             "    {",
@@ -454,6 +454,12 @@ mod tests {
             "        Code = 0;",
             "    }",
             "",
+            "    private static SampleClientException WithNativeCode(SampleClientException exception, int code)",
+            "    {",
+            "        exception.Code = code;",
+            "        return exception;",
+            "    }",
+            "",
             "    /// <summary>",
             "    /// Builds the concrete exception for the FFI's current thread-local last-error state,",
             "    /// dispatching to the specific per-variant exception class when the message's prefix",
@@ -465,9 +471,9 @@ mod tests {
             "        var code = NativeMethods.LastErrorCode();",
             "        var ctxPtr = NativeMethods.LastErrorContext();",
             "        var message = global::System.Runtime.InteropServices.Marshal.PtrToStringUTF8(ctxPtr) ?? fallbackMessage;",
-            "        if (message.StartsWith(\"Authentication failed:\")) return new AuthenticationException(message);",
-            "        if (message.StartsWith(\"Bad request:\")) return new BadRequestException(message);",
-            "        if (code == 2) return new ApiErrorException(message);",
+            "        if (message.StartsWith(\"Authentication failed:\")) return WithNativeCode(new AuthenticationException(message), code);",
+            "        if (message.StartsWith(\"Bad request:\")) return WithNativeCode(new BadRequestException(message), code);",
+            "        if (code == 2) return WithNativeCode(new ApiErrorException(message), code);",
             "        return new SampleClientException(code, message);",
             "    }",
             "}",

--- a/src/backends/csharp/templates/exception_class.jinja
+++ b/src/backends/csharp/templates/exception_class.jinja
@@ -7,7 +7,7 @@ namespace {{ namespace }};
 
 public class {{ class_name }} : Exception
 {
-    public int Code { get; }
+    public int Code { get; private set; }
 
     public {{ class_name }}(int code, string message) : base(message)
     {
@@ -24,6 +24,14 @@ public class {{ class_name }} : Exception
         Code = 0;
     }
 
+{% if has_base_error %}
+    private static {{ class_name }} WithNativeCode({{ class_name }} exception, int code)
+    {
+        exception.Code = code;
+        return exception;
+    }
+
+{% endif %}
     /// <summary>
     /// Builds the concrete exception for the FFI's current thread-local last-error state,
     /// dispatching to the specific per-variant exception class when the message's prefix
@@ -39,7 +47,7 @@ public class {{ class_name }} : Exception
 {% for line in variant_dispatch_lines %}
 {{ line }}
 {% endfor %}
-        if (code == 2) return new {{ base_exception_class }}(message);
+        if (code == 2) return WithNativeCode(new {{ base_exception_class }}(message), code);
 {% endif %}
         return new {{ class_name }}(code, message);
     }

--- a/tests/backends_csharp_example_generation.rs
+++ b/tests/backends_csharp_example_generation.rs
@@ -243,7 +243,7 @@ fn test_generated_code_example() {
             .content
             .contains("public class SampleCrateException : Exception")
     );
-    assert!(exception.content.contains("public int Code { get; }"));
+    assert!(exception.content.contains("public int Code { get; private set; }"));
     assert!(exception.content.contains("namespace SampleCrate"));
 
     let wrapper = files

--- a/tests/backends_csharp_gen_bindings/error_dispatch.rs
+++ b/tests/backends_csharp_gen_bindings/error_dispatch.rs
@@ -51,7 +51,7 @@ fn test_error_helper_preserves_base_error_acronym_class_name() {
     let dispatcher = dispatcher_for("GraphQLError");
 
     assert!(
-        dispatcher.contains("if (code == 2) return new GraphQLErrorException(message);"),
+        dispatcher.contains("if (code == 2) return WithNativeCode(new GraphQLErrorException(message), code);"),
         "{dispatcher}"
     );
     assert!(!dispatcher.contains("GraphQlErrorException"));
@@ -67,7 +67,51 @@ fn test_invalid_input_variant_does_not_hijack_ffi_conversion_error_code() {
         "FFI code 1 must not dispatch to a user variant: {dispatcher}"
     );
     assert!(
-        dispatcher.contains("if (message.StartsWith(\"invalid input:\")) return new InvalidInputException(message);"),
+        dispatcher.contains("if (message.StartsWith(\"invalid input:\")) return WithNativeCode(new InvalidInputException(message), code);"),
         "InvalidInput must dispatch by message prefix: {dispatcher}"
+    );
+}
+
+#[test]
+fn test_typed_exceptions_preserve_native_codes_and_legacy_constructors() {
+    if !dotnet_is_runnable() {
+        assert!(std::env::var_os("ALEF_REQUIRE_DOTNET").is_none(), "dotnet is required");
+        return;
+    }
+    let files = CsharpBackend
+        .generate_bindings(&error_api("RequestError"), &minimal_csharp_config("test"))
+        .unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let mut exception_count = 0;
+    for file in files {
+        if file.content.contains("public class ") && file.content.contains("Exception : ") {
+            let filename = file.path.file_name().unwrap();
+            std::fs::write(directory.path().join(filename), file.content).unwrap();
+            exception_count += 1;
+        }
+    }
+    assert_eq!(exception_count, 3);
+    std::fs::write(
+        directory.path().join("Program.cs"),
+        include_str!("../fixtures/csharp_error_codes.cs"),
+    )
+    .unwrap();
+    std::fs::write(
+        directory.path().join("Probe.csproj"),
+        r#"<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType>
+<TargetFramework>net8.0</TargetFramework><RollForward>LatestMajor</RollForward>
+<NuGetAudit>false</NuGetAudit></PropertyGroup></Project>"#,
+    )
+    .unwrap();
+    let output = std::process::Command::new("dotnet")
+        .args(["run", "--project", "Probe.csproj", "--verbosity", "quiet"])
+        .current_dir(directory.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
 }

--- a/tests/fixtures/csharp_error_codes.cs
+++ b/tests/fixtures/csharp_error_codes.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+using Test;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        AssertError(2, "invalid input: unannotated", typeof(InvalidInputException));
+        AssertError(109, "invalid input: explicit code", typeof(InvalidInputException));
+        AssertError(731, "invalid input: unknown code", typeof(InvalidInputException));
+        AssertError(2, "unclassified native error", typeof(RequestErrorException));
+        AssertError(731, "unclassified native error", typeof(TestException));
+        var inner = new Exception("inner");
+        var legacy = new InvalidInputException("legacy", inner);
+        if (legacy.Code != 0 || legacy.Message != "legacy" || legacy.InnerException != inner)
+            throw new Exception("Legacy constructor changed");
+        if (new InvalidInputException("legacy").Code != 0)
+            throw new Exception("Legacy message constructor changed");
+    }
+
+    private static void AssertError(int code, string message, Type type)
+    {
+        NativeMethods.Code = code;
+        NativeMethods.Context = Marshal.StringToCoTaskMemUTF8(message);
+        try
+        {
+            var error = (TestException)TestException.FromLastError("fallback");
+            if (error.GetType() != type || error.Code != code || error.Message != message)
+                throw new Exception($"Expected {type.Name}/{code}/{message}; got {error.GetType().Name}/{error.Code}/{error.Message}");
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(NativeMethods.Context);
+        }
+    }
+}
+
+namespace Test
+{
+    internal static class NativeMethods
+    {
+        internal static int Code;
+        internal static IntPtr Context;
+        internal static int LastErrorCode() => Code;
+        internal static IntPtr LastErrorContext() => Context;
+    }
+}


### PR DESCRIPTION
Preserve the actual native error code when C# dispatches to a typed exception or base-error fallback, retaining existing public constructor signatures. A generated C# runtime regression covers codes 2, 109, and 731 plus constructor compatibility; real liter-llm and html-to-markdown native probes also preserve their subtype, message, and code after regeneration.

Validation: 52 focused C# tests, actual dotnet execution, full Poly lint and format checks, and both native consumer probes pass. Closes #362.
