### PR TITLE
fix(python): preserve fields and shadow-safe stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "alef"
-version = "0.85.16"
+version = "0.85.17"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1895,9 +1895,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "alef"
-version = "0.85.16"
+version = "0.85.17"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT"

--- a/alef.toml
+++ b/alef.toml
@@ -11,4 +11,4 @@
 crates = []
 
 [workspace]
-alef_version = "0.85.16"
+alef_version = "0.85.17"

--- a/schemas/alef.schema.json
+++ b/schemas/alef.schema.json
@@ -8224,7 +8224,7 @@
       "type": "object"
     }
   },
-  "$id": "https://github.com/xberg-io/alef/releases/download/v0.85.16/alef.schema.json",
+  "$id": "https://github.com/xberg-io/alef/releases/download/v0.85.17/alef.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "description": "JSON Schema for the JSON representation of alef.toml.",
@@ -8343,6 +8343,6 @@
   ],
   "title": "Alef configuration",
   "type": "object",
-  "version": "0.85.16",
-  "x-alef-version": "0.85.16"
+  "version": "0.85.17",
+  "x-alef-version": "0.85.17"
 }

--- a/src/backends/dart/gen_rust_crate/mod.rs
+++ b/src/backends/dart/gen_rust_crate/mod.rs
@@ -35,7 +35,10 @@ mod trait_types;
 
 use bridge_fn::emit_bridge_fn;
 use build_rs::{emit_build_rs, emit_frb_yaml};
-use cargo::emit_cargo_toml;
+// Re-exported crate-wide, not merely imported: `scaffold::tests::repair` needs the manifest this
+// backend actually writes as the baseline its repair pass must leave untouched, and a hand-built
+// string could not prove that. ~keep
+pub(crate) use cargo::emit_cargo_toml;
 use mirror::{emit_mirror_enum, emit_mirror_error, emit_mirror_struct};
 use trait_bridge::{emit_excluded_bridge_types, emit_trait_bridge, needs_excluded_bridge_type};
 

--- a/src/backends/go/gen_bindings/types/helpers.rs
+++ b/src/backends/go/gen_bindings/types/helpers.rs
@@ -456,7 +456,8 @@ mod last_error_tests {
         let helper = gen_last_error_helper(&api, "sample");
 
         assert!(helper.contains(&format!("case {code}:")));
-        assert!(helper.contains("return ErrInvalidInput"));
+        assert!(helper.contains("sentinel = ErrInvalidInput"));
+        assert!(helper.contains("return &nativeError{sentinel: sentinel, message: message}"));
         assert!(helper.contains("fmt.Errorf(\"[%d] %s\", code, message)"));
     }
 }

--- a/src/backends/go/templates/last_error_helper.jinja
+++ b/src/backends/go/templates/last_error_helper.jinja
@@ -1,21 +1,46 @@
+{% if error_codes %}
+// nativeError pairs a native error message with its sentinel so callers can
+// match with errors.Is while still reading the detail the native layer
+// produced, such as observed durations, limits and counts.
+type nativeError struct {
+	sentinel error
+	message  string
+}
+
+// Error returns the message reported by the native layer.
+func (e *nativeError) Error() string { return e.message }
+
+// Unwrap returns the sentinel error, so errors.Is and errors.As keep working.
+func (e *nativeError) Unwrap() error { return e.sentinel }
+
+{% endif %}
 // lastError retrieves the last error from the FFI layer.
 func lastError() error {
 	code := int32(C.{{ last_error_code_fn }}())
 	if code == 0 {
 		return nil
 	}
+	var message string
+	if ctx := C.{{ last_error_context_fn }}(); ctx != nil {
+		message = C.GoString(ctx)
+	}
 {% if error_codes %}
+	var sentinel error
 	switch code {
 {% for error_code in error_codes %}
 	case {{ error_code.0 }}:
-		return {{ error_code.1 }}
+		sentinel = {{ error_code.1 }}
 {% endfor %}
 	}
+	if sentinel != nil {
+		if message == "" {
+			return sentinel
+		}
+		return &nativeError{sentinel: sentinel, message: message}
+	}
 {% endif %}
-	ctx := C.{{ last_error_context_fn }}()
-	if ctx == nil {
+	if message == "" {
 		return fmt.Errorf("[%d] native error", code)
 	}
-	message := C.GoString(ctx)
 	return fmt.Errorf("[%d] %s", code, message)
 }

--- a/src/backends/pyo3/gen_bindings/dataclass_closure_tests.rs
+++ b/src/backends/pyo3/gen_bindings/dataclass_closure_tests.rs
@@ -87,7 +87,7 @@ fn options_dataclass_type_names_includes_a_required_field_of_a_dataclass_type() 
 #[test]
 fn gen_options_py_emits_captioning_config_with_a_required_llm_field() {
     let api = captioning_config_api();
-    let options_py = gen_options_py(&api, "_rust", &DtoConfig::default(), &[]);
+    let options_py = gen_options_py(&api, "_rust", &DtoConfig::default(), &[], false);
 
     assert!(
         options_py.contains("class CaptioningConfig:"),

--- a/src/backends/pyo3/gen_bindings/functions/adapter_boundary_tests.rs
+++ b/src/backends/pyo3/gen_bindings/functions/adapter_boundary_tests.rs
@@ -70,6 +70,7 @@ fn render(api: &ApiSurface, adapter: &AdapterConfig) -> (String, String) {
         "_internal_bindings",
         &DtoConfig::default(),
         &[],
+        false,
     );
     (api_py, options_py)
 }

--- a/src/backends/pyo3/gen_bindings/functions/streaming_yield_tests.rs
+++ b/src/backends/pyo3/gen_bindings/functions/streaming_yield_tests.rs
@@ -100,7 +100,7 @@ fn render(api: &ApiSurface, adapter: &AdapterConfig) -> (String, String) {
         &crate::core::config::ResolvedCrateConfig::default(),
     );
     let options_py =
-        crate::backends::pyo3::gen_bindings::types::gen_options_py(api, MODULE_NAME, &DtoConfig::default(), &[]);
+        crate::backends::pyo3::gen_bindings::types::gen_options_py(api, MODULE_NAME, &DtoConfig::default(), &[], false);
     (api_py, options_py)
 }
 

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -528,10 +528,12 @@ impl Backend for Pyo3Backend {
                 );
                 // Inject from_json staticmethod into the existing #[pymethods] block when serde
                 if types::type_has_from_json(typ, api, has_serde) {
+                    let core_type_path = crate::codegen::conversions::core_type_path(typ, &core_import);
                     let from_json_method = crate::backends::pyo3::template_env::render(
                         "from_json_method.jinja",
                         minijinja::context! {
-                            core_type_path => &typ.rust_path,
+                            core_type_path => core_type_path,
+                            has_lifetime_params => typ.has_lifetime_params,
                         },
                     );
                     if impl_block.is_empty() {

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -17,6 +17,8 @@ pub mod functions;
 pub mod methods;
 mod mutex;
 #[cfg(test)]
+mod native_delegation_tests;
+#[cfg(test)]
 mod nested_serde_default_tests;
 mod opaque_helpers;
 mod postprocess;

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -528,12 +528,12 @@ impl Backend for Pyo3Backend {
                 );
                 // Inject from_json staticmethod into the existing #[pymethods] block when serde
                 if types::type_has_from_json(typ, api, has_serde) {
-                    let from_json_method = "    #[staticmethod]\n    \
-                         fn from_json(json_str: String) -> pyo3::PyResult<Self> {\n        \
-                         serde_json::from_str::<Self>(&json_str)\n            \
-                         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))\n    \
-                         }"
-                    .to_string();
+                    let from_json_method = crate::backends::pyo3::template_env::render(
+                        "from_json_method.jinja",
+                        minijinja::context! {
+                            core_type_path => &typ.rust_path,
+                        },
+                    );
                     if impl_block.is_empty() {
                         let type_name = &typ.name;
                         impl_block = format!("#[pymethods]\nimpl {type_name} {{\n{from_json_method}\n}}");

--- a/src/backends/pyo3/gen_bindings/native_delegation_tests.rs
+++ b/src/backends/pyo3/gen_bindings/native_delegation_tests.rs
@@ -1,0 +1,94 @@
+//! Regression coverage for the dataclass-twin capability-loss defect: `options.py`'s public
+//! `@dataclass` twin of a native `#[pyclass]` must not lose native-only capability (starting
+//! with `from_json`) just because its public name shadows the native class. Every assertion
+//! here fails against the pre-fix code, where `gen_options_py` never consulted
+//! `type_has_from_json` at all and a consumer's `from pkg import Widget` gave a class
+//! with no `from_json`.
+
+use super::types::gen_options_py;
+use crate::core::config::DtoConfig;
+use crate::core::ir::{ApiSurface, FieldDef, TypeDef, TypeRef};
+
+const WIDGET: &str = "Widget";
+const MODULE_NAME: &str = "_rust";
+
+/// A `has_default`, `has_serde` type with one plain field -- the minimal shape that makes it
+/// both a dataclass twin (`options_dataclass_type_names`) and `from_json`-eligible
+/// (`type_has_from_json`).
+fn widget_api(type_has_serde: bool) -> ApiSurface {
+    ApiSurface {
+        types: vec![TypeDef {
+            name: WIDGET.to_owned(),
+            rust_path: format!("sample_core::{WIDGET}"),
+            has_default: true,
+            has_serde: type_has_serde,
+            fields: vec![FieldDef {
+                name: "label".to_owned(),
+                ty: TypeRef::String,
+                ..FieldDef::default()
+            }],
+            ..TypeDef::default()
+        }],
+        ..ApiSurface::default()
+    }
+}
+
+/// The headline fix: a `from_json`-eligible dataclass twin gets a `from_json` staticmethod that
+/// delegates to the native class and lifts the result back into the dataclass via the existing
+/// `_from_native_*` converter -- so `from pkg import Widget; Widget.from_json(...)` works
+/// exactly like `from pkg._native import Widget; Widget.from_json(...)` does today.
+#[test]
+fn gen_options_py_emits_from_json_delegating_to_native_class() {
+    let api = widget_api(true);
+    let options_py = gen_options_py(&api, MODULE_NAME, &DtoConfig::default(), &[], true);
+
+    assert!(
+        options_py.contains("def from_json(json_str: str) -> \"Widget\":"),
+        "options.py must declare a from_json staticmethod on the Widget dataclass:\n{options_py}"
+    );
+    assert!(
+        options_py.contains(&format!(
+            "_from_native_widget({MODULE_NAME}.Widget.from_json(json_str))"
+        )),
+        "from_json must call the native class's from_json and lift the result back through \
+         the existing _from_native_widget converter, not construct Widget directly:\n{options_py}"
+    );
+    assert!(
+        options_py.contains(&format!("from . import {MODULE_NAME}\n")),
+        "the native module must be imported by name so from_json can reach {MODULE_NAME}.Widget:\n{options_py}"
+    );
+}
+
+/// Negative control: a type with NO core `Deserialize` (`has_serde: false` on the `TypeDef`
+/// itself) must NOT get a `from_json` delegate, even though the crate as a whole has serde
+/// available -- `type_has_from_json` requires both. Proves the from_json gate is a real
+/// condition, not an unconditional emission.
+#[test]
+fn gen_options_py_omits_from_json_when_type_has_no_serde() {
+    let api = widget_api(false);
+    let options_py = gen_options_py(&api, MODULE_NAME, &DtoConfig::default(), &[], true);
+
+    assert!(
+        !options_py.contains("def from_json("),
+        "a type without core Deserialize must not get a from_json delegate:\n{options_py}"
+    );
+    assert!(
+        !options_py.contains(&format!("from . import {MODULE_NAME}\n")),
+        "no from_json delegate anywhere in the file means the native-module-alias import must \
+         not be emitted either -- it would be dead code:\n{options_py}"
+    );
+}
+
+/// Negative control: even a `from_json`-eligible type gets no delegate when the crate itself has
+/// no serde support (`has_serde: false` passed to `gen_options_py`). Proves the crate-level half
+/// of the gate is consulted too, matching the native `#[pymethods]` injection's own condition.
+#[test]
+fn gen_options_py_omits_from_json_when_crate_has_no_serde() {
+    let api = widget_api(true);
+    let options_py = gen_options_py(&api, MODULE_NAME, &DtoConfig::default(), &[], false);
+
+    assert!(
+        !options_py.contains("def from_json("),
+        "no from_json delegate anywhere when the crate has no serde support:\n{options_py}"
+    );
+}

--- a/src/backends/pyo3/gen_bindings/nested_serde_default_tests.rs
+++ b/src/backends/pyo3/gen_bindings/nested_serde_default_tests.rs
@@ -89,7 +89,7 @@ fn api_surface() -> ApiSurface {
 }
 
 fn render() -> String {
-    gen_options_py(&api_surface(), "_internal_bindings", &DtoConfig::default(), &[])
+    gen_options_py(&api_surface(), "_internal_bindings", &DtoConfig::default(), &[], false)
 }
 
 /// A bare `#[serde(default)]` field on a closure-only type (no core `Default`) must render as

--- a/src/backends/pyo3/gen_bindings/public_files.rs
+++ b/src/backends/pyo3/gen_bindings/public_files.rs
@@ -63,7 +63,8 @@ pub(super) fn generate_public_api(
         .map(|c| c.reexported_types.clone())
         .unwrap_or_default();
 
-    let options_content = types::gen_options_py(api, &module_name, &config.dto, &reexported_types);
+    let has_serde = types::crate_has_serde(config);
+    let options_content = types::gen_options_py(api, &module_name, &config.dto, &reexported_types, has_serde);
     files.push(GeneratedFile {
         path: output_base.join("options.py"),
         content: options_content,

--- a/src/backends/pyo3/gen_bindings/tests.rs
+++ b/src/backends/pyo3/gen_bindings/tests.rs
@@ -271,12 +271,84 @@ fn from_json_deserializes_the_core_type_before_conversion() {
         "from_json must preserve the core serde contract before converting to the binding: {content}"
     );
     assert!(
-        content.contains("serde_json::from_str::<test_lib::config::BorrowedConfig<'static>>(&json_str)"),
+        content.contains("serde_json::from_str::<test_lib::config::BorrowedConfig<'_>>(&json_str)"),
         "from_json must specialize lifetime-bearing core DTOs before deserializing: {content}"
     );
     assert!(
         content.contains(".map(Into::into)"),
         "from_json must convert the deserialized core value into the pyo3 wrapper: {content}"
+    );
+}
+
+#[test]
+fn lifetime_from_json_compiles_for_a_borrowing_core_dto() {
+    use crate::core::ir::{ApiSurface, CoreWrapper, TypeDef};
+
+    let temporary_directory = tempfile::tempdir().unwrap();
+    let core_directory = temporary_directory.path().join("test-lib");
+    let binding_directory = temporary_directory.path().join("test-lib-py");
+    std::fs::create_dir_all(core_directory.join("src")).unwrap();
+    std::fs::create_dir_all(binding_directory.join("src")).unwrap();
+    std::fs::write(
+        core_directory.join("Cargo.toml"),
+        "[package]\nname = \"test-lib\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\
+         [dependencies]\nserde = { version = \"1\", features = [\"derive\"] }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        core_directory.join("src/lib.rs"),
+        "use std::borrow::Cow;\n\
+         #[derive(Clone, serde::Deserialize)]\n\
+         pub struct BorrowedConfig<'a> {\n\
+             #[serde(borrow)]\n\
+             pub label: Cow<'a, str>,\n\
+         }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        binding_directory.join("Cargo.toml"),
+        "[package]\nname = \"test-lib-py\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\
+         [dependencies]\npyo3 = \"=0.29.2\"\nserde = { version = \"1\", features = [\"derive\"] }\n\
+         serde_json = \"1\"\ntest-lib = { path = \"../test-lib\" }\n",
+    )
+    .unwrap();
+
+    let mut config = python_config();
+    config.python.as_mut().unwrap().module_name = Some("_test_lib".to_string());
+    config
+        .output_paths
+        .insert("python".to_string(), binding_directory.join("src"));
+    let api = ApiSurface {
+        crate_name: "test-lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![TypeDef {
+            name: "BorrowedConfig".to_string(),
+            rust_path: "test-lib::BorrowedConfig".to_string(),
+            has_serde: true,
+            has_lifetime_params: true,
+            fields: vec![FieldDef {
+                name: "label".to_string(),
+                ty: TypeRef::String,
+                core_wrapper: CoreWrapper::Cow,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let generated = Pyo3Backend.generate_bindings(&api, &config).unwrap();
+    std::fs::write(binding_directory.join("src/lib.rs"), &generated[0].content).unwrap();
+
+    let output = std::process::Command::new("cargo")
+        .args(["check", "--quiet", "--manifest-path"])
+        .arg(binding_directory.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", temporary_directory.path().join("target"))
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "generated borrowing DTO binding must compile:\n{}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/src/backends/pyo3/gen_bindings/tests.rs
+++ b/src/backends/pyo3/gen_bindings/tests.rs
@@ -215,6 +215,53 @@ fn struct_impl_block_skips_method_colliding_with_a_field_getter() {
     );
 }
 
+#[test]
+fn from_json_deserializes_the_core_type_before_conversion() {
+    use crate::core::ir::{ApiSurface, TypeDef};
+
+    let temporary_directory = tempfile::tempdir().unwrap();
+    let binding_directory = temporary_directory.path().join("test-lib-py");
+    std::fs::create_dir_all(binding_directory.join("src")).unwrap();
+    std::fs::write(
+        binding_directory.join("Cargo.toml"),
+        "[dependencies]\nserde = { version = \"1\", features = [\"derive\"] }\nserde_json = \"1\"\n",
+    )
+    .unwrap();
+    let mut config = python_config();
+    config
+        .output_paths
+        .insert("python".to_string(), binding_directory.join("src"));
+
+    let api = ApiSurface {
+        crate_name: "test-lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![TypeDef {
+            name: "ExtractionConfig".to_string(),
+            rust_path: "test_lib::config::ExtractionConfig".to_string(),
+            has_serde: true,
+            fields: vec![FieldDef {
+                name: "chunking".to_string(),
+                ty: TypeRef::String,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let files = Pyo3Backend.generate_bindings(&api, &config).unwrap();
+    let content = &files[0].content;
+
+    assert!(
+        content.contains("serde_json::from_str::<test_lib::config::ExtractionConfig>(&json_str)"),
+        "from_json must preserve the core serde contract before converting to the binding: {content}"
+    );
+    assert!(
+        content.contains(".map(Into::into)"),
+        "from_json must convert the deserialized core value into the pyo3 wrapper: {content}"
+    );
+}
+
 /// Regression test for issue #380, exercised through the real `Pyo3Backend::generate_bindings`
 /// path (not just the `gen_function` unit): a `&mut T` DTO parameter on a unit-returning free
 /// function must render as a binding that returns the mutated intermediate.

--- a/src/backends/pyo3/gen_bindings/tests.rs
+++ b/src/backends/pyo3/gen_bindings/tests.rs
@@ -235,17 +235,31 @@ fn from_json_deserializes_the_core_type_before_conversion() {
     let api = ApiSurface {
         crate_name: "test-lib".to_string(),
         version: "0.1.0".to_string(),
-        types: vec![TypeDef {
-            name: "ExtractionConfig".to_string(),
-            rust_path: "test_lib::config::ExtractionConfig".to_string(),
-            has_serde: true,
-            fields: vec![FieldDef {
-                name: "chunking".to_string(),
-                ty: TypeRef::String,
+        types: vec![
+            TypeDef {
+                name: "ExtractionConfig".to_string(),
+                rust_path: "test-lib::config::ExtractionConfig".to_string(),
+                has_serde: true,
+                fields: vec![FieldDef {
+                    name: "chunking".to_string(),
+                    ty: TypeRef::String,
+                    ..Default::default()
+                }],
                 ..Default::default()
-            }],
-            ..Default::default()
-        }],
+            },
+            TypeDef {
+                name: "BorrowedConfig".to_string(),
+                rust_path: "test-lib::config::BorrowedConfig".to_string(),
+                has_serde: true,
+                has_lifetime_params: true,
+                fields: vec![FieldDef {
+                    name: "label".to_string(),
+                    ty: TypeRef::String,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ],
         ..Default::default()
     };
 
@@ -255,6 +269,10 @@ fn from_json_deserializes_the_core_type_before_conversion() {
     assert!(
         content.contains("serde_json::from_str::<test_lib::config::ExtractionConfig>(&json_str)"),
         "from_json must preserve the core serde contract before converting to the binding: {content}"
+    );
+    assert!(
+        content.contains("serde_json::from_str::<test_lib::config::BorrowedConfig<'static>>(&json_str)"),
+        "from_json must specialize lifetime-bearing core DTOs before deserializing: {content}"
     );
     assert!(
         content.contains(".map(Into::into)"),

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -156,6 +156,7 @@ pub(super) fn gen_options_py(
     module_name: &str,
     dto: &DtoConfig,
     reexported_types: &[String],
+    has_serde: bool,
 ) -> String {
     use crate::core::ir::TypeRef;
 
@@ -192,6 +193,19 @@ pub(super) fn gen_options_py(
         let mut options_types = dataclass_names.clone();
         options_types.extend(published_return_type_names.iter().cloned());
         api.types.iter().any(|t| options_types.contains(&t.name))
+    };
+    // A dataclass twin needs the native module imported by name (not just the specific
+    // native symbols `runtime_native_imports` already pulls in) whenever at least one
+    // `options.py`-published type gets a delegating `from_json` staticmethod below -- the
+    // method body calls `{module_name}.{ClassName}.from_json(...)` directly. Scoped to the
+    // exact same type set `gen_from_native_converters` emits `_from_native_*` for, so this
+    // never imports a module nothing in the file ends up using. ~keep
+    let emits_from_json = {
+        let mut options_types = dataclass_names.clone();
+        options_types.extend(published_return_type_names.iter().cloned());
+        api.types
+            .iter()
+            .any(|t| options_types.contains(&t.name) && type_has_from_json(t, api, has_serde))
     };
     // Json-typed fields used to render as `dict[str, Any]` and so pulled in `Any`. They now
     // render as `str`, so a Json field alone no longer references `Any`; keeping the
@@ -323,6 +337,12 @@ pub(super) fn gen_options_py(
             ));
         }
         out.push_str(")\n");
+    }
+    if emits_from_json {
+        out.push_str(&crate::backends::pyo3::template_env::render(
+            "import_module_relative.jinja",
+            minijinja::context! { module_name => module_name },
+        ));
     }
     out.push('\n');
     if !type_checking_only_imports.is_empty() {
@@ -474,7 +494,10 @@ pub(super) fn gen_options_py(
         ));
         out.push('\n');
 
+        let native_delegation_py = render_native_delegation_methods(typ, api, has_serde, module_name);
+
         if ordered_fields.is_empty() {
+            out.push_str(&native_delegation_py);
             out.push('\n');
             continue;
         }
@@ -546,11 +569,49 @@ pub(super) fn gen_options_py(
                 out.push('\n');
             }
         }
+        out.push_str(&native_delegation_py);
         out.push('\n');
     }
 
     out.push_str(&gen_from_native_converters(api, dto, reexported_types));
 
+    out
+}
+
+/// Delegating methods appended to one `options.py` dataclass body so a consumer's public name
+/// for `typ` does not lose native-only capability relative to the native `#[pyclass]` it shadows
+/// -- the defect this generator exists to close. Eligibility is decided by the SAME predicate
+/// the native `#[pymethods]` injection uses (`type_has_from_json`, consulted from
+/// `gen_bindings::mod`'s `from_json` text injection too), so the two call sites can never drift
+/// apart again the way they did before.
+///
+/// Only `from_json` is wired up here. The no-arg native helpers (`validate`, `is_empty`,
+/// `is_ok`, ...) and the `Self`-returning builders (`with_*`, `from_bytes`, `from_uri`) both
+/// need a dataclass -> native forward conversion first, and that conversion is not a small
+/// thing to add safely: the only existing implementation is `functions::converters::emit_converters`
+/// (~700 lines), which handles trait-bridge params, opaque/capsule types, and fields that must
+/// be OMITTED from the native constructor call (not passed as `None`) so the Rust-side default
+/// applies (see `defers_to_rust_default`). A parallel, simplified re-implementation here would
+/// silently mishandle exactly the fields that logic exists to get right. The correct follow-up
+/// is extracting a per-type callable out of `emit_converters` that both `api.py` and `options.py`
+/// can call, not duplicating it. ~keep
+fn render_native_delegation_methods(
+    typ: &crate::core::ir::TypeDef,
+    api: &ApiSurface,
+    has_serde: bool,
+    module_name: &str,
+) -> String {
+    let mut out = String::new();
+    if type_has_from_json(typ, api, has_serde) {
+        out.push_str(&crate::backends::pyo3::template_env::render(
+            "trait_bridge/options_from_json_method.jinja",
+            minijinja::context! {
+                class_name => &typ.name,
+                module_name => module_name,
+                from_native_fn => from_native_converter_name(&typ.name),
+            },
+        ));
+    }
     out
 }
 

--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -98,6 +98,63 @@ pub fn is_python_builtin_name(name: &str) -> bool {
     BUILTINS.contains(&name)
 }
 
+const SHADOWABLE_BUILTIN_TYPES: &[&str] = &[
+    "bytes",
+    "str",
+    "int",
+    "float",
+    "bool",
+    "type",
+    "list",
+    "dict",
+    "set",
+    "tuple",
+    "frozenset",
+];
+
+pub(super) fn qualify_shadowed_builtin_types(annotation: &str, shadowed: &[&str]) -> String {
+    let mut qualified = annotation.to_string();
+    for builtin in shadowed {
+        qualified = replace_bare_ident(&qualified, builtin, &format!("builtins.{builtin}"));
+    }
+    qualified
+}
+
+pub(super) fn qualify_parameter_type(name: &str, annotation: &str) -> String {
+    if SHADOWABLE_BUILTIN_TYPES.contains(&name) {
+        qualify_shadowed_builtin_types(annotation, &[name])
+    } else {
+        annotation.to_string()
+    }
+}
+
+fn replace_bare_ident(haystack: &str, ident: &str, replacement: &str) -> String {
+    let bytes = haystack.as_bytes();
+    let mut output = String::with_capacity(haystack.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if haystack[index..].starts_with(ident) {
+            let before_is_boundary = index == 0 || {
+                let byte = bytes[index - 1];
+                !(byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'.')
+            };
+            let end = index + ident.len();
+            let after_is_boundary = end >= bytes.len() || {
+                let byte = bytes[end];
+                !(byte.is_ascii_alphanumeric() || byte == b'_')
+            };
+            if before_is_boundary && after_is_boundary {
+                output.push_str(replacement);
+                index = end;
+                continue;
+            }
+        }
+        output.push(bytes[index] as char);
+        index += 1;
+    }
+    output
+}
+
 /// Map a raw Rust type string from [`ClientConstructorConfig`] to its Python equivalent.
 ///
 /// Constructor params come from `alef.toml` as raw Rust type strings (e.g. `"&str"`).
@@ -516,10 +573,34 @@ pub(super) fn substitute_capsule_type(type_str: &str, capsule_names: &std::colle
 
 #[cfg(test)]
 mod tests {
-    use super::{gen_stubs, gen_type_stub, with_from_json_stub};
+    use super::{gen_stubs, gen_type_stub, qualify_parameter_type, with_from_json_stub};
     use crate::core::config::ResolvedCrateConfig;
     use crate::core::config::new_config::NewAlefConfig;
     use crate::core::ir::{ApiSurface, FieldDef, MethodDef, ReceiverKind, TypeDef, TypeRef};
+
+    #[test]
+    fn parameter_annotations_qualify_every_shadowable_builtin_type() {
+        let cases = [
+            ("bytes", "bytes | None", "builtins.bytes | None"),
+            ("str", "str", "builtins.str"),
+            ("int", "int", "builtins.int"),
+            ("float", "float", "builtins.float"),
+            ("bool", "bool", "builtins.bool"),
+            ("type", "type", "builtins.type"),
+            ("list", "list[str]", "builtins.list[str]"),
+            ("dict", "dict[str, int]", "builtins.dict[str, int]"),
+            ("set", "set[str]", "builtins.set[str]"),
+            ("tuple", "tuple[str, int]", "builtins.tuple[str, int]"),
+            ("frozenset", "frozenset[str]", "builtins.frozenset[str]"),
+        ];
+
+        for (name, annotation, expected) in cases {
+            assert_eq!(qualify_parameter_type(name, annotation), expected);
+        }
+        assert_eq!(qualify_parameter_type("license", "str"), "str");
+        assert_eq!(qualify_parameter_type("bytes", "bytestring"), "bytestring");
+        assert_eq!(qualify_parameter_type("bytes", "builtins.bytes"), "builtins.bytes");
+    }
 
     fn python_config() -> ResolvedCrateConfig {
         let cfg: NewAlefConfig = toml::from_str(

--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -110,6 +110,7 @@ const SHADOWABLE_BUILTIN_TYPES: &[&str] = &[
     "set",
     "tuple",
     "frozenset",
+    "object",
 ];
 
 pub(super) fn qualify_shadowed_builtin_types(annotation: &str, shadowed: &[&str]) -> String {

--- a/src/backends/pyo3/gen_stubs/classes.rs
+++ b/src/backends/pyo3/gen_stubs/classes.rs
@@ -75,6 +75,7 @@ pub(super) fn gen_opaque_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
+                &[],
             ));
         }
     }
@@ -87,6 +88,7 @@ pub(super) fn gen_opaque_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
+                &[],
             ));
         }
     }
@@ -167,6 +169,7 @@ pub(super) fn gen_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
+                &shadowed,
             ));
         }
     }
@@ -179,6 +182,7 @@ pub(super) fn gen_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
+                &shadowed,
             ));
         }
     }
@@ -315,6 +319,7 @@ fn gen_method_stub(
     capsule_names: &std::collections::HashSet<&str>,
     owner_type: Option<&str>,
     streaming_return_types: &std::collections::HashMap<(Option<String>, String), String>,
+    owner_shadowed_builtins: &[&str],
 ) -> String {
     let (required, optional): (Vec<_>, Vec<_>) = method.params.iter().partition(|p| !p.optional);
 
@@ -323,6 +328,7 @@ fn gen_method_stub(
         .map(|p| {
             let param_type = substitute_capsule_type(&python_type(&p.ty), capsule_names);
             let param_type = qualify_parameter_type(&p.name, &param_type);
+            let param_type = qualify_shadowed_builtin_types(&param_type, owner_shadowed_builtins);
             format!("{}: {}", p.name, param_type)
         })
         .collect();
@@ -330,6 +336,7 @@ fn gen_method_stub(
     params.extend(optional.iter().map(|p| {
         let type_str = substitute_capsule_type(&python_type(&p.ty), capsule_names);
         let type_str = qualify_parameter_type(&p.name, &type_str);
+        let type_str = qualify_shadowed_builtin_types(&type_str, owner_shadowed_builtins);
         let param_type = if !type_str.ends_with("| None") {
             format!("{} | None", type_str)
         } else {
@@ -345,6 +352,7 @@ fn gen_method_stub(
     } else {
         substitute_capsule_type(&python_type(&method.return_type), capsule_names)
     };
+    let return_type = qualify_shadowed_builtin_types(&return_type, owner_shadowed_builtins);
     let indent = "    ";
     let safe_name = python_safe_name(&method.name);
     // `adapter_streaming_wrapper.jinja` emits a streaming method's real wrapper as an async
@@ -494,6 +502,7 @@ mod tests {
             &std::collections::HashSet::new(),
             Some("DefaultClient"),
             &streaming_return_types,
+            &[],
         );
 
         assert!(
@@ -519,6 +528,7 @@ mod tests {
             &std::collections::HashSet::new(),
             Some("DefaultClient"),
             &std::collections::HashMap::new(),
+            &[],
         );
 
         assert!(
@@ -547,6 +557,7 @@ mod tests {
             &std::collections::HashSet::new(),
             Some("Document"),
             &std::collections::HashMap::new(),
+            &[],
         );
 
         assert!(
@@ -556,6 +567,58 @@ mod tests {
         assert!(
             !stub.contains("bytes: bytes"),
             "the ambiguous annotation is rejected by pyrefly:\n{stub}"
+        );
+    }
+
+    #[test]
+    fn class_field_named_bytes_qualifies_all_method_annotations_in_class_scope() {
+        let method = MethodDef {
+            name: "consume".to_string(),
+            params: vec![ParamDef {
+                name: "payload".to_string(),
+                ty: TypeRef::Bytes,
+                ..Default::default()
+            }],
+            return_type: TypeRef::Bytes,
+            ..Default::default()
+        };
+        let with_shadow = TypeDef {
+            name: "Container".to_string(),
+            fields: vec![FieldDef {
+                name: "bytes".to_string(),
+                ty: TypeRef::Bytes,
+                ..Default::default()
+            }],
+            methods: vec![method.clone()],
+            ..Default::default()
+        };
+        let without_shadow = TypeDef {
+            name: "Container".to_string(),
+            methods: vec![method],
+            ..Default::default()
+        };
+        let render = |typ: &TypeDef| {
+            gen_type_stub(
+                typ,
+                &ApiSurface::default(),
+                &ResolvedCrateConfig::default(),
+                &std::collections::HashSet::new(),
+                &OptionsFieldBridges::default(),
+                false,
+                &std::collections::HashMap::new(),
+            )
+        };
+
+        let shadowed = render(&with_shadow);
+        assert!(
+            shadowed.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
+            "class attributes shadow builtin names throughout the class body:\n{shadowed}"
+        );
+
+        let control = render(&without_shadow);
+        assert!(
+            control.contains("def consume(self, payload: bytes) -> bytes"),
+            "annotations should stay concise when no class attribute shadows them:\n{control}"
         );
     }
 

--- a/src/backends/pyo3/gen_stubs/classes.rs
+++ b/src/backends/pyo3/gen_stubs/classes.rs
@@ -1,6 +1,7 @@
 use super::{
-    OptionsFieldBridges, constructor_param_type, constructor_rust_type_to_python, is_python_builtin_name,
-    pyi_docstring, python_safe_name, substitute_capsule_type,
+    OptionsFieldBridges, SHADOWABLE_BUILTIN_TYPES, constructor_param_type, constructor_rust_type_to_python,
+    is_python_builtin_name, pyi_docstring, python_safe_name, qualify_parameter_type, qualify_shadowed_builtin_types,
+    substitute_capsule_type,
 };
 use crate::backends::pyo3::type_map::python_type;
 use crate::codegen::shared::binding_fields;
@@ -14,23 +15,9 @@ use crate::core::ir::{ApiSurface, MethodDef, TypeDef, TypeRef};
 /// rejects it (`Variable "X.bytes" is not valid as a type [valid-type]`). Qualifying such
 /// annotations as `builtins.<name>` breaks the shadowing; `gen_stubs.rs` emits `import builtins`
 /// whenever the body references it.
-const SHADOWABLE_BUILTINS: &[&str] = &[
-    "bytes",
-    "str",
-    "int",
-    "float",
-    "bool",
-    "type",
-    "list",
-    "dict",
-    "set",
-    "tuple",
-    "frozenset",
-];
-
 /// The builtins shadowed by a field name in `typ`, using the resolved Python stub field names.
 fn shadowed_builtins(typ: &TypeDef, config: &ResolvedCrateConfig) -> Vec<&'static str> {
-    SHADOWABLE_BUILTINS
+    SHADOWABLE_BUILTIN_TYPES
         .iter()
         .copied()
         .filter(|builtin| {
@@ -42,46 +29,6 @@ fn shadowed_builtins(typ: &TypeDef, config: &ResolvedCrateConfig) -> Vec<&'stati
             })
         })
         .collect()
-}
-
-/// Qualify whole-identifier occurrences of each shadowed builtin in a type annotation as
-/// `builtins.<name>` (e.g. `bytes | None` -> `builtins.bytes | None`).
-fn qualify_shadowed_builtins(annotation: &str, shadowed: &[&str]) -> String {
-    let mut out = annotation.to_string();
-    for builtin in shadowed {
-        out = replace_bare_ident(&out, builtin, &format!("builtins.{builtin}"));
-    }
-    out
-}
-
-/// Replace whole-identifier occurrences of `ident` — not preceded by `.`, an ASCII alphanumeric,
-/// or `_`, and not followed by an ASCII alphanumeric or `_` — with `replacement`. Annotations are
-/// ASCII, so byte-wise scanning is safe.
-fn replace_bare_ident(haystack: &str, ident: &str, replacement: &str) -> String {
-    let bytes = haystack.as_bytes();
-    let mut out = String::with_capacity(haystack.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if haystack[i..].starts_with(ident) {
-            let before_ok = i == 0 || {
-                let b = bytes[i - 1];
-                !(b.is_ascii_alphanumeric() || b == b'_' || b == b'.')
-            };
-            let end = i + ident.len();
-            let after_ok = end >= bytes.len() || {
-                let b = bytes[end];
-                !(b.is_ascii_alphanumeric() || b == b'_')
-            };
-            if before_ok && after_ok {
-                out.push_str(replacement);
-                i = end;
-                continue;
-            }
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    out
 }
 
 pub(super) fn gen_opaque_type_stub(
@@ -100,6 +47,7 @@ pub(super) fn gen_opaque_type_stub(
             .iter()
             .map(|p| {
                 let py_type = constructor_rust_type_to_python(&p.ty);
+                let py_type = qualify_parameter_type(&p.name, py_type);
                 format!("{}: {}", p.name, py_type)
             })
             .collect();
@@ -191,7 +139,7 @@ pub(super) fn gen_type_stub(
         } else {
             type_str
         };
-        let field_type = qualify_shadowed_builtins(&field_type, &shadowed);
+        let field_type = qualify_shadowed_builtin_types(&field_type, &shadowed);
         let stub_field_name = config
             .resolve_field_name(Language::Python, &typ.name, &field.name)
             .unwrap_or_else(|| field.name.clone());
@@ -280,7 +228,7 @@ fn gen_type_init_stub(
     let mut params: Vec<String> = required
         .iter()
         .map(|f| {
-            let param_type = qualify_shadowed_builtins(&constructor_param_type(&f.ty, api), &shadowed);
+            let param_type = qualify_shadowed_builtin_types(&constructor_param_type(&f.ty, api), &shadowed);
             let param_name = crate::backends::pyo3::gen_bindings::constructors::resolve_param_ident(
                 &f.name,
                 f.serde_rename.as_ref(),
@@ -292,7 +240,7 @@ fn gen_type_init_stub(
         .collect();
 
     params.extend(optional.iter().map(|f| {
-        let type_str = qualify_shadowed_builtins(&constructor_param_type(&f.ty, api), &shadowed);
+        let type_str = qualify_shadowed_builtin_types(&constructor_param_type(&f.ty, api), &shadowed);
         let param_type = if !type_str.ends_with("| None") {
             format!("{} | None", type_str)
         } else {
@@ -374,12 +322,14 @@ fn gen_method_stub(
         .iter()
         .map(|p| {
             let param_type = substitute_capsule_type(&python_type(&p.ty), capsule_names);
+            let param_type = qualify_parameter_type(&p.name, &param_type);
             format!("{}: {}", p.name, param_type)
         })
         .collect();
 
     params.extend(optional.iter().map(|p| {
         let type_str = substitute_capsule_type(&python_type(&p.ty), capsule_names);
+        let type_str = qualify_parameter_type(&p.name, &type_str);
         let param_type = if !type_str.ends_with("| None") {
             format!("{} | None", type_str)
         } else {
@@ -493,8 +443,8 @@ fn gen_method_stub(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::ir::FieldDef;
     use crate::core::ir::PrimitiveType;
+    use crate::core::ir::{FieldDef, ParamDef};
 
     fn streaming_method(name: &str) -> crate::core::ir::MethodDef {
         crate::core::ir::MethodDef {
@@ -574,6 +524,38 @@ mod tests {
         assert!(
             stub.trim_start().starts_with("async def chat("),
             "a non-streaming async method must keep `async def`, got:\n{stub}"
+        );
+    }
+
+    #[test]
+    fn method_parameter_named_bytes_qualifies_its_builtin_annotation() {
+        let method = MethodDef {
+            name: "from_bytes".to_string(),
+            params: vec![ParamDef {
+                name: "bytes".to_string(),
+                ty: TypeRef::Bytes,
+                ..Default::default()
+            }],
+            return_type: TypeRef::Named("Document".to_string()),
+            is_static: true,
+            ..Default::default()
+        };
+
+        let stub = gen_method_stub(
+            &method,
+            true,
+            &std::collections::HashSet::new(),
+            Some("Document"),
+            &std::collections::HashMap::new(),
+        );
+
+        assert!(
+            stub.contains("bytes: builtins.bytes"),
+            "the parameter must not resolve its annotation to its own value:\n{stub}"
+        );
+        assert!(
+            !stub.contains("bytes: bytes"),
+            "the ambiguous annotation is rejected by pyrefly:\n{stub}"
         );
     }
 

--- a/src/backends/pyo3/gen_stubs/classes.rs
+++ b/src/backends/pyo3/gen_stubs/classes.rs
@@ -17,16 +17,34 @@ use crate::core::ir::{ApiSurface, MethodDef, TypeDef, TypeRef};
 /// whenever the body references it.
 /// The builtins shadowed by a field name in `typ`, using the resolved Python stub field names.
 fn shadowed_builtins(typ: &TypeDef, config: &ResolvedCrateConfig) -> Vec<&'static str> {
+    let field_names: std::collections::HashSet<String> = binding_fields(&typ.fields)
+        .map(|field| {
+            config
+                .resolve_field_name(Language::Python, &typ.name, &field.name)
+                .unwrap_or_else(|| field.name.clone())
+        })
+        .collect();
     SHADOWABLE_BUILTIN_TYPES
         .iter()
         .copied()
         .filter(|builtin| {
-            binding_fields(&typ.fields).any(|f| {
-                let name = config
-                    .resolve_field_name(Language::Python, &typ.name, &f.name)
-                    .unwrap_or_else(|| f.name.clone());
-                name == *builtin
-            })
+            field_names.contains(*builtin)
+                || typ.methods.iter().any(|method| {
+                    (method.is_static || !field_names.contains(&method.name))
+                        && python_safe_name(&method.name) == *builtin
+                })
+        })
+        .collect()
+}
+
+fn opaque_shadowed_builtins(typ: &TypeDef) -> Vec<&'static str> {
+    SHADOWABLE_BUILTIN_TYPES
+        .iter()
+        .copied()
+        .filter(|builtin| {
+            typ.methods
+                .iter()
+                .any(|method| python_safe_name(&method.name) == *builtin)
         })
         .collect()
 }
@@ -38,6 +56,7 @@ pub(super) fn gen_opaque_type_stub(
     ctor: Option<&ClientConstructorConfig>,
 ) -> String {
     let mut lines = vec![];
+    let shadowed = opaque_shadowed_builtins(typ);
 
     lines.push(format!("class {}:", typ.name));
 
@@ -75,7 +94,7 @@ pub(super) fn gen_opaque_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
-                &[],
+                &shadowed,
             ));
         }
     }
@@ -88,7 +107,7 @@ pub(super) fn gen_opaque_type_stub(
                 capsule_names,
                 Some(&typ.name),
                 streaming_return_types,
-                &[],
+                &shadowed,
             ));
         }
     }
@@ -619,6 +638,129 @@ mod tests {
         assert!(
             control.contains("def consume(self, payload: bytes) -> bytes"),
             "annotations should stay concise when no class attribute shadows them:\n{control}"
+        );
+    }
+
+    fn builtin_named_method_fixture() -> TypeDef {
+        TypeDef {
+            name: "Container".to_string(),
+            methods: vec![
+                MethodDef {
+                    name: "bytes".to_string(),
+                    return_type: TypeRef::Unit,
+                    ..Default::default()
+                },
+                MethodDef {
+                    name: "consume".to_string(),
+                    params: vec![ParamDef {
+                        name: "payload".to_string(),
+                        ty: TypeRef::Bytes,
+                        ..Default::default()
+                    }],
+                    return_type: TypeRef::Bytes,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn method_named_bytes_qualifies_sibling_annotations_for_regular_classes() {
+        let render = |typ: &TypeDef| {
+            gen_type_stub(
+                typ,
+                &ApiSurface::default(),
+                &ResolvedCrateConfig::default(),
+                &std::collections::HashSet::new(),
+                &OptionsFieldBridges::default(),
+                false,
+                &std::collections::HashMap::new(),
+            )
+        };
+        let mut typ = builtin_named_method_fixture();
+        let stub = render(&typ);
+
+        assert!(
+            stub.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
+            "an emitted method name shadows builtins throughout the class scope:\n{stub}"
+        );
+
+        typ.methods.remove(0);
+        let control = render(&typ);
+        assert!(
+            control.contains("def consume(self, payload: bytes) -> bytes"),
+            "annotations should stay concise without a builtin-named class member:\n{control}"
+        );
+    }
+
+    #[test]
+    fn method_named_bytes_qualifies_sibling_annotations_for_opaque_classes() {
+        let mut typ = builtin_named_method_fixture();
+        typ.is_opaque = true;
+        let stub = gen_opaque_type_stub(
+            &typ,
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+            None,
+        );
+
+        assert!(
+            stub.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
+            "opaque class methods share the same class annotation scope:\n{stub}"
+        );
+    }
+
+    fn object_named_method_fixture() -> TypeDef {
+        TypeDef {
+            name: "ObjectContainer".to_string(),
+            methods: vec![
+                MethodDef {
+                    name: "object".to_string(),
+                    return_type: TypeRef::Unit,
+                    ..Default::default()
+                },
+                MethodDef {
+                    name: "consume".to_string(),
+                    params: vec![ParamDef {
+                        name: "payload".to_string(),
+                        ty: TypeRef::Named("object".to_string()),
+                        ..Default::default()
+                    }],
+                    return_type: TypeRef::Named("object".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn method_named_object_qualifies_regular_and_opaque_class_annotations() {
+        let typ = object_named_method_fixture();
+        let regular = gen_type_stub(
+            &typ,
+            &ApiSurface::default(),
+            &ResolvedCrateConfig::default(),
+            &std::collections::HashSet::new(),
+            &OptionsFieldBridges::default(),
+            false,
+            &std::collections::HashMap::new(),
+        );
+        assert!(
+            regular.contains("def consume(self, payload: builtins.object) -> builtins.object"),
+            "regular class methods can shadow object annotations:\n{regular}"
+        );
+
+        let opaque = gen_opaque_type_stub(
+            &typ,
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+            None,
+        );
+        assert!(
+            opaque.contains("def consume(self, payload: builtins.object) -> builtins.object"),
+            "opaque class methods can shadow object annotations:\n{opaque}"
         );
     }
 

--- a/src/backends/pyo3/gen_stubs/enums.rs
+++ b/src/backends/pyo3/gen_stubs/enums.rs
@@ -1,4 +1,6 @@
-use super::{pyi_docstring, python_safe_name};
+use super::{
+    SHADOWABLE_BUILTIN_TYPES, pyi_docstring, python_safe_name, qualify_parameter_type, qualify_shadowed_builtin_types,
+};
 use crate::backends::pyo3::type_map::python_type;
 use crate::core::ir::{EnumDef, EnumVariant, TypeRef};
 use ahash::AHashSet;
@@ -193,8 +195,7 @@ fn gen_data_enum_variant_constructor_stubs(
         })
         .collect();
 
-    const SHADOWABLE_BUILTINS: &[&str] = &["list", "dict", "set", "tuple", "frozenset", "type"];
-    let shadowed: Vec<&str> = SHADOWABLE_BUILTINS
+    let shadowed: Vec<&str> = SHADOWABLE_BUILTIN_TYPES
         .iter()
         .copied()
         .filter(|b| ctors.iter().any(|c| c.snake_name == *b))
@@ -207,10 +208,9 @@ fn gen_data_enum_variant_constructor_stubs(
             .enumerate()
             .map(|(idx, p)| {
                 let optional = p.optional || crate::codegen::shared::is_promoted_optional(&ctor.params, idx);
-                let mut py_type = factory_param_type(&p.ty, coercible_dtos);
-                for builtin in &shadowed {
-                    py_type = py_type.replace(&format!("{builtin}["), &format!("builtins.{builtin}["));
-                }
+                let py_type = factory_param_type(&p.ty, coercible_dtos);
+                let py_type = qualify_parameter_type(&python_safe_name(&p.name), &py_type);
+                let py_type = qualify_shadowed_builtin_types(&py_type, &shadowed);
                 let py_type = if optional && !py_type.contains("| None") {
                     format!("{py_type} | None")
                 } else {

--- a/src/backends/pyo3/gen_stubs/enums/tests.rs
+++ b/src/backends/pyo3/gen_stubs/enums/tests.rs
@@ -7,6 +7,37 @@ fn no_dtos() -> AHashSet<&'static str> {
     AHashSet::new()
 }
 
+#[test]
+fn builtin_named_factory_qualifies_sibling_factory_annotations() {
+    let enum_def = EnumDef {
+        name: "BinaryPayload".to_string(),
+        variants: vec![
+            EnumVariant {
+                name: "Bytes".to_string(),
+                fields: vec![field("marker", TypeRef::Primitive(PrimitiveType::U8))],
+                ..Default::default()
+            },
+            EnumVariant {
+                name: "Data".to_string(),
+                fields: vec![field("payload", TypeRef::Bytes)],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let stub = gen_enum_stub(&enum_def, false, &no_dtos(), true);
+
+    assert!(
+        stub.contains("def bytes("),
+        "fixture must emit the shadowing factory:\n{stub}"
+    );
+    assert!(
+        stub.contains("payload: builtins.bytes"),
+        "factory names shadow builtin annotations across the enum class:\n{stub}"
+    );
+}
+
 fn field(name: &str, ty: TypeRef) -> FieldDef {
     FieldDef {
         version: Default::default(),

--- a/src/backends/pyo3/gen_stubs/functions.rs
+++ b/src/backends/pyo3/gen_stubs/functions.rs
@@ -1,4 +1,6 @@
-use super::{OptionsFieldBridges, is_python_builtin_name, python_safe_name, substitute_capsule_type};
+use super::{
+    OptionsFieldBridges, is_python_builtin_name, python_safe_name, qualify_parameter_type, substitute_capsule_type,
+};
 use crate::backends::pyo3::type_map::python_type;
 use crate::core::ir::{FunctionDef, TypeRef};
 
@@ -23,6 +25,7 @@ pub(super) fn gen_function_stub(
             } else {
                 substitute_capsule_type(&python_type(&p.ty), capsule_names)
             };
+            let type_str = qualify_parameter_type(&p.name, &type_str);
             if optional {
                 let param_type = if type_str.ends_with("| None") {
                     type_str
@@ -119,6 +122,33 @@ pub(super) fn gen_function_stub(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::ir::ParamDef;
+
+    #[test]
+    fn free_function_parameter_named_bytes_qualifies_its_builtin_annotation() {
+        let function = FunctionDef {
+            name: "decode".to_string(),
+            params: vec![ParamDef {
+                name: "bytes".to_string(),
+                ty: TypeRef::Bytes,
+                ..Default::default()
+            }],
+            return_type: TypeRef::String,
+            ..Default::default()
+        };
+
+        let stub = gen_function_stub(
+            &function,
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &OptionsFieldBridges::default(),
+            &std::collections::HashMap::new(),
+            &ahash::AHashSet::new(),
+        );
+
+        assert!(stub.contains("bytes: builtins.bytes"), "{stub}");
+        assert!(!stub.contains("bytes: bytes"), "{stub}");
+    }
 
     /// Free-function counterpart of `classes::tests::
     /// streaming_method_stub_keeps_a_plain_def_keyword_despite_method_is_async`: a streaming

--- a/src/backends/pyo3/gen_stubs/protocol.rs
+++ b/src/backends/pyo3/gen_stubs/protocol.rs
@@ -1,4 +1,7 @@
-use super::{pyi_docstring, python_safe_name, qualify_parameter_type, substitute_capsule_type};
+use super::{
+    SHADOWABLE_BUILTIN_TYPES, pyi_docstring, python_safe_name, qualify_parameter_type, qualify_shadowed_builtin_types,
+    substitute_capsule_type,
+};
 use crate::backends::pyo3::type_map::{python_callback_return_type, python_type};
 use crate::codegen::shared::substitute_excluded_types;
 use crate::core::config::TraitBridgeConfig;
@@ -46,6 +49,15 @@ pub(super) fn gen_visitor_protocol_stub(
     let is_plugin_bridge = bridge.register_fn.is_some();
     let (required, optional): (Vec<&crate::core::ir::MethodDef>, Vec<&crate::core::ir::MethodDef>) =
         methods.iter().partition(|m| !(is_plugin_bridge && m.has_default_impl));
+    let shadowed: Vec<&str> = SHADOWABLE_BUILTIN_TYPES
+        .iter()
+        .copied()
+        .filter(|builtin| {
+            required
+                .iter()
+                .any(|method| !method.binding_excluded && python_safe_name(&method.name) == *builtin)
+        })
+        .collect();
 
     let excluded: std::collections::HashSet<&str> = api
         .excluded_type_paths
@@ -122,6 +134,7 @@ pub(super) fn gen_visitor_protocol_stub(
                 ),
             };
             let param_type = qualify_parameter_type(&p.name, &param_type);
+            let param_type = qualify_shadowed_builtin_types(&param_type, &shadowed);
             params.push(format!("{}: {}", p.name, param_type));
         }
         // Return position: the host produces this value and the bridge extracts it, so it takes
@@ -151,6 +164,7 @@ pub(super) fn gen_visitor_protocol_stub(
                 capsule_names,
             )
         };
+        let return_type = qualify_shadowed_builtin_types(&return_type, &shadowed);
         let safe_name = python_safe_name(&method.name);
         let signature = format!("    def {}({}) -> {}: ...", safe_name, params.join(", "), return_type);
         lines.push(signature);
@@ -167,7 +181,7 @@ pub(super) fn gen_visitor_protocol_stub(
 mod tests {
     use crate::codegen::visitor_context::test_support::neutral_visitor_fixture;
     use crate::core::config::TraitBridgeConfig;
-    use crate::core::ir::ApiSurface;
+    use crate::core::ir::{ApiSurface, MethodDef, ParamDef, TypeRef};
     use ahash::AHashSet;
 
     /// The neutral fixture's context type is `TypeDef::default()`-shaped, so `is_clone` is
@@ -280,6 +294,116 @@ mod tests {
         assert!(
             !stub.contains("dict[str, object]"),
             "a plugin bridge has no visitor context fallback to describe:\n{stub}"
+        );
+    }
+
+    #[test]
+    fn protocol_method_named_bytes_qualifies_sibling_annotations() {
+        let (mut api, _, bridge) = neutral_visitor_fixture();
+        let trait_def = api
+            .types
+            .iter_mut()
+            .find(|type_def| type_def.name == bridge.trait_name)
+            .expect("neutral visitor fixture should include its trait");
+        trait_def.methods = vec![
+            MethodDef {
+                name: "bytes".to_string(),
+                return_type: TypeRef::Unit,
+                ..Default::default()
+            },
+            MethodDef {
+                name: "consume".to_string(),
+                params: vec![ParamDef {
+                    name: "payload".to_string(),
+                    ty: TypeRef::Bytes,
+                    ..Default::default()
+                }],
+                return_type: TypeRef::Bytes,
+                ..Default::default()
+            },
+        ];
+
+        let stub = render(&api, &bridge, &AHashSet::new());
+
+        assert!(
+            stub.contains("def bytes("),
+            "fixture must emit the shadowing method:\n{stub}"
+        );
+        assert!(
+            stub.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
+            "protocol methods share their class annotation scope:\n{stub}"
+        );
+    }
+
+    #[test]
+    fn protocol_method_named_object_qualifies_sibling_annotations() {
+        let (mut api, bridge) = class_path_fixture();
+        let trait_def = api
+            .types
+            .iter_mut()
+            .find(|type_def| type_def.name == bridge.trait_name)
+            .expect("neutral visitor fixture should include its trait");
+        trait_def.methods.insert(
+            0,
+            MethodDef {
+                name: "object".to_string(),
+                return_type: TypeRef::Unit,
+                has_default_impl: true,
+                ..Default::default()
+            },
+        );
+
+        let absent: AHashSet<String> = ["TraversalState".to_string()].into_iter().collect();
+        let stub = render(&api, &bridge, &absent);
+
+        assert!(
+            stub.contains("def object("),
+            "fixture must emit the shadowing method:\n{stub}"
+        );
+        assert!(
+            stub.contains("dict[str, builtins.object]"),
+            "Protocol method names shadow object annotations throughout the class:\n{stub}"
+        );
+
+        let Ok(pyrefly) = which::which("pyrefly") else {
+            return;
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("protocol.pyi");
+        std::fs::write(
+            dir.path().join("pyproject.toml"),
+            "[tool.pyrefly]\npreset = \"strict\"\nproject-includes = [\"*.pyi\"]\n",
+        )
+        .expect("write strict pyrefly config");
+        let source = format!("import builtins\nfrom typing import Protocol\nclass WalkOutcome: ...\n\n{stub}\n");
+        std::fs::write(&path, &source).expect("write generated Protocol stub");
+        let clean = std::process::Command::new(&pyrefly)
+            .arg("check")
+            .arg(dir.path())
+            .output()
+            .expect("run pyrefly on generated Protocol stub");
+        assert!(
+            clean.status.success(),
+            "qualified generated Protocol must pass pyrefly:\n{}{}",
+            String::from_utf8_lossy(&clean.stdout),
+            String::from_utf8_lossy(&clean.stderr)
+        );
+
+        std::fs::write(&path, source.replace("builtins.object", "object")).expect("write adversarial Protocol stub");
+        let broken = std::process::Command::new(pyrefly)
+            .arg("check")
+            .arg(dir.path())
+            .output()
+            .expect("run pyrefly negative control");
+        let diagnostics = format!(
+            "{}{}",
+            String::from_utf8_lossy(&broken.stdout),
+            String::from_utf8_lossy(&broken.stderr)
+        );
+        assert!(!broken.status.success(), "negative control must fail pyrefly");
+        assert!(
+            diagnostics.contains("[not-a-type]"),
+            "negative control must reproduce the object shadowing diagnostic:\n{diagnostics}"
         );
     }
 }

--- a/src/backends/pyo3/gen_stubs/protocol.rs
+++ b/src/backends/pyo3/gen_stubs/protocol.rs
@@ -1,4 +1,4 @@
-use super::{pyi_docstring, python_safe_name, substitute_capsule_type};
+use super::{pyi_docstring, python_safe_name, qualify_parameter_type, substitute_capsule_type};
 use crate::backends::pyo3::type_map::{python_callback_return_type, python_type};
 use crate::codegen::shared::substitute_excluded_types;
 use crate::core::config::TraitBridgeConfig;
@@ -121,6 +121,7 @@ pub(super) fn gen_visitor_protocol_stub(
                     capsule_names,
                 ),
             };
+            let param_type = qualify_parameter_type(&p.name, &param_type);
             params.push(format!("{}: {}", p.name, param_type));
         }
         // Return position: the host produces this value and the bridge extracts it, so it takes

--- a/src/backends/pyo3/template_env.rs
+++ b/src/backends/pyo3/template_env.rs
@@ -2,6 +2,10 @@ use minijinja::Environment;
 
 static TEMPLATES: &[(&str, &str)] = &[
     (
+        "from_json_method.jinja",
+        include_str!("templates/from_json_method.jinja"),
+    ),
+    (
         "trait_bridge/import_item.jinja",
         include_str!("templates/trait_bridge/import_item.jinja"),
     ),

--- a/src/backends/pyo3/template_env.rs
+++ b/src/backends/pyo3/template_env.rs
@@ -30,6 +30,10 @@ static TEMPLATES: &[(&str, &str)] = &[
         include_str!("templates/trait_bridge/options_from_native_helper.jinja"),
     ),
     (
+        "trait_bridge/options_from_json_method.jinja",
+        include_str!("templates/trait_bridge/options_from_json_method.jinja"),
+    ),
+    (
         "trait_bridge/indented_import_item.jinja",
         include_str!("templates/trait_bridge/indented_import_item.jinja"),
     ),
@@ -160,6 +164,10 @@ static TEMPLATES: &[(&str, &str)] = &[
     (
         "import_from_options.jinja",
         include_str!("templates/import_from_options.jinja"),
+    ),
+    (
+        "import_module_relative.jinja",
+        include_str!("templates/import_module_relative.jinja"),
     ),
     (
         "converters/signature_with_visitor.jinja",

--- a/src/backends/pyo3/templates/from_json_method.jinja
+++ b/src/backends/pyo3/templates/from_json_method.jinja
@@ -1,6 +1,6 @@
     #[staticmethod]
     fn from_json(json_str: String) -> pyo3::PyResult<Self> {
-        serde_json::from_str::<{{ core_type_path }}>(&json_str)
+        serde_json::from_str::<{{ core_type_path }}{% if has_lifetime_params %}<'static>{% endif %}>(&json_str)
             .map(Into::into)
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))
     }

--- a/src/backends/pyo3/templates/from_json_method.jinja
+++ b/src/backends/pyo3/templates/from_json_method.jinja
@@ -1,0 +1,6 @@
+    #[staticmethod]
+    fn from_json(json_str: String) -> pyo3::PyResult<Self> {
+        serde_json::from_str::<{{ core_type_path }}>(&json_str)
+            .map(Into::into)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))
+    }

--- a/src/backends/pyo3/templates/from_json_method.jinja
+++ b/src/backends/pyo3/templates/from_json_method.jinja
@@ -1,6 +1,6 @@
     #[staticmethod]
     fn from_json(json_str: String) -> pyo3::PyResult<Self> {
-        serde_json::from_str::<{{ core_type_path }}{% if has_lifetime_params %}<'static>{% endif %}>(&json_str)
+        serde_json::from_str::<{{ core_type_path }}{% if has_lifetime_params %}<'_>{% endif %}>(&json_str)
             .map(Into::into)
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))
     }

--- a/src/backends/pyo3/templates/import_module_relative.jinja
+++ b/src/backends/pyo3/templates/import_module_relative.jinja
@@ -1,0 +1,1 @@
+from . import {{ module_name }}

--- a/src/backends/pyo3/templates/trait_bridge/options_from_json_method.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/options_from_json_method.jinja
@@ -1,0 +1,5 @@
+    @staticmethod
+    def from_json(json_str: str) -> "{{ class_name }}":
+        """Build a `{{ class_name }}` from a JSON string, via the native binding."""
+        return {{ from_native_fn }}({{ module_name }}.{{ class_name }}.from_json(json_str))
+

--- a/src/bin_cli/all_commands.rs
+++ b/src/bin_cli/all_commands.rs
@@ -395,6 +395,14 @@ pub(crate) fn handle(command: Commands, context: &DispatchContext) -> Result<Opt
                 let scaffold_sweep_roots = pipeline::generate_sweep_roots(&languages, false, resolved_cfg, &base_dir);
                 pipeline::sweep_manifest_orphans(&previous_scaffold_paths, &scaffold_keep, &scaffold_sweep_roots, &[])?;
                 cache::write_scaffold_manifest(&resolved_cfg.name, &scaffold_output_paths)?;
+                // The same call `alef generate` and `alef scaffold` make after their own scaffold
+                // phase. Omitting it here left the three manifests `scaffold::repair` covers with
+                // two different contents for one tree, decided by which command last ran: a
+                // manifest whose wholesale write the ownership guard refused above stays stale
+                // under this command and gets patched under the other two. The repair is
+                // additive-only and, on a tree whose scaffold write succeeded, a no-op -- so
+                // running it here costs nothing and is the only way the commands can agree. ~keep
+                crate::scaffold::repair_missing_cfg_binding_features(&api, resolved_cfg, &languages);
 
                 tracing::info!("Running post-build processing...");
                 // A bare `?`/`return Err` here used to hard-stop the entire run: not just the

--- a/src/bin_cli/pyrefly_generated_package_tests.rs
+++ b/src/bin_cli/pyrefly_generated_package_tests.rs
@@ -87,6 +87,10 @@ impl Point {
             label: self.label.clone(),
         }
     }
+
+    pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Point {
+        Point::new(bytes.into().len() as i64, 0, None)
+    }
 }
 
 pub fn list_points(count: i64) -> Vec<Point> {
@@ -440,6 +444,12 @@ fn alef_all_generated_python_package_type_checks_clean_under_pyrefly() {
     assert!(
         api_py.is_file(),
         "sanity: alef all must have written api.py, got tree under {root:?}"
+    );
+    let stub = std::fs::read_to_string(root.join("packages/python/test_lib/test_lib.pyi"))
+        .expect("alef all must write the native module stub");
+    assert!(
+        stub.contains("bytes: builtins.bytes"),
+        "a Python-visible `bytes` parameter must keep its builtin type annotation resolvable:\n{stub}"
     );
     let project_dir = find_pyrefly_project_dir(&root);
 

--- a/src/bin_cli/pyrefly_generated_package_tests.rs
+++ b/src/bin_cli/pyrefly_generated_package_tests.rs
@@ -108,6 +108,24 @@ impl ByteContainer {
     }
 }
 
+#[derive(Default, Clone)]
+pub struct MethodShadow;
+
+impl MethodShadow {
+    pub fn bytes(&self) -> Vec<u8> {
+        Vec::new()
+    }
+
+    pub fn consume(&self, payload: Vec<u8>) -> Vec<u8> {
+        payload
+    }
+}
+
+pub enum BinaryPayload {
+    Bytes { marker: u8 },
+    Data { payload: Vec<u8> },
+}
+
 pub enum Shape {
     Circle { radius: f64 },
     Rectangle { width: f64, height: f64 },
@@ -465,6 +483,16 @@ fn alef_all_generated_python_package_type_checks_clean_under_pyrefly() {
     assert!(
         stub.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
         "a class field must qualify sibling method annotations in the same class scope:\n{stub}"
+    );
+    assert_eq!(
+        stub.matches("def consume(self, payload: builtins.bytes) -> builtins.bytes")
+            .count(),
+        2,
+        "both the field-shadowed and method-shadowed classes must qualify sibling annotations:\n{stub}"
+    );
+    assert!(
+        stub.contains("def data(payload: builtins.bytes) -> BinaryPayload"),
+        "a data-enum factory must qualify annotations shadowed by a sibling factory:\n{stub}"
     );
     let project_dir = find_pyrefly_project_dir(&root);
 

--- a/src/bin_cli/pyrefly_generated_package_tests.rs
+++ b/src/bin_cli/pyrefly_generated_package_tests.rs
@@ -97,6 +97,17 @@ pub fn list_points(count: i64) -> Vec<Point> {
     (0..count).map(|i| Point::new(i, i, None)).collect()
 }
 
+#[derive(Default, Clone)]
+pub struct ByteContainer {
+    pub bytes: Vec<u8>,
+}
+
+impl ByteContainer {
+    pub fn consume(&self, payload: Vec<u8>) -> Vec<u8> {
+        payload
+    }
+}
+
 pub enum Shape {
     Circle { radius: f64 },
     Rectangle { width: f64, height: f64 },
@@ -450,6 +461,10 @@ fn alef_all_generated_python_package_type_checks_clean_under_pyrefly() {
     assert!(
         stub.contains("bytes: builtins.bytes"),
         "a Python-visible `bytes` parameter must keep its builtin type annotation resolvable:\n{stub}"
+    );
+    assert!(
+        stub.contains("def consume(self, payload: builtins.bytes) -> builtins.bytes"),
+        "a class field must qualify sibling method annotations in the same class scope:\n{stub}"
     );
     let project_dir = find_pyrefly_project_dir(&root);
 

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -696,11 +696,21 @@ pub fn cfg_default_and_forwarding_lines(
 /// a purely additive `[features]` change cannot corrupt, reorder, or drop anything else in the
 /// file, so it is safe to apply on its own, narrower write path even when the guard would
 /// otherwise refuse the whole manifest. ~keep
+///
+/// `excluded_default_features` is the same per-language list every scaffolder feeds
+/// [`cfg_default_and_forwarding_lines`], and it binds here for the same reason: a name the
+/// binding's own config deliberately keeps out of `default` must not be put back by a later
+/// repair pass. Without it this function re-enabled exactly the names a scaffolder had just
+/// excluded, so the manifest a scaffold run wrote and the manifest a scaffold-plus-repair run
+/// wrote disagreed on `default` for every configured exclusion. An excluded name still gets its
+/// forwarding row (so `cargo build --features <name>` keeps working), matching the scaffolders'
+/// own treatment -- only the `default` array is held back. ~keep
 pub fn merge_missing_cfg_features(
     existing: &str,
     api: &ApiSurface,
     core_crate_name: &str,
     core_declared_features: &BTreeSet<String>,
+    excluded_default_features: &HashSet<&str>,
 ) -> anyhow::Result<Option<String>> {
     let mut doc = existing
         .parse::<toml_edit::DocumentMut>()
@@ -727,7 +737,11 @@ pub fn merge_missing_cfg_features(
         .filter(|feature| core_declared_features.contains(feature))
         .collect();
     let needs_declaration: BTreeSet<String> = referenced.difference(&declared).cloned().collect();
-    let needs_default: BTreeSet<String> = referenced.difference(&enabled_by_default).cloned().collect();
+    let needs_default: BTreeSet<String> = referenced
+        .difference(&enabled_by_default)
+        .filter(|name| !excluded_default_features.contains(name.as_str()))
+        .cloned()
+        .collect();
 
     if needs_declaration.is_empty() && needs_default.is_empty() {
         return Ok(None);

--- a/src/codegen/cfg/tests/mod.rs
+++ b/src/codegen/cfg/tests/mod.rs
@@ -669,6 +669,8 @@ struct MergeCase {
     existing: &'static str,
     gated_functions: &'static [(&'static str, Option<&'static str>)],
     core_declared_features: &'static [&'static str],
+    /// The binding's configured `excluded_default_features`, exactly as its scaffolder reads it.
+    excluded_default_features: &'static [&'static str],
     /// Substrings the patched output must contain. Empty when [`Self::expect_none`] is `true`.
     expect_contains: &'static [&'static str],
     /// Substrings that must survive verbatim -- proof the merge is additive-only, not a
@@ -690,6 +692,7 @@ fn merge_missing_cfg_features_table() {
                        [dependencies]\nserde = \"1\"\n",
             gated_functions: &[("count_tokens", Some(r#"feature = "tokenizer""#))],
             core_declared_features: &["native-http", "tokenizer"],
+            excluded_default_features: &[],
             expect_contains: &[
                 r#"tokenizer = ["core/tokenizer"]"#,
                 r#"default = ["native-http", "tokenizer"]"#,
@@ -708,6 +711,7 @@ fn merge_missing_cfg_features_table() {
                        tokenizer = [\"core/tokenizer\"]\n",
             gated_functions: &[("count_tokens", Some(r#"feature = "tokenizer""#))],
             core_declared_features: &["tokenizer"],
+            excluded_default_features: &[],
             expect_contains: &[],
             expect_preserved: &[r#"tokenizer = ["core/tokenizer"]"#],
             expect_none: true,
@@ -720,6 +724,7 @@ fn merge_missing_cfg_features_table() {
                        tokenizer = [\"core/tokenizer\"]\n",
             gated_functions: &[("count_tokens", Some(r#"feature = "tokenizer""#))],
             core_declared_features: &["native-http", "tokenizer"],
+            excluded_default_features: &[],
             expect_contains: &[r#"default = ["native-http", "tokenizer"]"#],
             expect_preserved: &[
                 r#"tokenizer = ["core/tokenizer"]"#,
@@ -732,6 +737,7 @@ fn merge_missing_cfg_features_table() {
             existing: "[package]\nname = \"x\"\nversion = \"0.1.0\"\n\n[dependencies]\nserde = \"1\"\n",
             gated_functions: &[("count_tokens", Some(r#"feature = "tokenizer""#))],
             core_declared_features: &["tokenizer"],
+            excluded_default_features: &[],
             expect_contains: &[
                 "[features]",
                 r#"tokenizer = ["core/tokenizer"]"#,
@@ -745,8 +751,22 @@ fn merge_missing_cfg_features_table() {
             existing: "[package]\nname = \"x\"\n\n[features]\ndefault = []\n",
             gated_functions: &[("count_tokens", Some(r#"feature = "tokenizer""#))],
             core_declared_features: &[],
+            excluded_default_features: &[],
             expect_contains: &[],
             expect_preserved: &["default = []"],
+            expect_none: true,
+        },
+        MergeCase {
+            name: "an excluded_default_features name already forwarded is not pushed back into default",
+            existing: "[package]\nname = \"x\"\n\n[features]\n\
+                       default = [\"native-http\"]\n\
+                       native-http = [\"core/native-http\"]\n\
+                       heic = [\"core/heic\"]\n",
+            gated_functions: &[("decode", Some(r#"feature = "heic""#))],
+            core_declared_features: &["native-http", "heic"],
+            excluded_default_features: &["heic"],
+            expect_contains: &[],
+            expect_preserved: &["default = [\"native-http\"]", r#"heic = ["core/heic"]"#],
             expect_none: true,
         },
     ];
@@ -755,7 +775,9 @@ fn merge_missing_cfg_features_table() {
         let api = api_with_gated_functions(case.gated_functions);
         let core_declared: BTreeSet<String> = case.core_declared_features.iter().map(|s| s.to_string()).collect();
 
-        let result = merge_missing_cfg_features(case.existing, &api, "core", &core_declared)
+        let excluded: HashSet<&str> = case.excluded_default_features.iter().copied().collect();
+
+        let result = merge_missing_cfg_features(case.existing, &api, "core", &core_declared, &excluded)
             .unwrap_or_else(|error| panic!("case `{}`: merge failed: {error}", case.name));
 
         if case.expect_none {
@@ -811,7 +833,7 @@ fn merge_missing_cfg_features_preserves_untouched_lines_verbatim() {
     let api = api_with_gated_functions(&[("count_tokens", Some(r#"feature = "tokenizer""#))]);
     let core_declared: BTreeSet<String> = ["native-http", "tokenizer"].into_iter().map(String::from).collect();
 
-    let patched = merge_missing_cfg_features(existing, &api, "core", &core_declared)
+    let patched = merge_missing_cfg_features(existing, &api, "core", &core_declared, &HashSet::new())
         .expect("merge must succeed")
         .expect("a missing feature must produce a patch");
 

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -630,7 +630,7 @@ pub mod cran {
 }
 
 pub mod precommit {
-    pub const ALEF_REV: &str = "v0.85.16";
+    pub const ALEF_REV: &str = "v0.85.17";
 
     /// Codegen format version — bumped only when output-affecting codegen
     /// changes require all generated files to be re-stamped. Unlike

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -202,8 +202,10 @@ pub mod cargo {
 
     // renovate: datasource=crate depName=walkdir
     pub const WALKDIR: &str = "2";
+
     /// gzip encoder for the generated mock server, so a fixture declaring
     /// `content-encoding: gzip` is served a genuinely encoded body. ~keep
+    // renovate: datasource=crate depName=flate2
     pub const FLATE2: &str = "1";
 
     /// brotli encoder for the generated mock server, so a fixture declaring

--- a/src/e2e/codegen/client/http_call.rs
+++ b/src/e2e/codegen/client/http_call.rs
@@ -99,8 +99,8 @@ pub fn render_http_test<R: TestClientRenderer + ?Sized>(out: &mut String, render
     for name in header_names {
         let value = &http.expected_response.headers[name];
         if name.eq_ignore_ascii_case("content-encoding") {
-            // Not because the mock layer strips it -- as of xberg-io/xberg#1598 the
-            // server gzip-encodes the body for real. Clients disagree about what
+            // Not because the mock layer strips it -- the generated mock server
+            // gzip-encodes the body for real. Clients disagree about what
             // survives transparent decompression: `fetch` decodes and leaves the
             // header in place, others remove it once decoded. Asserting the value
             // would test the client's behaviour rather than ours. The decompression

--- a/src/e2e/codegen/client/mod.rs
+++ b/src/e2e/codegen/client/mod.rs
@@ -169,7 +169,7 @@ pub fn is_skipped(fixture: &Fixture, language: &str) -> bool {
 /// `content-encoding`.
 ///
 /// `content-encoding` stays excluded, but no longer because the mock layer strips it --
-/// as of xberg-io/xberg#1598 the server encodes the body for real. It is excluded because
+/// the generated mock server now encodes the body for real. It is excluded because
 /// HTTP clients disagree about what survives transparent decompression: `fetch` decodes
 /// and leaves the header in place, while other clients remove it once the body is decoded.
 /// Asserting the value would therefore pass or fail on client behaviour rather than on

--- a/src/e2e/codegen/python/test_function.rs
+++ b/src/e2e/codegen/python/test_function.rs
@@ -161,10 +161,15 @@ pub(super) fn render_test_function(out: &mut String, fixture: &Fixture, context:
                 .get("python")
                 .and_then(|value| value.from_json_module.as_deref())
         });
-    // An explicitly selected native module has no public dataclass shadowing it, so neither the
-    // options type nor any argument type should be measured against the options-wrapped set. Compute
-    // it once and use the same answer for both decisions. ~keep
-    let shadowing_types = native_module
+    // An explicitly selected native module means the CALL's own options type has no public
+    // dataclass shadowing it, so that one type should not be measured against the
+    // options-wrapped set. This says nothing about any OTHER argument's type: a consumer's
+    // `from_json_module` override on a call exists to unshadow that call's options type, but
+    // a sibling argument can resolve to a completely different type that is still shadowed by
+    // `options.py`'s dataclass mirror regardless of where the options type is imported from.
+    // Gating the per-argument set on this override let every call with a `from_json_module`
+    // override skip the per-argument check entirely. ~keep
+    let call_options_type_shadowing = native_module
         .filter(|candidate| *candidate != helpers::resolve_module(e2e_config))
         .is_none()
         .then_some(options_wrapped_types);
@@ -174,9 +179,26 @@ pub(super) fn render_test_function(out: &mut String, fixture: &Fixture, context:
         type_defs,
         convertible_types,
         crate_has_serde,
-        shadowing_types,
+        call_options_type_shadowing,
     );
-    static NO_SHADOWED_TYPES: std::sync::LazyLock<HashSet<String>> = std::sync::LazyLock::new(HashSet::new);
+    // A `from_json_module` override that names a different module than the default resolves
+    // shadowing for the call's OWN options type only (that one type really is imported from the
+    // native module and really does have `from_json`). It says nothing about any OTHER
+    // argument's type, which stays shadowed by `options.py`'s dataclass mirror regardless of
+    // where the options type is imported from. Scope the exemption to that single type name
+    // rather than either the whole set (masks a sibling argument) or none of it (breaks the
+    // call's own options type, which has no public dataclass to fall back on). ~keep
+    let native_module_applies = native_module
+        .filter(|candidate| *candidate != helpers::resolve_module(e2e_config))
+        .is_some();
+    let from_json_unavailable_types: std::borrow::Cow<'_, HashSet<String>> =
+        if native_module_applies && effective_options_type.is_some_and(|name| options_wrapped_types.contains(name)) {
+            let mut narrowed = options_wrapped_types.clone();
+            narrowed.remove(effective_options_type.expect("checked above"));
+            std::borrow::Cow::Owned(narrowed)
+        } else {
+            std::borrow::Cow::Borrowed(options_wrapped_types)
+        };
 
     let desc_with_period = if description.ends_with('.') {
         description.to_string()
@@ -228,7 +250,7 @@ pub(super) fn render_test_function(out: &mut String, fixture: &Fixture, context:
         call_config,
         options_type: effective_options_type,
         options_via: effective_options_via,
-        from_json_unavailable_types: shadowing_types.unwrap_or(&NO_SHADOWED_TYPES),
+        from_json_unavailable_types: from_json_unavailable_types.as_ref(),
         enum_fields,
         handle_nested_types,
         handle_dict_types,
@@ -510,5 +532,109 @@ mod tests {
         render_test_function(&mut out, &fixture, context);
         assert!(out.contains("pytest.mark.skip"), "got: {out}");
         assert!(out.contains("not supported"), "got: {out}");
+    }
+
+    /// Pins the `extract`-shaped defect: a call whose options type (`ExtractionConfig`) has an
+    /// explicit `from_json_module` override must not let that override blanket-exempt a
+    /// *different* argument's type (`ExtractInput`) from the options-wrapped shadow check.
+    /// `ExtractInput` is still `options.py`'s method-less `@dataclass` mirror regardless of
+    /// where `ExtractionConfig` is imported from, so the `input` argument must fall back to a
+    /// plain constructor, not `ExtractInput.from_json(...)`. ~keep
+    #[test]
+    fn a_from_json_module_override_on_the_call_options_type_does_not_exempt_a_sibling_argument() {
+        use crate::e2e::config::{ArgMapping, CallConfig, CallOverride};
+        use crate::e2e::fixture::Fixture;
+
+        let fixture = Fixture {
+            docs: None,
+            requirements: Vec::new(),
+            id: "extract_from_bytes".to_string(),
+            description: "Extracts from raw bytes".to_string(),
+            input: serde_json::json!({ "input": { "kind": "bytes" } }),
+            http: None,
+            asyncapi: None,
+            websocket: None,
+            preserve_input_urls: false,
+            assertions: Vec::new(),
+            call: None,
+            skip: None,
+            env: None,
+            setup: Vec::new(),
+            visitor: None,
+            args: vec![ArgMapping {
+                name: "input".to_string(),
+                field: "input".to_string(),
+                arg_type: "json_object".to_string(),
+                optional: false,
+                owned: true,
+                element_type: Some("ExtractInput".to_string()),
+                go_type: None,
+                vec_inner_is_ref: false,
+                trait_name: None,
+            }],
+            assertion_recipes: vec![],
+            mock_response: None,
+            source: String::new(),
+            category: None,
+            tags: Vec::new(),
+        };
+
+        let python_override = CallOverride {
+            options_type: Some("ExtractionConfig".to_string()),
+            options_via: Some("from_json".to_string()),
+            from_json_module: Some("xberg._xberg".to_string()),
+            ..Default::default()
+        };
+
+        let mut call_config = CallConfig {
+            function: "extract".to_string(),
+            module: "xberg".to_string(),
+            ..Default::default()
+        };
+        call_config.overrides.insert("python".to_string(), python_override);
+
+        let e2e_config = crate::e2e::config::E2eConfig {
+            call: call_config.clone(),
+            ..Default::default()
+        };
+
+        let config = crate::core::config::ResolvedCrateConfig::default();
+        // `ExtractionConfig` is serde-derived and core<->binding convertible, so pyo3 actually
+        // injects `from_json` on it -- the call-level decision must survive down to "from_json"
+        // for this test to exercise the per-argument check rather than a call-level downgrade
+        // that would mask it.
+        let type_defs: Vec<crate::core::ir::TypeDef> = vec![crate::core::ir::TypeDef {
+            name: "ExtractionConfig".to_string(),
+            has_serde: true,
+            ..Default::default()
+        }];
+        let enums: Vec<crate::core::ir::EnumDef> = Vec::new();
+        let convertible_types = helpers::core_to_binding_convertible_types(&type_defs, &enums);
+        // `ExtractInput` has a public `@dataclass` mirror in `options.py`; `ExtractionConfig`
+        // does not (it is reexported natively), matching the real xberg configuration.
+        let options_wrapped_types: HashSet<String> = ["ExtractInput".to_string()].into_iter().collect();
+        let mut out = String::new();
+        let context = RenderTestFunctionContext {
+            e2e_config: &e2e_config,
+            config: &config,
+            type_defs: &type_defs,
+            enums: &enums,
+            functions: &[],
+            errors: &[],
+            options_type: None,
+            options_via: "kwargs",
+            enum_fields: &HashMap::new(),
+            handle_nested_types: &HashMap::new(),
+            handle_dict_types: &HashSet::new(),
+            force_bind_result: false,
+            convertible_types: &convertible_types,
+            crate_has_serde: true,
+            options_wrapped_types: &options_wrapped_types,
+        };
+        render_test_function(&mut out, &fixture, context);
+        assert!(
+            !out.contains("ExtractInput.from_json("),
+            "the shadowed argument type must not use from_json: got: {out}"
+        );
     }
 }

--- a/src/e2e/codegen/python/test_function/args.rs
+++ b/src/e2e/codegen/python/test_function/args.rs
@@ -27,12 +27,12 @@ pub(super) struct ArgSetupContext<'a> {
     /// so `from_json` does not exist on them.
     ///
     /// `options_via` is resolved ONCE for the whole call, against the call's options type -- but it
-    /// is then applied to every argument, and a call can mix the two spellings. xberg's `extract`
-    /// does: its config resolves to the native `ExtractionConfig` (which has `from_json`) while its
-    /// input resolves to the public `ExtractInput` dataclass (which does not), and every generated
-    /// Python e2e test died on `AttributeError: type object 'ExtractInput' has no attribute
-    /// 'from_json'`. Consulted per argument so one argument's eligibility cannot decide another's.
-    /// ~keep
+    /// is then applied to every argument, and a call can mix the two spellings. A measured consumer
+    /// call does: its config argument resolves to a native extension type (which has `from_json`)
+    /// while its input argument resolves to a public `options.py` dataclass mirror (which does
+    /// not), and every generated Python e2e test died on `AttributeError: type object '<Input>' has
+    /// no attribute 'from_json'`. Consulted per argument so one argument's eligibility cannot
+    /// decide another's. ~keep
     pub from_json_unavailable_types: &'a HashSet<String>,
     pub enum_fields: &'a HashMap<String, String>,
     pub handle_nested_types: &'a HashMap<String, String>,

--- a/src/e2e/codegen/ruby/enum_variant_access.rs
+++ b/src/e2e/codegen/ruby/enum_variant_access.rs
@@ -92,8 +92,8 @@ pub(super) fn classify(field_resolver: &FieldResolver, field: &str) -> RubyEnumA
 /// there unconditionally. Both of those need the hop.
 ///
 /// Emitting the wrong one of the three is a `KeyError` at runtime, in either direction — alef
-/// 0.85.11 taught the binding to flatten and left this generator emitting the `_0` hop, and xberg's
-/// Ruby suite was red from its 1.1.4 release onward. `union_variant_payload_is_tuple` and
+/// 0.85.11 taught the binding to flatten and left this generator emitting the `_0` hop, and a
+/// consumer's Ruby suite was red from its next release onward. `union_variant_payload_is_tuple` and
 /// `union_variant_payload` read the same IR the magnus backend reads, so the two cannot drift
 /// apart again without the flag itself changing meaning.
 ///

--- a/src/e2e/codegen/rust/cargo_toml.rs
+++ b/src/e2e/codegen/rust/cargo_toml.rs
@@ -201,7 +201,7 @@ pub fn render_cargo_toml(inputs: &CargoTomlInputs<'_>) -> String {
         if needs_mock_server {
             // The mock server gzip-encodes a body whose fixture declares
             // `content-encoding: gzip`, so the client-side decompression paths are
-            // actually reachable (xberg-io/xberg#1598). ~keep
+            // actually reachable. ~keep
             dep_entries.push((
                 "flate2".to_string(),
                 format!("flate2 = \"{flate2}\"", flate2 = tv::cargo::FLATE2),

--- a/src/e2e/codegen/rust/mock_server/runtime_server.rs
+++ b/src/e2e/codegen/rust/mock_server/runtime_server.rs
@@ -104,7 +104,7 @@ fn serve_route(route: &MockRoute) -> Response {
     // for every later test in the suite, not just the compression one. This server used to strip the header and serve plain bytes instead, which was
     // safe but left every client-side decompression branch unreachable in every suite --
     // so a compression regression in any binding's HTTP surface could not fail a single
-    // test (xberg-io/xberg#1598). An unsupported encoding is a hard error rather than a
+    // test. An unsupported encoding is a hard error rather than a
     // silent fallback to an unencoded body: serving plain bytes under a content-encoding
     // header is exactly the breakage the old strip existed to avoid, and a fixture asking
     // for an encoding this server cannot produce is a fixture bug that should be loud.

--- a/src/e2e/field_access/types.rs
+++ b/src/e2e/field_access/types.rs
@@ -336,7 +336,7 @@ pub struct IrEnumMap {
     /// predicate reads, so the Ruby e2e generator and the Ruby binding backend cannot disagree
     /// about which variants serde flattens. They did disagree once: alef 0.85.11 taught the
     /// binding to flatten and left the e2e generator emitting the `_0` hop, which turned every
-    /// tagged-enum payload assertion in xberg's Ruby suite into a `KeyError`. ~keep
+    /// tagged-enum payload assertion in a consumer's Ruby suite into a `KeyError`. ~keep
     pub variant_payload_tuple: HashMap<String, HashSet<String>>,
     /// `tagged_enum_wire[enum_name] -> (serde_tag, Rust variant -> serde wire value)`.
     /// Carries the exact discriminator spellings assertion generators need at runtime.

--- a/src/scaffold/repair.rs
+++ b/src/scaffold/repair.rs
@@ -27,6 +27,7 @@
 
 use crate::core::config::{Language, ResolvedCrateConfig};
 use crate::core::ir::ApiSurface;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// One Rust-emitting binding manifest this repair covers: the language it belongs to, its
@@ -35,25 +36,54 @@ use std::path::PathBuf;
 /// the row points at a dependency-table entry the manifest does not have. Ruby and Elixir key
 /// their forwarding rows off the raw, unmodified crate name; Dart keys off `[crates.dart]
 /// core_crate_override` when configured, otherwise the crate name with `-` replaced by `_` (see
-/// `backends::dart::gen_rust_crate::dart_core_dep_key`'s doc). ~keep
-fn managed_manifests(config: &ResolvedCrateConfig) -> Vec<(Language, PathBuf, String)> {
+/// `backends::dart::gen_rust_crate::dart_core_dep_key`'s doc).
+///
+/// The fourth element is that language's own `excluded_default_features`, read from the same
+/// config field its scaffolder reads. The repair has to honour it for the same reason the
+/// scaffolder does: a name the config deliberately keeps out of `default` must stay out, or this
+/// pass re-enables exactly what the scaffolder just excluded and the two disagree on disk. ~keep
+fn managed_manifests(config: &ResolvedCrateConfig) -> Vec<(Language, PathBuf, String, HashSet<&str>)> {
+    fn excluded(names: Option<&[String]>) -> HashSet<&str> {
+        names.unwrap_or_default().iter().map(String::as_str).collect()
+    }
+
     vec![
         (
             Language::Ruby,
             super::ruby_native_manifest_path(config),
             config.name.clone(),
+            excluded(config.ruby.as_ref().map(|c| c.excluded_default_features.as_slice())),
         ),
         (
             Language::Elixir,
             PathBuf::from(super::elixir_native_crate_dir(config)).join("Cargo.toml"),
             config.name.clone(),
+            excluded(config.elixir.as_ref().map(|c| c.excluded_default_features.as_slice())),
         ),
         (
             Language::Dart,
             crate::backends::dart::gen_rust_crate::dart_native_manifest_path(config),
             crate::backends::dart::gen_rust_crate::dart_core_dep_key(config),
+            excluded(config.dart.as_ref().map(|c| c.excluded_default_features.as_slice())),
         ),
     ]
+}
+
+/// The surface a binding backend actually emits from, given the surface this repair is handed.
+///
+/// `cli::pipeline::generate::generation::project_binding_api` drops every `binding_excluded`
+/// function before any backend sees the IR, so a manifest written by a backend declares features
+/// gated on the *projected* surface. This repair is called with the raw, unprojected surface --
+/// whose `#[cfg(feature = "...")]` gates include those of functions no binding ever emits -- so
+/// without the same projection it proposes forwarding rows for features nothing in the generated
+/// crate references, and the manifest a backend wrote and the manifest this pass leaves behind
+/// differ by exactly those names. Only the function retain is reproduced: the sibling projection
+/// step (`project_docs_without_unreachable_foreign_variants`) rewrites doc lines only and cannot
+/// change what `collect_cfg_features` finds. ~keep
+fn project_binding_surface(api: &ApiSurface) -> ApiSurface {
+    let mut projected = api.clone();
+    projected.functions.retain(|function| !function.binding_excluded);
+    projected
 }
 
 /// Add every cfg-forwarded feature the generated source for `languages` references but an
@@ -73,7 +103,8 @@ pub(crate) fn repair_missing_cfg_binding_features(
     languages: &[Language],
 ) -> Vec<PathBuf> {
     let mut repaired = Vec::new();
-    for (language, relative_manifest, core_dep_key) in managed_manifests(config) {
+    let projected = project_binding_surface(api);
+    for (language, relative_manifest, core_dep_key, excluded_default_features) in managed_manifests(config) {
         if !languages.contains(&language) {
             continue;
         }
@@ -100,7 +131,13 @@ pub(crate) fn repair_missing_cfg_binding_features(
             continue;
         };
         let core_declared_features = crate::codegen::cfg::core_crate_declared_features(config);
-        match crate::codegen::cfg::merge_missing_cfg_features(&existing, api, &core_dep_key, &core_declared_features) {
+        match crate::codegen::cfg::merge_missing_cfg_features(
+            &existing,
+            &projected,
+            &core_dep_key,
+            &core_declared_features,
+            &excluded_default_features,
+        ) {
             Ok(Some(patched)) => match std::fs::write(&manifest_path, &patched) {
                 Ok(()) => {
                     tracing::info!(

--- a/src/scaffold/tests/repair.rs
+++ b/src/scaffold/tests/repair.rs
@@ -185,6 +185,199 @@ fn repair_adds_missing_features_to_dart_manifest() {
     }
 }
 
+/// The Dart manifest must come out byte-identical whether or not this repair runs after the
+/// backend wrote it -- `alef all` had no repair call at all while `alef generate`/`alef scaffold`
+/// both made one, so one source tree produced two different `[features]` tables depending on
+/// which command was invoked.
+///
+/// Both halves of the divergence are staged here, because each one alone reproduces it:
+///
+/// * `hidden_gate` is `binding_excluded`, so `project_binding_api` drops it before any backend
+///   sees the IR and `internal-only` gates nothing the generated crate contains. The repair is
+///   handed the raw, unprojected surface, so without the matching projection it forwards a
+///   feature name no emitted file mentions.
+/// * `heic` is in `excluded_default_features`, so the backend deliberately writes its forwarding
+///   row while keeping it out of `default`. Without honouring that list the repair reads the
+///   absence as a defect and pushes the name straight back in, inverting the exclusion.
+///
+/// Mode A is the backend's own output on the projected surface (what `alef all` leaves on disk);
+/// mode B is that same file after the repair runs on the raw surface (what `alef generate` and
+/// `alef scaffold` leave on disk). They must agree. ~keep
+#[test]
+fn dart_manifest_is_identical_with_and_without_the_repair_pass() {
+    use crate::core::config::languages::DartConfig;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ws_root = dir.path();
+    let mut config = sample_config(ws_root);
+    config.dart = Some(DartConfig {
+        excluded_default_features: vec!["heic".to_string()],
+        ..Default::default()
+    });
+    let core_dir = ws_root.join("crates").join("sample-core");
+    std::fs::create_dir_all(&core_dir).expect("create core crate dir");
+    std::fs::write(
+        core_dir.join("Cargo.toml"),
+        "[package]\nname = \"sample-core\"\n\n[features]\n\
+         default = []\ntokenizer = []\ntower = []\nheic = []\ninternal-only = []\n",
+    )
+    .expect("write core Cargo.toml");
+
+    let mut api = sample_api();
+    api.functions.push(FunctionDef {
+        name: "decode_heic".to_string(),
+        rust_path: "sample_core::decode_heic".to_string(),
+        cfg: Some(r#"feature = "heic""#.to_string()),
+        ..Default::default()
+    });
+    api.functions.push(FunctionDef {
+        name: "hidden_gate".to_string(),
+        rust_path: "sample_core::hidden_gate".to_string(),
+        cfg: Some(r#"feature = "internal-only""#.to_string()),
+        binding_excluded: true,
+        ..Default::default()
+    });
+
+    let mut projected = api.clone();
+    projected.functions.retain(|function| !function.binding_excluded);
+
+    let dart_relative = crate::backends::dart::gen_rust_crate::dart_native_manifest_path(&config);
+    let rust_dir = dart_relative
+        .parent()
+        .expect("the Dart manifest has a parent")
+        .to_string_lossy()
+        .into_owned();
+    let source_crate_name = config.name.replace('-', "_");
+    let mode_a =
+        crate::backends::dart::gen_rust_crate::emit_cargo_toml(&rust_dir, &projected, &config, &source_crate_name)
+            .content;
+
+    let manifest_path = crate::codegen::cfg::resolve_against_workspace_root(&config, &dart_relative);
+    std::fs::create_dir_all(manifest_path.parent().expect("manifest has a parent")).expect("create manifest dir");
+    std::fs::write(&manifest_path, &mode_a).expect("write the backend's own manifest");
+
+    let repaired = repair_missing_cfg_binding_features(&api, &config, &[Language::Dart]);
+    let mode_b = std::fs::read_to_string(&manifest_path).expect("read the manifest after the repair pass");
+
+    // Control: the fixture must actually exercise both halves, or an equality assertion over two
+    // identical no-op paths would pass while proving nothing. ~keep
+    assert!(
+        mode_a.contains(r#"heic = ["sample_core/heic"]"#),
+        "control: the backend must forward the excluded feature, got:\n{mode_a}"
+    );
+    let default_line = mode_a
+        .lines()
+        .find(|line| line.starts_with("default = ["))
+        .expect("control: the backend must emit a default array");
+    assert!(
+        !default_line.contains("\"heic\""),
+        "control: the backend must keep the excluded feature out of default, got: {default_line}"
+    );
+    assert!(
+        !mode_a.contains("internal-only"),
+        "control: a binding_excluded function's gate must not reach the backend's manifest, got:\n{mode_a}"
+    );
+
+    let added: Vec<&str> = mode_b.lines().filter(|line| !mode_a.contains(*line)).collect();
+    assert!(
+        added.is_empty(),
+        "the repair pass added lines the backend's own manifest does not have, so `alef all` and \
+         `alef generate` disagree on this file: {added:#?}"
+    );
+    assert_eq!(
+        mode_b, mode_a,
+        "the Dart manifest must not depend on whether the repair pass ran -- `alef all` omits it \
+         while `alef generate`/`alef scaffold` run it, so any difference here is one source tree \
+         producing two different manifests"
+    );
+    assert!(
+        repaired.is_empty(),
+        "the repair must be a no-op on a manifest the backend just wrote, but it rewrote: {repaired:?}"
+    );
+}
+
+/// The Ruby and Elixir counterpart of the invariant above, and the regression guard on narrowing
+/// this repair's input surface: both scaffolders are handed the raw, unprojected surface, so the
+/// tables they write are a superset of anything the now-projected repair can reference. The
+/// repair must stay the permanent no-op it already is for these two -- a change that made it
+/// touch either manifest would rewrite committed consumer files this task's fix is required not
+/// to disturb. The fixture includes a `binding_excluded` gate and an `excluded_default_features`
+/// name for the same reason as the Dart case: both are what a naive input surface gets wrong. ~keep
+#[test]
+fn ruby_and_elixir_manifests_are_untouched_by_the_repair_pass() {
+    use crate::core::config::languages::RubyConfig;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ws_root = dir.path();
+    let mut config = sample_config(ws_root);
+    // `RubyConfig` has no `Default`, and a struct literal here would break on every future
+    // field; deserializing the one line that matters is what its own scaffolder tests do. ~keep
+    config.ruby = Some(
+        toml::from_str::<RubyConfig>("gem_name = \"sample_core\"\nexcluded_default_features = [\"heic\"]\n")
+            .expect("ruby config fixture"),
+    );
+    let core_dir = ws_root.join("crates").join("sample-core");
+    std::fs::create_dir_all(&core_dir).expect("create core crate dir");
+    std::fs::write(
+        core_dir.join("Cargo.toml"),
+        "[package]\nname = \"sample-core\"\n\n[features]\n\
+         default = []\ntokenizer = []\ntower = []\nheic = []\ninternal-only = []\n",
+    )
+    .expect("write core Cargo.toml");
+
+    let mut api = sample_api();
+    api.functions.push(FunctionDef {
+        name: "decode_heic".to_string(),
+        rust_path: "sample_core::decode_heic".to_string(),
+        cfg: Some(r#"feature = "heic""#.to_string()),
+        ..Default::default()
+    });
+    api.functions.push(FunctionDef {
+        name: "hidden_gate".to_string(),
+        rust_path: "sample_core::hidden_gate".to_string(),
+        cfg: Some(r#"feature = "internal-only""#.to_string()),
+        binding_excluded: true,
+        ..Default::default()
+    });
+
+    let scaffolded = crate::scaffold::scaffold_ruby_cargo(&api, &config)
+        .expect("ruby cargo scaffold")
+        .into_iter()
+        .chain(crate::scaffold::scaffold_elixir_cargo(&api, &config).expect("elixir cargo scaffold"))
+        .filter(|file| file.path.file_name().is_some_and(|name| name == "Cargo.toml"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        scaffolded.len(),
+        2,
+        "control: both the Ruby and the Elixir native manifest must be produced, got: {:?}",
+        scaffolded.iter().map(|file| file.path.clone()).collect::<Vec<_>>()
+    );
+
+    let mut before: Vec<(PathBuf, String)> = Vec::new();
+    for file in &scaffolded {
+        let path = crate::codegen::cfg::resolve_against_workspace_root(&config, &file.path);
+        std::fs::create_dir_all(path.parent().expect("manifest has a parent")).expect("create manifest dir");
+        std::fs::write(&path, &file.content).expect("write the scaffolder's own manifest");
+        before.push((path, file.content.clone()));
+    }
+
+    let repaired = repair_missing_cfg_binding_features(&api, &config, &[Language::Ruby, Language::Elixir]);
+
+    assert!(
+        repaired.is_empty(),
+        "the repair must not touch a Ruby or Elixir manifest their own scaffolders just wrote, \
+         but it rewrote: {repaired:?}"
+    );
+    for (path, original) in before {
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read manifest after the repair pass"),
+            original,
+            "{} must be byte-for-byte unchanged by the repair pass",
+            path.display()
+        );
+    }
+}
+
 /// A language absent from the requested set must not have its manifest touched, even though it
 /// is equally missing the feature -- scaffolding one language must never write another's files.
 #[test]

--- a/tests/backends_go_gen_bindings_test.rs
+++ b/tests/backends_go_gen_bindings_test.rs
@@ -218,7 +218,7 @@ fn test_basic_generation() {
         "Should call FFI error code function"
     );
     assert!(
-        content.contains("if ctx == nil {\n\t\treturn fmt.Errorf(\"[%d] native error\", code)\n\t}"),
+        content.contains("if message == \"\" {\n\t\treturn fmt.Errorf(\"[%d] native error\", code)\n\t}"),
         "lastError must tolerate a nonzero error code with no context pointer"
     );
 
@@ -893,6 +893,77 @@ fn test_error_types() {
     assert!(
         content.contains("GoError") || content.contains("lastError"),
         "Should generate error-related code"
+    );
+}
+
+#[test]
+fn coded_error_keeps_the_native_message_and_still_matches_its_sentinel() {
+    let backend = GoBackend;
+
+    let api = ApiSurface {
+        crate_name: "test-lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![],
+        functions: vec![],
+        enums: vec![],
+        errors: vec![ErrorDef {
+            name: "GoError".to_string(),
+            rust_path: "test_lib::GoError".to_string(),
+            original_rust_path: String::new(),
+            variants: vec![ErrorVariant {
+                name: "Timeout".to_string(),
+                error_code: Some(1014),
+                fields: vec![
+                    make_field("elapsed_ms", TypeRef::String, false),
+                    make_field("limit_ms", TypeRef::String, false),
+                ],
+                doc: "Extraction timed out".to_string(),
+                message_template: Some("Extraction timed out after {elapsed_ms}ms (limit: {limit_ms}ms)".to_string()),
+                has_source: false,
+                has_from: false,
+                is_unit: false,
+                is_tuple: false,
+            }],
+            doc: "Error type for library".to_string(),
+            methods: vec![],
+            binding_excluded: false,
+            binding_exclusion_reason: None,
+            version: Default::default(),
+        }],
+        excluded_type_paths: ::std::collections::BTreeMap::new(),
+        excluded_trait_names: ::std::collections::HashSet::new(),
+        services: vec![],
+        handler_contracts: vec![],
+        unsupported_public_items: Vec::new(),
+    };
+
+    let files = backend
+        .generate_bindings(&api, &make_config())
+        .expect("Generation should succeed");
+    let content = &files[0].content;
+
+    assert!(
+        content.contains("sentinel = ErrTimeout"),
+        "the coded variant must still resolve to its sentinel: {content}"
+    );
+    assert!(
+        !content.contains("case 1014:\n\t\treturn ErrTimeout"),
+        "returning the bare sentinel discards the native message"
+    );
+    assert!(
+        content.contains("return &nativeError{sentinel: sentinel, message: message}"),
+        "a coded error carrying a context message must surface that message"
+    );
+    assert!(
+        content.contains("func (e *nativeError) Unwrap() error { return e.sentinel }"),
+        "errors.Is must keep matching the sentinel through Unwrap"
+    );
+
+    let context_read = content.find("C.test_last_error_context()").expect("reads context");
+    let switch_start = content.find("\tswitch code {").expect("emits the code switch");
+    assert!(
+        context_read < switch_start,
+        "the context must be read before the switch, or coded errors return early and lose it"
     );
 }
 

--- a/tests/backends_java_gen_bindings_test.rs
+++ b/tests/backends_java_gen_bindings_test.rs
@@ -350,12 +350,13 @@ fn bool_function_uses_widened_long_ffi_layout_and_boolean_wrapper_result() {
     );
     assert!(!native_lib.contains("ValueLayout.JAVA_BOOLEAN"));
     assert!(
-        main_class.contains("var primitiveResult = (long) NativeLib.TEST_IS_READY.invoke((enabled ? 1 : 0));"),
-        "wrapper must unbox the bool result as long, got:\n{main_class}"
+        main_class.contains("var primitiveResult = (int)(long) NativeLib.TEST_IS_READY.invoke((enabled ? 1 : 0));"),
+        "wrapper must unbox the bool result as long and narrow it to int before the != 0 test, \
+         because the native side returns int32_t under the widened JAVA_LONG layout, got:\n{main_class}"
     );
     assert!(
         main_class.contains("return primitiveResult != 0;"),
-        "safe wrapper must convert the long bool result to boolean, got:\n{main_class}"
+        "safe wrapper must convert the narrowed bool result to boolean, got:\n{main_class}"
     );
 }
 

--- a/tests/backends_pyo3_gen_stubs_test.rs
+++ b/tests/backends_pyo3_gen_stubs_test.rs
@@ -1816,7 +1816,7 @@ fn test_opaque_type_with_constructor_emits_init_stub() {
 languages = ["python"]
 
 [workspace.client_constructors.DefaultClient]
-body = "{source_path}::new(api_key, base_url)"
+body = "{source_path}::new(api_key, base_url, bytes)"
 
 [[workspace.client_constructors.DefaultClient.params]]
 name = "api_key"
@@ -1825,6 +1825,10 @@ type = "&str"
 [[workspace.client_constructors.DefaultClient.params]]
 name = "base_url"
 type = "String"
+
+[[workspace.client_constructors.DefaultClient.params]]
+name = "bytes"
+type = "Vec<u8>"
 
 [[crates]]
 name = "test-lib"
@@ -1846,8 +1850,8 @@ output = "packages/python/src/"
     let content = result.unwrap().into_iter().next().unwrap().content;
 
     assert!(
-        content.contains("def __init__(self, api_key: str, base_url: str) -> None: ..."),
-        "opaque type with constructor must emit __init__ stub. Got:\n{content}"
+        content.contains("bytes: builtins.bytes"),
+        "opaque constructor parameters must keep shadowed builtin annotations resolvable. Got:\n{content}"
     );
 
     assert!(

--- a/tests/e2e_zig_c_string_span_fix.rs
+++ b/tests/e2e_zig_c_string_span_fix.rs
@@ -130,7 +130,22 @@ result_is_json_struct = true
     );
 }
 
-/// Verify that _result_json is passed directly to allocPrint without std.mem.span.
+/// The `interact` function name, which used to be special-cased into a JSON wrapper.
+///
+/// `eb5cd0a98` deleted that special case: `render_test_fn` matched the *called function's name*
+/// against a hard-coded `"interact" => Some("interaction")` and, on a hit, emitted a
+/// `std.fmt.allocPrint` that re-wrapped the binding's own JSON under an invented `interaction`
+/// key before parsing it. The binding never produced that shape, so the accessor chain it
+/// existed to satisfy was addressing a key alef had just fabricated. `interaction.` is a virtual
+/// namespace label that every other backend strips; zig was alone in materialising it.
+///
+/// This test used to require that `allocPrint`, which is why it outlived the fix: it asserted the
+/// *span-free* spelling of the wrapper rather than the wrapper's existence, so deleting the
+/// wrapper left it demanding emitted text nothing emits any more. It now asserts what the
+/// surviving `interact` path must actually do, and the no-wrapper half is pinned in its own right
+/// by `e2e::codegen::zig::result_is_json_struct_ir_tests::
+/// json_result_is_not_wrapped_based_on_function_name`, which covers `process` and `interact`
+/// together so the name-based branch cannot come back for one name only. ~keep
 #[test]
 fn result_slice_passed_directly_in_format_string() {
     let toml = format!(
@@ -161,15 +176,16 @@ result_is_json_struct = true
 
     assert!(
         !rendered.contains("std.mem.span(_result_json)"),
-        "must NOT wrap _result_json with std.mem.span in format string. Rendered:\n{rendered}"
+        "must NOT wrap _result_json with std.mem.span on the interact path. Rendered:\n{rendered}"
     );
     assert!(
-        rendered.contains("allocPrint"),
-        "interact path should use allocPrint to build wrapped JSON. Rendered:\n{rendered}"
+        rendered.contains("parseFromSlice(std.json.Value, allocator, _result_json"),
+        "the interact path must parse the binding's own slice directly. Rendered:\n{rendered}"
     );
     assert!(
-        rendered.contains("allocPrint(allocator, \"") && rendered.contains("_result_json"),
-        "allocPrint should receive _result_json directly without std.mem.span. Rendered:\n{rendered}"
+        !rendered.contains("_wrapped_json"),
+        "`interact` must not be special-cased into an invented `interaction` JSON wrapper. \
+         Rendered:\n{rendered}"
     );
 }
 


### PR DESCRIPTION
PyO3 `from_json` now deserializes through each DTO's authoritative core Rust path before converting to the wrapper, preserving core fields marked `serde(skip)` and supporting nested, external, and borrowing DTOs with inferred lifetimes. Generated Python stubs also qualify built-in annotation types when class fields, methods, parameters, enum factories, Protocol methods, or opaque types shadow their names.

Validation: 243 PyO3 tests, 26 stub integration tests, real generated borrowing-crate compilation, strict generated-package Pyrefly, poly format/lint and pre-commit gates pass. Independent review passed after adversarial shadowing controls. The remaining Windows Kotlin CI failure is unrelated and tracked in #376.

Refs xberg-io/xberg-enterprise#1864.
