### PR TITLE
fix(test): repair compiler oracles across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve the Kotlin compiler launcher for identifier grammar probes and compilation on Windows,
+  and fail required-mode availability checks instead of silently skipping.
+
 ## [0.85.16] - 2026-09-11
 
 ### Fixed

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -204,6 +204,7 @@ pub mod cargo {
     pub const WALKDIR: &str = "2";
     /// gzip encoder for the generated mock server, so a fixture declaring
     /// `content-encoding: gzip` is served a genuinely encoded body. ~keep
+    // renovate: datasource=crate depName=flate2
     pub const FLATE2: &str = "1";
 
     /// brotli encoder for the generated mock server, so a fixture declaring

--- a/src/e2e/codegen/client/http_call.rs
+++ b/src/e2e/codegen/client/http_call.rs
@@ -99,7 +99,7 @@ pub fn render_http_test<R: TestClientRenderer + ?Sized>(out: &mut String, render
     for name in header_names {
         let value = &http.expected_response.headers[name];
         if name.eq_ignore_ascii_case("content-encoding") {
-            // Not because the mock layer strips it -- as of xberg-io/xberg#1598 the
+            // Not because the mock layer strips it -- the
             // server gzip-encodes the body for real. Clients disagree about what
             // survives transparent decompression: `fetch` decodes and leaves the
             // header in place, others remove it once decoded. Asserting the value

--- a/src/e2e/codegen/client/mod.rs
+++ b/src/e2e/codegen/client/mod.rs
@@ -169,7 +169,7 @@ pub fn is_skipped(fixture: &Fixture, language: &str) -> bool {
 /// `content-encoding`.
 ///
 /// `content-encoding` stays excluded, but no longer because the mock layer strips it --
-/// as of xberg-io/xberg#1598 the server encodes the body for real. It is excluded because
+/// the server encodes the body for real. It is excluded because
 /// HTTP clients disagree about what survives transparent decompression: `fetch` decodes
 /// and leaves the header in place, while other clients remove it once the body is decoded.
 /// Asserting the value would therefore pass or fail on client behaviour rather than on

--- a/src/e2e/codegen/python/test_function/args.rs
+++ b/src/e2e/codegen/python/test_function/args.rs
@@ -27,8 +27,8 @@ pub(super) struct ArgSetupContext<'a> {
     /// so `from_json` does not exist on them.
     ///
     /// `options_via` is resolved ONCE for the whole call, against the call's options type -- but it
-    /// is then applied to every argument, and a call can mix the two spellings. xberg's `extract`
-    /// does: its config resolves to the native `ExtractionConfig` (which has `from_json`) while its
+    /// is then applied to every argument, and a call can mix the two spellings. A downstream call
+    /// does: its config resolves to a native options type (which has `from_json`) while its
     /// input resolves to the public `ExtractInput` dataclass (which does not), and every generated
     /// Python e2e test died on `AttributeError: type object 'ExtractInput' has no attribute
     /// 'from_json'`. Consulted per argument so one argument's eligibility cannot decide another's.
@@ -455,7 +455,7 @@ mod tests {
     }
 
     /// `options_via` is resolved once per call, against the CALL's options type, then applied to
-    /// every argument. xberg's `extract` mixes the two spellings -- a native `ExtractionConfig`
+    /// every argument. A downstream call mixes the two spellings -- a native options type
     /// that has `from_json` and a public `ExtractInput` dataclass that does not -- so every
     /// generated Python e2e test raised `AttributeError: type object 'ExtractInput' has no
     /// attribute 'from_json'`, and the whole suite was red.

--- a/src/e2e/codegen/ruby/enum_variant_access.rs
+++ b/src/e2e/codegen/ruby/enum_variant_access.rs
@@ -92,8 +92,8 @@ pub(super) fn classify(field_resolver: &FieldResolver, field: &str) -> RubyEnumA
 /// there unconditionally. Both of those need the hop.
 ///
 /// Emitting the wrong one of the three is a `KeyError` at runtime, in either direction — alef
-/// 0.85.11 taught the binding to flatten and left this generator emitting the `_0` hop, and xberg's
-/// Ruby suite was red from its 1.1.4 release onward. `union_variant_payload_is_tuple` and
+/// 0.85.11 taught the binding to flatten and left this generator emitting the `_0` hop, breaking a
+/// downstream Ruby suite. `union_variant_payload_is_tuple` and
 /// `union_variant_payload` read the same IR the magnus backend reads, so the two cannot drift
 /// apart again without the flag itself changing meaning.
 ///
@@ -396,7 +396,7 @@ mod tests {
     /// `#[serde(flatten)]` on a TUPLE variant's field when the enum is internally tagged, so the
     /// payload lands beside the discriminator and there is no wrapper Hash to hop through. Emitting
     /// the hop anyway raises `KeyError: key not found: :_0` against the real binding, which is what
-    /// xberg's Ruby suite did from its 1.1.4 release onward.
+    /// a downstream Ruby suite did with flattened tuple variants.
     #[test]
     fn render_assertion_omits_the_wrapper_hop_for_a_flattened_tuple_variant() {
         let out = render("summary.encoding.spreadsheet.sheet_count");

--- a/src/e2e/codegen/rust/cargo_toml.rs
+++ b/src/e2e/codegen/rust/cargo_toml.rs
@@ -201,7 +201,7 @@ pub fn render_cargo_toml(inputs: &CargoTomlInputs<'_>) -> String {
         if needs_mock_server {
             // The mock server gzip-encodes a body whose fixture declares
             // `content-encoding: gzip`, so the client-side decompression paths are
-            // actually reachable (xberg-io/xberg#1598). ~keep
+            // actually reachable. ~keep
             dep_entries.push((
                 "flate2".to_string(),
                 format!("flate2 = \"{flate2}\"", flate2 = tv::cargo::FLATE2),

--- a/src/e2e/codegen/rust/mock_server/runtime_server.rs
+++ b/src/e2e/codegen/rust/mock_server/runtime_server.rs
@@ -104,7 +104,7 @@ fn serve_route(route: &MockRoute) -> Response {
     // for every later test in the suite, not just the compression one. This server used to strip the header and serve plain bytes instead, which was
     // safe but left every client-side decompression branch unreachable in every suite --
     // so a compression regression in any binding's HTTP surface could not fail a single
-    // test (xberg-io/xberg#1598). An unsupported encoding is a hard error rather than a
+    // test. An unsupported encoding is a hard error rather than a
     // silent fallback to an unencoded body: serving plain bytes under a content-encoding
     // header is exactly the breakage the old strip existed to avoid, and a fixture asking
     // for an encoding this server cannot produce is a fixture bug that should be loud.

--- a/src/e2e/field_access/types.rs
+++ b/src/e2e/field_access/types.rs
@@ -336,7 +336,7 @@ pub struct IrEnumMap {
     /// predicate reads, so the Ruby e2e generator and the Ruby binding backend cannot disagree
     /// about which variants serde flattens. They did disagree once: alef 0.85.11 taught the
     /// binding to flatten and left the e2e generator emitting the `_0` hop, which turned every
-    /// tagged-enum payload assertion in xberg's Ruby suite into a `KeyError`. ~keep
+    /// tagged-enum payload assertion in a downstream Ruby suite into a `KeyError`. ~keep
     pub variant_payload_tuple: HashMap<String, HashSet<String>>,
     /// `tagged_enum_wire[enum_name] -> (serde_tag, Rust variant -> serde wire value)`.
     /// Carries the exact discriminator spellings assertion generators need at runtime.

--- a/tests/backends_java_gen_bindings_test.rs
+++ b/tests/backends_java_gen_bindings_test.rs
@@ -350,12 +350,12 @@ fn bool_function_uses_widened_long_ffi_layout_and_boolean_wrapper_result() {
     );
     assert!(!native_lib.contains("ValueLayout.JAVA_BOOLEAN"));
     assert!(
-        main_class.contains("var primitiveResult = (long) NativeLib.TEST_IS_READY.invoke((enabled ? 1 : 0));"),
-        "wrapper must unbox the bool result as long, got:\n{main_class}"
+        main_class.contains("var primitiveResult = (int)(long) NativeLib.TEST_IS_READY.invoke((enabled ? 1 : 0));"),
+        "wrapper must unbox the bool result as long and narrow it to int, got:\n{main_class}"
     );
     assert!(
         main_class.contains("return primitiveResult != 0;"),
-        "safe wrapper must convert the long bool result to boolean, got:\n{main_class}"
+        "safe wrapper must convert the narrowed bool result to boolean, got:\n{main_class}"
     );
 }
 

--- a/tests/cli_version_ffi_rebuild.rs
+++ b/tests/cli_version_ffi_rebuild.rs
@@ -201,9 +201,15 @@ fn changed_ffi_source_rebuilds_even_when_no_version_moves() {
         "a broken bridge was reported as a successful sync: {output:?}"
     );
     let diagnostics = String::from_utf8_lossy(&output.stderr);
+    let expected_command = format!(
+        "cargo build --manifest-path {}",
+        Path::new("packages/ffi").join("Cargo.toml").display()
+    );
     assert!(
-        diagnostics.contains("Rebuilding FFI to refresh C headers"),
-        "the bridge edit did not even trigger a rebuild attempt: {diagnostics}"
+        diagnostics.contains("broken bridge")
+            && diagnostics.contains("compile_error!")
+            && diagnostics.contains(&expected_command),
+        "the bridge edit did not trigger the expected failed compilation: {diagnostics}"
     );
 
     // And it must stay failed: a retry cannot resurrect the invalidated success.
@@ -228,12 +234,14 @@ fn unchanged_ffi_source_still_skips_the_rebuild() {
     .expect("FFI manifest");
     fs::write(root.join("packages/ffi/src/lib.rs"), "pub fn bridge() {}\n").expect("FFI source");
     assert!(run(root).status.success());
+    let artifact = root.join("target/debug/libcustom_bridge.rlib");
+    assert!(artifact.is_file(), "initial sync did not build the bridge");
+    fs::remove_file(&artifact).expect("remove only the compiled artifact");
 
     let second = run(root);
     assert!(second.status.success(), "{second:?}");
-    let diagnostics = String::from_utf8_lossy(&second.stderr);
     assert!(
-        !diagnostics.contains("Rebuilding FFI to refresh C headers"),
-        "an unchanged bridge was rebuilt anyway: {diagnostics}"
+        !artifact.exists(),
+        "an unchanged bridge was rebuilt despite its recorded source fingerprint"
     );
 }

--- a/tests/e2e_zig_c_string_span_fix.rs
+++ b/tests/e2e_zig_c_string_span_fix.rs
@@ -5,7 +5,7 @@
 //! "invalid type given to std.mem.span: []u8"
 //!
 //! The wrapper always converts the FFI return value to []u8 before returning
-//! to the test, so e2e tests pass slices directly to parseFromSlice and allocPrint.
+//! to the test, so e2e tests pass slices directly to parseFromSlice.
 
 use alef::core::config::NewAlefConfig;
 use alef::e2e::codegen::E2eCodegen;
@@ -130,9 +130,9 @@ result_is_json_struct = true
     );
 }
 
-/// Verify that _result_json is passed directly to allocPrint without std.mem.span.
+/// Returned JSON preserves its shape and is parsed directly as an owned slice. ~keep
 #[test]
-fn result_slice_passed_directly_in_format_string() {
+fn result_slice_preserves_json_shape_for_interact() {
     let toml = format!(
         r#"{}
 [crates.e2e.call.overrides.zig]
@@ -161,15 +161,19 @@ result_is_json_struct = true
 
     assert!(
         !rendered.contains("std.mem.span(_result_json)"),
-        "must NOT wrap _result_json with std.mem.span in format string. Rendered:\n{rendered}"
+        "must NOT wrap the owned _result_json slice with std.mem.span. Rendered:\n{rendered}"
     );
     assert!(
-        rendered.contains("allocPrint"),
-        "interact path should use allocPrint to build wrapped JSON. Rendered:\n{rendered}"
+        rendered.contains("parseFromSlice(std.json.Value, allocator, _result_json, .{})")
+            && rendered.contains("defer std.heap.c_allocator.free(_result_json);"),
+        "interact must parse and release the returned slice directly. Rendered:\n{rendered}"
     );
     assert!(
-        rendered.contains("allocPrint(allocator, \"") && rendered.contains("_result_json"),
-        "allocPrint should receive _result_json directly without std.mem.span. Rendered:\n{rendered}"
+        !rendered.contains("_wrapped_json")
+            && !rendered.contains("allocPrint")
+            && rendered.contains("result.object.get(\"interaction\").?.object.get(\"action_results\").?")
+            && rendered.contains("try testing.expect(std.mem.indexOf(u8, _js, \"success\") != null);"),
+        "interact must preserve the returned JSON shape for nested assertions. Rendered:\n{rendered}"
     );
 }
 

--- a/tests/identifier_grammar_compiler_oracle.rs
+++ b/tests/identifier_grammar_compiler_oracle.rs
@@ -69,9 +69,13 @@ fn probe_segments() -> Vec<(String, String)> {
     segments
 }
 
+fn kotlin_compiler_command() -> Command {
+    alef::core::tool_command("kotlinc")
+}
+
 fn tool_available(tool: &str) -> bool {
     let version_flag = if tool == "kotlinc" { "-version" } else { "--version" };
-    Command::new(tool)
+    alef::core::tool_command(tool)
         .arg(version_flag)
         .output()
         .map(|output| output.status.success())
@@ -86,15 +90,19 @@ fn tool_available(tool: &str) -> bool {
 /// check here would leave the skip unreachable and fail the assertion below on every machine
 /// that has the shim but not a real kotlinc. ~keep
 fn kotlinc_is_genuinely_installed() -> bool {
-    Command::new("kotlinc")
-        .arg("-version")
-        .output()
-        .is_ok_and(|output| output.status.success())
+    which::which("kotlinc")
+        .ok()
+        .and_then(|path| Command::new(path).arg("-version").output().ok())
+        .is_some_and(|output| output.status.success())
 }
 
 #[test]
 fn installed_kotlinc_is_detected_by_the_availability_probe() {
     if !kotlinc_is_genuinely_installed() {
+        assert!(
+            std::env::var_os("ALEF_REQUIRE_KOTLINC").is_none(),
+            "ALEF_REQUIRE_KOTLINC is set but kotlinc is unavailable"
+        );
         eprintln!("SKIPPED: kotlinc is not installed; its availability probe was not verified");
         return;
     }
@@ -340,7 +348,7 @@ fn kotlinc_agrees_with_validate_kotlin_package() {
         format!("package probe.{segment}\nclass {class}\n")
     });
 
-    let mut command = Command::new("kotlinc");
+    let mut command = kotlin_compiler_command();
     command.arg("-d").arg(dir.path().join("out")).current_dir(&sources);
     for (index, _) in probe_segments().iter().enumerate() {
         command.arg(format!("P{index:04}.kt"));
@@ -424,4 +432,100 @@ fn ci_installs_and_requires_kotlinc_for_runtime_regressions() {
     let workflow = include_str!("../.github/workflows/ci.yml");
     assert!(workflow.contains("uses: fwilhe2/setup-kotlin@"));
     assert!(workflow.contains("ALEF_REQUIRE_KOTLINC: \"1\""));
+}
+
+#[test]
+fn required_installed_kotlinc_probe_cannot_skip_when_the_launcher_is_missing() {
+    let empty_path = tempfile::tempdir().expect("create empty PATH");
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--exact",
+            "installed_kotlinc_is_detected_by_the_availability_probe",
+            "--nocapture",
+        ])
+        .env("PATH", empty_path.path())
+        .env("ALEF_REQUIRE_KOTLINC", "1")
+        .output()
+        .expect("run required probe without kotlinc");
+    let diagnostics = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "required probe silently skipped: {diagnostics}"
+    );
+    assert!(diagnostics.contains("ALEF_REQUIRE_KOTLINC is set"), "{diagnostics}");
+}
+
+#[test]
+fn kotlin_probe_and_compile_use_the_resolved_launcher_with_spaces() {
+    let directory = tempfile::Builder::new()
+        .prefix("alef Kotlin launcher ")
+        .tempdir()
+        .expect("create launcher directory with spaces");
+    let launcher = directory
+        .path()
+        .join(if cfg!(windows) { "kotlinc.bat" } else { "kotlinc" });
+    let script = if cfg!(windows) {
+        "@echo off\r\nif \"%~1\"==\"-version\" exit /b 0\r\necho %~1\r\necho %~2\r\necho %~3\r\n"
+    } else {
+        "#!/bin/sh\nif [ \"$1\" = -version ]; then exit 0; fi\nprintf '%s\\n' \"$@\"\n"
+    };
+    std::fs::write(&launcher, script).expect("write launcher");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&launcher, std::fs::Permissions::from_mode(0o755)).expect("executable launcher");
+    }
+    let mut paths = vec![directory.path().to_path_buf()];
+    paths.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()));
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--ignored",
+            "--exact",
+            "kotlin_launcher_subprocess_fixture",
+            "--nocapture",
+        ])
+        .env("PATH", std::env::join_paths(paths).expect("fixture PATH"))
+        .env("ALEF_KOTLIN_LAUNCHER_FIXTURE", &launcher)
+        .env("ALEF_REQUIRE_KOTLINC", "1")
+        .output()
+        .expect("run launcher fixture");
+    assert!(
+        output.status.success(),
+        "fixture failed: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("1 passed"),
+        "fixture must execute exactly one test"
+    );
+}
+
+#[test]
+#[ignore = "subprocess fixture with an isolated PATH; invoked by launcher regression"]
+fn kotlin_launcher_subprocess_fixture() {
+    let launcher = std::env::var_os("ALEF_KOTLIN_LAUNCHER_FIXTURE").expect("fixture launcher path");
+    let mut command = kotlin_compiler_command();
+    assert_eq!(
+        command.get_program(),
+        launcher,
+        "compile must use the resolved launcher"
+    );
+    assert!(
+        kotlinc_is_genuinely_installed(),
+        "independent probe must launch the resolved tool"
+    );
+    assert!(
+        require_tool("kotlinc", "ALEF_REQUIRE_KOTLINC", true),
+        "probe must launch the batch tool"
+    );
+    let output = command
+        .args(["-d", "output directory with spaces", "source file with spaces.kt"])
+        .output()
+        .expect("launch compiler with space-containing arguments");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).lines().collect::<Vec<_>>(),
+        ["-d", "output directory with spaces", "source file with spaces.kt"]
+    );
 }

--- a/tests/publish_normalize_targets_test.rs
+++ b/tests/publish_normalize_targets_test.rs
@@ -8,6 +8,9 @@
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+#[path = "support/publish_shell_diagnostics.rs"]
+mod shell_diagnostics;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -32,7 +35,7 @@ fn assert_normalized(raw_targets: Option<&str>, expected: &str) {
     assert!(
         output.status.success(),
         "normalize-release-targets.sh exited non-zero for RAW_TARGETS={raw_targets:?}: {}",
-        String::from_utf8_lossy(&output.stderr)
+        shell_diagnostics::describe(&output)
     );
     let stdout = String::from_utf8(output.stdout).expect("stdout must be utf8");
     assert_eq!(

--- a/tests/publish_normalize_targets_test.rs
+++ b/tests/publish_normalize_targets_test.rs
@@ -6,7 +6,7 @@
 //! "release everything" (see `parse_targets` in src/cli/commands/release_metadata.rs).
 
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::Output;
 
 #[path = "support/publish_shell_diagnostics.rs"]
 mod shell_diagnostics;
@@ -20,7 +20,7 @@ fn script_path() -> PathBuf {
 }
 
 fn run_normalize(raw_targets: Option<&str>) -> Output {
-    let mut command = Command::new("bash");
+    let mut command = shell_diagnostics::bash_command();
     command.arg(script_path());
     if let Some(raw) = raw_targets {
         command.env("RAW_TARGETS", raw);
@@ -43,6 +43,14 @@ fn assert_normalized(raw_targets: Option<&str>, expected: &str) {
         expected,
         "RAW_TARGETS={raw_targets:?} must normalize to {expected:?}"
     );
+}
+
+#[test]
+fn shell_command_uses_the_absolute_path_resolved_from_path() {
+    let expected = which::which("bash").expect("bash must be installed for publish script tests");
+    assert!(expected.is_absolute(), "resolved bash must be absolute: {expected:?}");
+    let command = shell_diagnostics::bash_command();
+    assert_eq!(command.get_program(), expected.as_os_str());
 }
 
 #[test]

--- a/tests/publish_scoop_gate_test.rs
+++ b/tests/publish_scoop_gate_test.rs
@@ -5,7 +5,7 @@
 //! and does not false-positive on a target name that merely contains "scoop" as a substring.
 
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::Output;
 
 #[path = "support/publish_shell_diagnostics.rs"]
 mod shell_diagnostics;
@@ -19,7 +19,7 @@ fn script_path() -> PathBuf {
 }
 
 fn run_gate(release_targets: &str) -> Output {
-    Command::new("bash")
+    shell_diagnostics::bash_command()
         .arg(script_path())
         .env("RELEASE_TARGETS", release_targets)
         .output()

--- a/tests/publish_scoop_gate_test.rs
+++ b/tests/publish_scoop_gate_test.rs
@@ -7,6 +7,9 @@
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+#[path = "support/publish_shell_diagnostics.rs"]
+mod shell_diagnostics;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -28,7 +31,7 @@ fn assert_gate(release_targets: &str, expected: &str) {
     assert!(
         output.status.success(),
         "compute-scoop-gate.sh exited non-zero for RELEASE_TARGETS={release_targets:?}: {}",
-        String::from_utf8_lossy(&output.stderr)
+        shell_diagnostics::describe(&output)
     );
     let stdout = String::from_utf8(output.stdout).expect("stdout must be utf8");
     assert_eq!(

--- a/tests/publish_scoop_manifest_commit_test.rs
+++ b/tests/publish_scoop_manifest_commit_test.rs
@@ -105,7 +105,7 @@ impl BucketFixture {
 }
 
 fn run_commit_script(bucket_dir: &Path, manifest_path: &str, version: &str) -> Output {
-    Command::new("bash")
+    shell_diagnostics::bash_command()
         .arg(script_path())
         .env("BUCKET_DIR", bucket_dir)
         .env("MANIFEST_PATH", manifest_path)

--- a/tests/publish_scoop_manifest_commit_test.rs
+++ b/tests/publish_scoop_manifest_commit_test.rs
@@ -18,6 +18,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[path = "support/publish_shell_diagnostics.rs"]
+mod shell_diagnostics;
+
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -123,7 +126,7 @@ fn first_publish_of_untracked_manifest_is_committed() {
     assert!(
         output.status.success(),
         "commit-scoop-manifest.sh failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        shell_diagnostics::describe(&output)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -152,14 +155,14 @@ fn no_op_retry_on_unchanged_manifest_makes_no_commit() {
     std::fs::write(bucket_dir.join("bucket/alef.json"), "{\"version\":\"1.0.0\"}\n").expect("write manifest");
 
     let first = run_commit_script(&bucket_dir, "bucket/alef.json", "1.0.0");
-    assert!(first.status.success());
+    assert!(first.status.success(), "{}", shell_diagnostics::describe(&first));
     let verify_after_first = fixture.reclone();
     let sha_after_first = run_git(&verify_after_first, &["rev-parse", "HEAD"]);
 
     // Re-render the identical content (as a real no-op retry would) and run again.
     std::fs::write(bucket_dir.join("bucket/alef.json"), "{\"version\":\"1.0.0\"}\n").expect("rewrite manifest");
     let second = run_commit_script(&bucket_dir, "bucket/alef.json", "1.0.0");
-    assert!(second.status.success());
+    assert!(second.status.success(), "{}", shell_diagnostics::describe(&second));
     let stdout = String::from_utf8_lossy(&second.stdout);
     assert!(
         stdout.trim_end().ends_with("skipped"),
@@ -181,11 +184,11 @@ fn real_version_bump_on_tracked_manifest_is_committed() {
     let bucket_dir = fixture.bucket_dir();
     std::fs::write(bucket_dir.join("bucket/alef.json"), "{\"version\":\"1.0.0\"}\n").expect("write manifest");
     let first = run_commit_script(&bucket_dir, "bucket/alef.json", "1.0.0");
-    assert!(first.status.success());
+    assert!(first.status.success(), "{}", shell_diagnostics::describe(&first));
 
     std::fs::write(bucket_dir.join("bucket/alef.json"), "{\"version\":\"1.0.1\"}\n").expect("bump manifest");
     let second = run_commit_script(&bucket_dir, "bucket/alef.json", "1.0.1");
-    assert!(second.status.success());
+    assert!(second.status.success(), "{}", shell_diagnostics::describe(&second));
     let stdout = String::from_utf8_lossy(&second.stdout);
     assert!(
         stdout.trim_end().ends_with("committed"),

--- a/tests/support/publish_shell_diagnostics.rs
+++ b/tests/support/publish_shell_diagnostics.rs
@@ -1,4 +1,14 @@
-use std::process::Output;
+use std::process::{Command, Output};
+
+pub(super) fn bash_command() -> Command {
+    // ~keep Windows' bare executable search can launch WSL even when PATH resolves Git Bash.
+    let executable = which::which("bash").expect("bash must be installed for publish script tests");
+    assert!(
+        executable.is_absolute(),
+        "resolved bash must be absolute: {executable:?}"
+    );
+    Command::new(executable)
+}
 
 pub(super) fn describe(output: &Output) -> String {
     format!(

--- a/tests/support/publish_shell_diagnostics.rs
+++ b/tests/support/publish_shell_diagnostics.rs
@@ -1,0 +1,11 @@
+use std::process::Output;
+
+pub(super) fn describe(output: &Output) -> String {
+    format!(
+        "status={:?}; stdout={:?}; stderr={:?}; which::which(bash)={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        which::which("bash")
+    )
+}

--- a/tests/template_versions_renovate_coverage.rs
+++ b/tests/template_versions_renovate_coverage.rs
@@ -81,7 +81,7 @@ fn the_custom_manager_regex_matches_the_bulk_of_the_version_table() {
 fn version_consts_whose_names_contain_digits_are_tracked() {
     let tracked = tracked_dependency_names(&custom_manager_pattern(), &template_versions_source());
 
-    for dependency in ["base64", "pyo3", "pyo3-async-runtimes"] {
+    for dependency in ["base64", "pyo3", "pyo3-async-runtimes", "flate2"] {
         assert!(
             tracked.contains(dependency),
             "`{dependency}` must be reachable by the customManager; a const name with a digit \


### PR DESCRIPTION
Repair Windows Kotlin discovery and update Java, Zig and incremental-FFI test oracles to match generated output, while preserving flate2 dependency tracking. Publish-script tests now launch the absolute Bash executable resolved from PATH, avoiding the Windows WSL launcher observed in the preceding CI failure. Native verification passed 14,487 tests (58 declared ignored), all 18 affected publish-script tests and strict targeted Clippy; the executable-selection negative control failed as intended, and fresh three-platform CI and tobocop2 review remain required.
